### PR TITLE
fix: cast dimension value to str to avoid issue where EMF silently fails

### DIFF
--- a/aws_lambda_powertools/metrics/base.py
+++ b/aws_lambda_powertools/metrics/base.py
@@ -205,11 +205,12 @@ class MetricManager:
         logger.debug(f"Adding dimension: {name}:{value}")
 
         # Cast value to str according to EMF spec
-        # Majority of values are expected to be string already, so checking before casting improves performance in most cases
-        if isinstance(value, str):  
+        # Majority of values are expected to be string already, so
+        # checking before casting improves performance in most cases
+        if isinstance(value, str):
             self.dimension_set[name] = value
         else:
-            self.dimension_set[name] = str(value)  
+            self.dimension_set[name] = str(value)
 
     def __extract_metric_unit_value(self, unit: Union[str, MetricUnit]) -> str:
         """Return metric value from metric unit whether that's str or MetricUnit enum

--- a/aws_lambda_powertools/metrics/base.py
+++ b/aws_lambda_powertools/metrics/base.py
@@ -203,7 +203,13 @@ class MetricManager:
             Dimension value
         """
         logger.debug(f"Adding dimension: {name}:{value}")
-        self.dimension_set[name] = value
+
+        # Cast value to str according to EMF spec
+        # Majority of values are expected to be string already, so checking before casting improves performance in most cases
+        if isinstance(value, str):  
+            self.dimension_set[name] = value
+        else:
+            self.dimension_set[name] = str(value)  
 
     def __extract_metric_unit_value(self, unit: Union[str, MetricUnit]) -> str:
         """Return metric value from metric unit whether that's str or MetricUnit enum

--- a/tests/functional/test_metrics.py
+++ b/tests/functional/test_metrics.py
@@ -1,5 +1,5 @@
 import json
-from typing import Dict, List
+from typing import Dict, List, Any
 
 import pytest
 
@@ -48,7 +48,7 @@ def dimensions() -> List[Dict[str, str]]:
     ]
 
 @pytest.fixture
-def non_str_dimensions() -> List[Dict[str, str]]:
+def non_str_dimensions() -> List[Dict[str, Any]]:
     return [
         {"name": "test_dimension", "value": True},
         {"name": "test_dimension_2", "value": 3},

--- a/tests/functional/test_metrics.py
+++ b/tests/functional/test_metrics.py
@@ -1,5 +1,5 @@
 import json
-from typing import Dict, List, Any
+from typing import Any, Dict, List
 
 import pytest
 
@@ -47,12 +47,14 @@ def dimensions() -> List[Dict[str, str]]:
         {"name": "test_dimension_2", "value": "test"},
     ]
 
+
 @pytest.fixture
 def non_str_dimensions() -> List[Dict[str, Any]]:
     return [
         {"name": "test_dimension", "value": True},
         {"name": "test_dimension_2", "value": 3},
     ]
+
 
 @pytest.fixture
 def namespace() -> Dict[str, str]:
@@ -386,6 +388,7 @@ def test_log_metrics_clear_metrics_after_invocation(metric, dimension, namespace
 
     # THEN metric set should be empty after function has been run
     assert my_metrics.metric_set == {}
+
 
 def test_log_metrics_non_string_dimension_values(capsys, metrics, non_str_dimensions, namespace):
     # GIVEN Metrics is initialized and dimensions with non-string values are added

--- a/tests/functional/test_metrics.py
+++ b/tests/functional/test_metrics.py
@@ -403,15 +403,9 @@ def test_log_metrics_non_string_dimension_values(capsys, metrics, non_str_dimens
         return True
 
     lambda_handler({}, {})
-
     output = json.loads(capsys.readouterr().out.strip())
-    expected = serialize_metrics(metrics=metrics, dimensions=non_str_dimensions, namespace=namespace)
-
-    remove_timestamp(metrics=[output, expected])  # Timestamp will always be different
 
     # THEN we should have no exceptions
     # and dimension values hould be serialized as strings
-    assert expected["_aws"] == output["_aws"]
     for dimension in non_str_dimensions:
-        assert dimension["name"] in output
         assert isinstance(output[dimension["name"]], str)

--- a/tests/functional/test_metrics.py
+++ b/tests/functional/test_metrics.py
@@ -47,6 +47,12 @@ def dimensions() -> List[Dict[str, str]]:
         {"name": "test_dimension_2", "value": "test"},
     ]
 
+@pytest.fixture
+def non_str_dimensions() -> List[Dict[str, str]]:
+    return [
+        {"name": "test_dimension", "value": True},
+        {"name": "test_dimension_2", "value": 3},
+    ]
 
 @pytest.fixture
 def namespace() -> Dict[str, str]:
@@ -380,3 +386,32 @@ def test_log_metrics_clear_metrics_after_invocation(metric, dimension, namespace
 
     # THEN metric set should be empty after function has been run
     assert my_metrics.metric_set == {}
+
+def test_log_metrics_non_string_dimension_values(capsys, metrics, non_str_dimensions, namespace):
+    # GIVEN Metrics is initialized and dimensions with non-string values are added
+    my_metrics = Metrics()
+    my_metrics.add_namespace(**namespace)
+    for metric in metrics:
+        my_metrics.add_metric(**metric)
+    for dimension in non_str_dimensions:
+        my_metrics.add_dimension(**dimension)
+
+    # WHEN we utilize log_metrics to serialize
+    # and flush all metrics at the end of a function execution
+    @my_metrics.log_metrics
+    def lambda_handler(evt, ctx):
+        return True
+
+    lambda_handler({}, {})
+
+    output = json.loads(capsys.readouterr().out.strip())
+    expected = serialize_metrics(metrics=metrics, dimensions=non_str_dimensions, namespace=namespace)
+
+    remove_timestamp(metrics=[output, expected])  # Timestamp will always be different
+
+    # THEN we should have no exceptions
+    # and dimension values hould be serialized as strings
+    assert expected["_aws"] == output["_aws"]
+    for dimension in non_str_dimensions:
+        assert dimension["name"] in output
+        assert isinstance(output[dimension["name"]], str)


### PR DESCRIPTION

*Issue #, if available:* #51 

*Description of changes:* If non-string values are passed to add_dimension, cast them to str. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
