### PR TITLE
feat: improve error handling for log_metrics decorator

### DIFF
--- a/aws_lambda_powertools/metrics/metrics.py
+++ b/aws_lambda_powertools/metrics/metrics.py
@@ -122,7 +122,11 @@ class Metrics(MetricManager):
         # Return a partial function with args filled
         if lambda_handler is None:
             logger.debug("Decorator called with parameters")
-            return functools.partial(self.log_metrics, capture_cold_start_metric=capture_cold_start_metric)
+            return functools.partial(
+                self.log_metrics,
+                capture_cold_start_metric=capture_cold_start_metric,
+                raise_on_empty_metrics=raise_on_empty_metrics,
+            )
 
         @functools.wraps(lambda_handler)
         def decorate(event, context):

--- a/aws_lambda_powertools/metrics/metrics.py
+++ b/aws_lambda_powertools/metrics/metrics.py
@@ -2,6 +2,7 @@ import functools
 import json
 import logging
 import os
+import warnings
 from typing import Any, Callable
 
 from aws_lambda_powertools.metrics.base import MetricManager
@@ -136,7 +137,7 @@ class Metrics(MetricManager):
                     self.__add_cold_start_metric(context=context)
             finally:
                 if not raise_on_empty_metrics and not self.metric_set:
-                    logger.debug("No metrics to publish, skipping")
+                    warnings.warn("No metrics to publish, skipping")
                 else:
                     metrics = self.serialize_metric_set()
                     self.clear_metrics()

--- a/aws_lambda_powertools/metrics/metrics.py
+++ b/aws_lambda_powertools/metrics/metrics.py
@@ -86,7 +86,7 @@ class Metrics(MetricManager):
         self,
         lambda_handler: Callable[[Any, Any], Any] = None,
         capture_cold_start_metric: bool = False,
