### PR TITLE
chore: rename Makefile target docs-dev to docs-local

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,7 @@ build-docs-website: dev-docs
 docs-local:
 	cd docs && npm run start
 
-docs-api-dev:
+docs-api-local:
 	poetry run pdoc --http : aws_lambda_powertools
 
 security-baseline:

--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,7 @@ build-docs-website: dev-docs
 	cd docs && npm run build
 	cp -R docs/public/* dist/
 
-docs-dev:
+docs-local:
 	cd docs && npm run start
 
 docs-api-dev:


### PR DESCRIPTION
**Issue #, if available:**

## Description of changes:

> Makefile had 2 targets: docs-dev (which ran the gatsby docs site locally) and dev-docs (which installs required packages for docs build). Renamed the former to better represent what it does.

* [x] [Meet tenets criteria](https://awslabs.github.io/aws-lambda-powertools-python/#tenets)
* [ ] Update tests
* [ ] Update docs
* [x] PR title follows [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-python/blob/376ec0a2ac0d2a40e0af5717bef42ff84ca0d1b9/.github/semantic.yml#L2)

## Breaking change checklist

> Ignore if it's not a breaking change

**RFC issue #**:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
