### PR TITLE
fix: correct env var name for publish to pypi test

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -21,7 +21,7 @@ name: Publish to PyPi
 
 on:
   release:
-    types: [published] 
+    types: [published]
 
 jobs:
   upload:
@@ -50,13 +50,13 @@ jobs:
       run: make release-test
       env:
         PYPI_USERNAME: __token__
-        PYPI_TOKEN: ${{ secrets.PYPI_TEST_TOKEN }}
+        PYPI_TEST_TOKEN: ${{ secrets.PYPI_TEST_TOKEN }}
     - name: Upload to PyPi prod
       run: make release-prod
       env:
         PYPI_USERNAME: __token__
         PYPI_TOKEN: ${{ secrets.PYPI_TOKEN }}
-  
+
   sync_master:
     needs: upload
     runs-on: ubuntu-latest
@@ -66,5 +66,5 @@ jobs:
       # If version matches CHANGELOG and pyproject.toml
       # If it passes all checks, successfully releases to test and prod
       # Then sync up master with latest source code release
-      # where commit message will be Release notes title  
+      # where commit message will be Release notes title
       run: git push origin HEAD:refs/heads/master --force


### PR DESCRIPTION
**Issue #, if available:**

## Description of changes:

> Fix github workflow to push to pypi

* [ ] [Meet tenets criteria](https://awslabs.github.io/aws-lambda-powertools-python/#tenets)
* [ ] Update tests
* [ ] Update docs
* [ ] PR title follows [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-python/blob/376ec0a2ac0d2a40e0af5717bef42ff84ca0d1b9/.github/semantic.yml#L2)

## Breaking change checklist

> Ignore if it's not a breaking change

**RFC issue #**:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
