### PR TITLE
Add Algolia search for docs and API reference

### DIFF
--- a/docs/gatsby-config.js
+++ b/docs/gatsby-config.js
@@ -15,6 +15,8 @@ module.exports = {
                 menuTitle: 'Helpful resources',
                 githubRepo: 'awslabs/aws-lambda-powertools-python',
                 baseUrl: 'https://awslabs.github.io/aws-lambda-powertools-python',
+                algoliaApiKey: 'a8491b576861e819fd50d567134eb9ce',
+                algoliaIndexName: 'aws-lambda-powertools-python',
                 sidebarCategories: {
                     null: [
                         'index'


### PR DESCRIPTION
Signed-off-by: heitorlessa <lessa@amazon.co.uk>

*Issue #, if available:* #37

*Description of changes:*

This completes the docs experience by including a search for both docs, and API docs.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