-        raise_for_empty_metrics: bool = False,
+        raise_on_empty_metrics: bool = False,
     ):
         """Decorator to serialize and publish metrics at the end of a function execution.
 
@@ -109,7 +109,7 @@ class Metrics(MetricManager):
             Lambda function handler, by default None
         capture_cold_start_metric : bool, optional
             Captures cold start metric, by default False
-        raise_for_empty_metrics : bool, optional
+        raise_on_empty_metrics : bool, optional
             Raise exception if no metrics are emitted, by default False
 
         Raises
@@ -131,7 +131,7 @@ class Metrics(MetricManager):
                 if capture_cold_start_metric:
                     self.__add_cold_start_metric(context=context)
             finally:
-                if not raise_for_empty_metrics and not self.metric_set:
+                if not raise_on_empty_metrics and not self.metric_set:
                     logger.debug("No metrics to publish, skipping")
                 else:
                     metrics = self.serialize_metric_set()

--- a/docs/content/core/metrics.mdx
+++ b/docs/content/core/metrics.mdx
@@ -135,6 +135,10 @@ def lambda_handler(evt, ctx):
 
 If you prefer not to use `log_metrics` because you might want to encapsulate additional logic when doing so, you can manually flush and clear metrics as follows:
 
+<Note type="warning">
+  Metrics, dimensions and namespace validation still applies.
+</Note><br/>
+
 ```python:title=manual_metric_serialization.py
 import json
 from aws_lambda_powertools.metrics import Metrics, MetricUnit

--- a/docs/content/core/metrics.mdx
+++ b/docs/content/core/metrics.mdx
@@ -103,14 +103,28 @@ def lambda_handler(evt, ctx):
     ...
 ```
 
-`log_metrics` decorator **validates**, **serializes**, and **flushes** all your metrics. During metrics validation, if no metrics are provided then a warning will be logged, but no exception will be raised. If metrics are provided, and any of the following criteria are not met, `SchemaValidationError` exception will be raised:
+`log_metrics` decorator **validates**, **serializes**, and **flushes** all your metrics. During metrics validation, if no metrics are provided then a warning will be logged, but no exception will be raised.
+
+If metrics are provided, and any of the following criteria are not met, `SchemaValidationError` exception will be raised:
 
 * Minimum of 1 dimension
 * Maximum of 9 dimensions
 * Namespace is set, and no more than one
 * Metric units must be [supported by CloudWatch](https://docs.aws.amazon.com/AmazonCloudWatch/latest/APIReference/API_MetricDatum.html)
 
-If you want to ensure that at least 1 metric is emitted, you can pass `raise_on_empty_metrics` to the `log_metrics` decorator: `@metrics.log_metrics(raise_on_empty_metrics=True)`. If you expect your function to execute without publishing metrics every time, you can suppress the warning with `warnings.filterwarnings("ignore", "No metrics to publish*")`.
+If you want to ensure that at least one metric is emitted, you can pass `raise_on_empty_metrics` to the **log_metrics** decorator:
+
+```python:title=lambda_handler.py
+from aws_lambda_powertools.metrics import Metrics
+
+@metrics.log_metrics(raise_on_empty_metrics=True) # highlight-line
+def lambda_handler(evt, ctx):
+    ...
+```
+
+<Note type="info">
+  If you expect your function to execute without publishing metrics every time, you can suppress the warning with <strong><code>warnings.filterwarnings("ignore", "No metrics to publish*")</code></strong>.
+</Note><br/>
 
 <Note type="warning">
   When nesting multiple middlewares, you should use <strong><code>log_metrics</code> as your last decorator wrapping all subsequent ones</strong>.

--- a/docs/content/core/metrics.mdx
+++ b/docs/content/core/metrics.mdx
@@ -110,7 +110,7 @@ def lambda_handler(evt, ctx):
 * Namespace is set, and no more than one
 * Metric units must be [supported by CloudWatch](https://docs.aws.amazon.com/AmazonCloudWatch/latest/APIReference/API_MetricDatum.html)
 
-If you want to ensure that at least 1 metric is emitted, you can pass `raise_for_empty_metrics` to the `log_metrics` decorator: `@metrics.log_metrics(raise_for_empty_metrics=True)`
+If you want to ensure that at least 1 metric is emitted, you can pass `raise_on_empty_metrics` to the `log_metrics` decorator: `@metrics.log_metrics(raise_on_empty_metrics=True)`
 
 <Note type="warning">
   When nesting multiple middlewares, you should use <strong><code>log_metrics</code> as your last decorator wrapping all subsequent ones</strong>.

--- a/docs/content/core/metrics.mdx
+++ b/docs/content/core/metrics.mdx
@@ -103,15 +103,17 @@ def lambda_handler(evt, ctx):
     ...
 ```
 
-`log_metrics` decorator **validates**, **serializes**, and **flushes** all your metrics. During metrics validation, if any of the following criteria is met, `SchemaValidationError` exception will be raised:
+`log_metrics` decorator **validates**, **serializes**, and **flushes** all your metrics. During metrics validation, if no metrics are provided then no exception will be raised. If metrics are provided, and any of the following criteria are not met, `SchemaValidationError` exception will be raised:
 
-* At least of one Metric and Dimension
+* Minimum of 1 dimension
 * Maximum of 9 dimensions
 * Namespace is set, and no more than one
 * Metric units must be [supported by CloudWatch](https://docs.aws.amazon.com/AmazonCloudWatch/latest/APIReference/API_MetricDatum.html)
 
+If you want to ensure that at least 1 metric is emitted, you can pass `raise_for_empty_metrics` to the `log_metrics` decorator: `@metrics.log_metrics(raise_for_empty_metrics=True)`
+
 <Note type="warning">
-  When nesting multiple middlwares, you should use <strong><code>log_metrics</code> as your last decorator wrapping all subsequent ones</strong>.
+  When nesting multiple middlewares, you should use <strong><code>log_metrics</code> as your last decorator wrapping all subsequent ones</strong>.
 </Note><br/>
 
 ```python:title=lambda_handler_nested_middlewares.py

--- a/docs/content/core/metrics.mdx
+++ b/docs/content/core/metrics.mdx
@@ -103,14 +103,14 @@ def lambda_handler(evt, ctx):
     ...
 ```
 
-`log_metrics` decorator **validates**, **serializes**, and **flushes** all your metrics. During metrics validation, if no metrics are provided then no exception will be raised. If metrics are provided, and any of the following criteria are not met, `SchemaValidationError` exception will be raised:
+`log_metrics` decorator **validates**, **serializes**, and **flushes** all your metrics. During metrics validation, if no metrics are provided then a warning will be logged, but no exception will be raised. If metrics are provided, and any of the following criteria are not met, `SchemaValidationError` exception will be raised:
 
 * Minimum of 1 dimension
 * Maximum of 9 dimensions
 * Namespace is set, and no more than one
 * Metric units must be [supported by CloudWatch](https://docs.aws.amazon.com/AmazonCloudWatch/latest/APIReference/API_MetricDatum.html)
 
-If you want to ensure that at least 1 metric is emitted, you can pass `raise_on_empty_metrics` to the `log_metrics` decorator: `@metrics.log_metrics(raise_on_empty_metrics=True)`
+If you want to ensure that at least 1 metric is emitted, you can pass `raise_on_empty_metrics` to the `log_metrics` decorator: `@metrics.log_metrics(raise_on_empty_metrics=True)`. If you expect your function to execute without publishing metrics every time, you can suppress the warning with `warnings.filterwarnings("ignore", "No metrics to publish*")`.
 
 <Note type="warning">
   When nesting multiple middlewares, you should use <strong><code>log_metrics</code> as your last decorator wrapping all subsequent ones</strong>.

--- a/tests/functional/test_metrics.py
+++ b/tests/functional/test_metrics.py
@@ -1,4 +1,5 @@
 import json
+import warnings
 from collections import namedtuple
 from typing import Any, Dict, List
 
@@ -635,7 +636,7 @@ def test_emit_cold_start_metric_only_once(capsys, namespace, dimension, metric):
     assert "function_name" not in output
 
 
-def test_log_metrics_decorator_no_metrics(capsys, dimensions, namespace):
+def test_log_metrics_decorator_no_metrics(dimensions, namespace):
     # GIVEN Metrics is initialized
     my_metrics = Metrics(namespace=namespace["name"], service="test_service")
 
@@ -644,8 +645,8 @@ def test_log_metrics_decorator_no_metrics(capsys, dimensions, namespace):
     def lambda_handler(evt, context):
         pass
 
-    # THEN it should not throw an exception, and should not log anything
-    LambdaContext = namedtuple("LambdaContext", "function_name")
-    lambda_handler({}, LambdaContext("example_fn"))
-
-    assert capsys.readouterr().out == ""
+    # THEN it should raise a warning instead of throwing an exception
+    with warnings.catch_warnings(record=True) as w:
+        lambda_handler({}, {})
+        assert len(w) == 1
+        assert str(w[-1].message) == "No metrics to publish, skipping"

--- a/tests/functional/test_metrics.py
+++ b/tests/functional/test_metrics.py
@@ -351,9 +351,9 @@ def test_log_no_metrics_error_propagation(capsys, metric, dimension, namespace):
     # GIVEN Metrics is initialized
     my_metrics = Metrics()
 
-    @my_metrics.log_metrics(raise_for_empty_metrics=True)
+    @my_metrics.log_metrics(raise_on_empty_metrics=True)
     def lambda_handler(evt, context):
-        # WHEN log_metrics is used with raise_for_empty_metrics param and has no metrics
+        # WHEN log_metrics is used with raise_on_empty_metrics param and has no metrics
         # and the function decorated also raised an exception
         raise ValueError("Bubble up")
 

--- a/tests/functional/test_metrics.py
+++ b/tests/functional/test_metrics.py
@@ -358,7 +358,7 @@ def test_log_no_metrics_error_propagation(capsys, metric, dimension, namespace):
         raise ValueError("Bubble up")
 
     # THEN the raised exception should be
-    with pytest.raises(ValueError):
+    with pytest.raises(SchemaValidationError):
         lambda_handler({}, {})
 
 


### PR DESCRIPTION
**Issue #, if available:**

## Description of changes:

> Change default behavior for log_metrics decorator: no longer throws exception if no metrics are emitted during the wrapped function's execution. Added parameter to revert this behavior if exception is desired in this case.

* [X] [Meet tenets criteria](https://awslabs.github.io/aws-lambda-powertools-python/#tenets)
* [X] Update tests
* [X] Update docs
* [X] PR title follows [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-python/blob/376ec0a2ac0d2a40e0af5717bef42ff84ca0d1b9/.github/semantic.yml#L2)

## Breaking change checklist

> Ignore if it's not a breaking change

**RFC issue #**:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
