### PR TITLE
improv: include example tests in `make tests`

### DIFF
--- a/example/README.md
+++ b/example/README.md
@@ -1,6 +1,6 @@
 # Summary
 
-This example uses both [tracing](https://github.com/awslabs/aws-lambda-powertools/tree/develop/python#tracing) and [logging](https://github.com/awslabs/aws-lambda-powertools/tree/develop/python#logging) features, includes all environment variables that can be used, and demonstrates how to explicitly disable tracing while running unit tests - That is not necessary when running within SAM CLI as it detects the local env automatically.
+This example uses [tracer](https://awslabs.github.io/aws-lambda-powertools-python/core/tracer/), [metrics](https://awslabs.github.io/aws-lambda-powertools-python/core/metrics/),and [logger](https://awslabs.github.io/aws-lambda-powertools-python/core/logger/) features, includes all environment variables that can be used, and demonstrates how to explicitly disable tracing while running unit tests - That is not necessary when running within SAM CLI as it detects the local env automatically.
 
 **Quick commands**
 
@@ -118,7 +118,7 @@ Tests are defined in the `tests` folder in this project. Use PIP to install the 
 ```bash
 example$ pip install -r hello_world/requirements.txt
 example$ pip install -r requirements-dev.txt
-example$ POWERTOOLS_TRACE_DISABLED=1 python -m pytest tests/ -v
+example$ pytest -v
 ```
 
 ## Cleanup

--- a/example/tests/test_handler.py
+++ b/example/tests/test_handler.py
@@ -1,6 +1,6 @@
 import json
 import os
-
+import sys
 from dataclasses import dataclass
 
 import pytest
@@ -12,10 +12,13 @@ def env_vars(monkeypatch):
     monkeypatch.setenv("POWERTOOLS_SERVICE_NAME", "example_service")
     monkeypatch.setenv("POWERTOOLS_TRACE_DISABLED", "1")
 
+
 @pytest.fixture()
 def lambda_handler(env_vars):
     from hello_world import app
+
     return app.lambda_handler
+
 
 @pytest.fixture()
 def apigw_event():
@@ -82,6 +85,7 @@ class Context:
     aws_request_id: str = "5b441b59-a550-11c8-6564-f1c833cf438c"
 
 
+@pytest.mark.skipif(sys.version_info < (3, 7), reason="requires python3.7 or higher")
 def test_lambda_handler(lambda_handler, apigw_event, mocker, capsys):
     ret = lambda_handler(apigw_event, Context())
     data = json.loads(ret["body"])

--- a/poetry.lock
+++ b/poetry.lock
@@ -240,6 +240,15 @@ version = "*"
 toml = ["toml"]
 
 [[package]]
+category = "dev"
+description = "A backport of the dataclasses module for Python 3.6"
+marker = "python_version >= \"3.6\" and python_version < \"3.7\""
+name = "dataclasses"
+optional = false
+python-versions = ">=3.6, <3.7"
+version = "0.7"
+
+[[package]]
 category = "main"
 description = "Docutils -- Python Documentation Utilities"
 name = "docutils"
@@ -949,7 +958,7 @@ docs = ["sphinx", "jaraco.packaging (>=3.2)", "rst.linker (>=1.9)"]
 testing = ["jaraco.itertools", "func-timeout"]
 
 [metadata]
-content-hash = "11587b6860e090c953a7e70372c266723b32848accdde9e3546e7ed9d5208a9f"
+content-hash = "68009b53f884801ad967ab41923a811dd51d61c28979658545b1db8e7ee1588a"
 python-versions = "^3.6"
 
 [metadata.files]
@@ -1063,6 +1072,10 @@ coverage = [
     {file = "coverage-5.1-cp39-cp39-win32.whl", hash = "sha256:a82b92b04a23d3c8a581fc049228bafde988abacba397d57ce95fe95e0338ab4"},
     {file = "coverage-5.1-cp39-cp39-win_amd64.whl", hash = "sha256:bb28a7245de68bf29f6fb199545d072d1036a1917dca17a1e75bbb919e14ee8e"},
     {file = "coverage-5.1.tar.gz", hash = "sha256:f90bfc4ad18450c80b024036eaf91e4a246ae287701aaa88eaebebf150868052"},
+]
+dataclasses = [
+    {file = "dataclasses-0.7-py3-none-any.whl", hash = "sha256:3459118f7ede7c8bea0fe795bff7c6c2ce287d01dd226202f7c9ebc0610a7836"},
+    {file = "dataclasses-0.7.tar.gz", hash = "sha256:494a6dcae3b8bcf80848eea2ef64c0cc5cd307ffc263e17cdf42f3e5420808e6"},
 ]
 docutils = [
     {file = "docutils-0.15.2-py2-none-any.whl", hash = "sha256:9e4d7ecfc600058e07ba661411a2b7de2fd0fafa17d1a7f7361cd47b1175c827"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,7 @@ radon = "^4.1.0"
 xenon = "^0.7.0"
 flake8-bugbear = "^20.1.4"
 flake8-eradicate = "^0.3.0"
-dataclasses = {version = "^0.7", python = "~3.6"}
+dataclasses = {version = "*", python = "~3.6"}
 
 [tool.coverage.run]
 source = ["aws_lambda_powertools"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,7 @@ radon = "^4.1.0"
 xenon = "^0.7.0"
 flake8-bugbear = "^20.1.4"
 flake8-eradicate = "^0.3.0"
+dataclasses = {version = "^0.7", python = "~3.6"}
 
 [tool.coverage.run]
 source = ["aws_lambda_powertools"]

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,3 +1,3 @@
 [pytest]
 addopts = -ra --cov --cov-config=.coveragerc
-testpaths = ./tests
+testpaths = ./tests ./example/tests


### PR DESCRIPTION
**Issue #, if available:**

## Description of changes:

> Update pytest config to run example tests. Update tests in example/tests to specify env vars as fixture without requiring user to pass them at runtime.

* [x] [Meet tenets criteria](https://awslabs.github.io/aws-lambda-powertools-python/#tenets)
* [x] Update tests
* [x] Update docs
* [x] PR title follows [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-python/blob/376ec0a2ac0d2a40e0af5717bef42ff84ca0d1b9/.github/semantic.yml#L2)

## Breaking change checklist

> Ignore if it's not a breaking change

**RFC issue #**:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
