### PR TITLE
fix: metrics default dimension creation

### DIFF
--- a/aws_lambda_powertools/metrics/base.py
+++ b/aws_lambda_powertools/metrics/base.py
@@ -36,6 +36,8 @@ class MetricManager:
     ---------------------
     POWERTOOLS_METRICS_NAMESPACE : str
         metric namespace to be set for all metrics
+    POWERTOOLS_SERVICE_NAME : str
+        service name used for default dimension
 
     Raises
     ------
@@ -49,10 +51,13 @@ class MetricManager:
         When metric object fails EMF schema validation
     """
 
-    def __init__(self, metric_set: Dict[str, str] = None, dimension_set: Dict = None, namespace: str = None):
+    def __init__(
+        self, metric_set: Dict[str, str] = None, dimension_set: Dict = None, namespace: str = None, service: str = None
+    ):
         self.metric_set = metric_set if metric_set is not None else {}
         self.dimension_set = dimension_set if dimension_set is not None else {}
         self.namespace = namespace or os.getenv("POWERTOOLS_METRICS_NAMESPACE")
+        self.service = service or os.environ.get("POWERTOOLS_SERVICE_NAME")
         self._metric_units = [unit.value for unit in MetricUnit]
         self._metric_unit_options = list(MetricUnit.__members__)
 
@@ -157,6 +162,9 @@ class MetricManager:
 
         if dimensions is None:  # pragma: no cover
             dimensions = self.dimension_set
+
+        if self.service and not self.dimension_set.get("service"):
+            self.dimension_set["service"] = self.service
 
         logger.debug("Serializing...", {"metrics": metrics, "dimensions": dimensions})
 

--- a/aws_lambda_powertools/metrics/metrics.py
+++ b/aws_lambda_powertools/metrics/metrics.py
@@ -1,7 +1,6 @@
 import functools
 import json
 import logging
-import os
 import warnings
 from typing import Any, Callable
 
@@ -72,11 +71,11 @@ class Metrics(MetricManager):
     def __init__(self, service: str = None, namespace: str = None):
         self.metric_set = self._metrics
         self.dimension_set = self._dimensions
-        self.service = service or os.environ.get("POWERTOOLS_SERVICE_NAME")
+        self.service = service
         self.namespace = namespace
-        if self.service:
-            self.dimension_set["service"] = self.service
-        super().__init__(metric_set=self.metric_set, dimension_set=self.dimension_set, namespace=self.namespace)
+        super().__init__(
+            metric_set=self.metric_set, dimension_set=self.dimension_set, namespace=self.namespace, service=self.service
+        )
 
     def clear_metrics(self):
         logger.debug("Clearing out existing metric set from memory")


### PR DESCRIPTION
**Issue #, if available:** #75 

## Description of changes: 

> Change Metrics code to add default "service" dimension when metrics are serialized, rather than just when Metrics is initialized.

* [x] [Meet tenets criteria](https://awslabs.github.io/aws-lambda-powertools-python/#tenets)
* [x] Update tests
* [x] Update docs
* [x] PR title follows [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-python/blob/376ec0a2ac0d2a40e0af5717bef42ff84ca0d1b9/.github/semantic.yml#L2)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
