### PR TITLE
chore: remove deprecated code before GA

### DIFF
--- a/aws_lambda_powertools/helper/__init__.py
+++ b/aws_lambda_powertools/helper/__init__.py
@@ -1,2 +1,0 @@
-"""Collection of reusable code shared across powertools utilities
-"""

--- a/aws_lambda_powertools/helper/models.py
+++ b/aws_lambda_powertools/helper/models.py
@@ -4,7 +4,6 @@ key data used in more than one place.
 """
 
 from enum import Enum
-from typing import Union
 
 
 class LambdaContextModel:
@@ -100,33 +99,3 @@ class MetricUnit(Enum):
     GigabitsPerSecond = "Gigabits/Second"
     TerabitsPerSecond = "Terabits/Second"
     CountPerSecond = "Count/Second"
-
-
-def build_metric_unit_from_str(unit: Union[str, MetricUnit]) -> MetricUnit:
-    """Builds correct metric unit value from string or return Count as default
-
-    Parameters
-    ----------
-    unit : str, MetricUnit
-        metric unit
-
-    Returns
-    -------
-    MetricUnit
-        Metric Unit enum from string value or MetricUnit.Count as a default
-    """
-    if isinstance(unit, MetricUnit):
-        return unit
-
-    if isinstance(unit, str):
-        unit = unit.lower().capitalize()
-
-    metric_unit = None
-
-    try:
-        metric_unit = MetricUnit[unit]
-    except (TypeError, KeyError):
-        metric_units = [units for units, _ in MetricUnit.__members__.items()]
-        raise ValueError(f"Invalid Metric Unit - Received {unit}. Value Metric Units are {metric_units}")
-
-    return metric_unit

--- a/aws_lambda_powertools/logging/__init__.py
+++ b/aws_lambda_powertools/logging/__init__.py
@@ -1,6 +1,6 @@
 """Logging utility
 """
 from ..helper.models import MetricUnit
-from .logger import Logger, log_metric, logger_inject_lambda_context, logger_setup
+from .logger import Logger
 
-__all__ = ["logger_setup", "logger_inject_lambda_context", "log_metric", "MetricUnit", "Logger"]
+__all__ = ["MetricUnit", "Logger"]

--- a/aws_lambda_powertools/logging/__init__.py
+++ b/aws_lambda_powertools/logging/__init__.py
@@ -1,6 +1,5 @@
 """Logging utility
 """
-from ..helper.models import MetricUnit
 from .logger import Logger
 
-__all__ = ["MetricUnit", "Logger"]
+__all__ = ["Logger"]

--- a/aws_lambda_powertools/logging/formatter.py
+++ b/aws_lambda_powertools/logging/formatter.py
@@ -1,0 +1,99 @@
+import json
+import logging
+from typing import Any
+
+
+def json_formatter(unserialized_value: Any):
+    """JSON custom serializer to cast unserialisable values to strings.
+
+    Example
+    -------
+
+    **Serialize unserialisable value to string**
+
+        class X: pass
+        value = {"x": X()}
+
+        json.dumps(value, default=json_formatter)
+
+    Parameters
+    ----------
+    unserialized_value: Any
+        Python object unserializable by JSON
+    """
+    return str(unserialized_value)
+
+
+class JsonFormatter(logging.Formatter):
+    """AWS Lambda Logging formatter.
+
+    Formats the log message as a JSON encoded string.  If the message is a
+    dict it will be used directly.  If the message can be parsed as JSON, then
+    the parse d value is used in the output record.
+
+    Originally taken from https://gitlab.com/hadrien/aws_lambda_logging/
+
+    """
+
+    def __init__(self, **kwargs):
+        """Return a JsonFormatter instance.
+
+        The `json_default` kwarg is used to specify a formatter for otherwise
+        unserialisable values.  It must not throw.  Defaults to a function that
+        coerces the value to a string.
+
+        Other kwargs are used to specify log field format strings.
+        """
+        datefmt = kwargs.pop("datefmt", None)
+
+        super(JsonFormatter, self).__init__(datefmt=datefmt)
+        self.reserved_keys = ["timestamp", "level", "location"]
+        self.format_dict = {
+            "timestamp": "%(asctime)s",
+            "level": "%(levelname)s",
+            "location": "%(funcName)s:%(lineno)d",
+        }
+        self.format_dict.update(kwargs)
+        self.default_json_formatter = kwargs.pop("json_default", json_formatter)
+
+    def format(self, record):  # noqa: A003
+        record_dict = record.__dict__.copy()
+        record_dict["asctime"] = self.formatTime(record, self.datefmt)
+
+        log_dict = {}
+        for key, value in self.format_dict.items():
+            if value and key in self.reserved_keys:
+                # converts default logging expr to its record value
+                # e.g. '%(asctime)s' to '2020-04-24 09:35:40,698'
+                log_dict[key] = value % record_dict
+            else:
+                log_dict[key] = value
+
+        if isinstance(record_dict["msg"], dict):
+            log_dict["message"] = record_dict["msg"]
+        else:
+            log_dict["message"] = record.getMessage()
+
+            # Attempt to decode the message as JSON, if so, merge it with the
+            # overall message for clarity.
+            try:
+                log_dict["message"] = json.loads(log_dict["message"])
+            except (json.decoder.JSONDecodeError, TypeError, ValueError):
+                pass
+
+        if record.exc_info:
+            # Cache the traceback text to avoid converting it multiple times
+            # (it's constant anyway)
+            # from logging.Formatter:format
+            if not record.exc_text:
+                record.exc_text = self.formatException(record.exc_info)
+
+        if record.exc_text:
+            log_dict["exception"] = record.exc_text
+
+        json_record = json.dumps(log_dict, default=self.default_json_formatter)
+
+        if hasattr(json_record, "decode"):  # pragma: no cover
+            json_record = json_record.decode("utf-8")
+
+        return json_record

--- a/aws_lambda_powertools/logging/lambda_context.py
+++ b/aws_lambda_powertools/logging/lambda_context.py
@@ -1,32 +1,15 @@
-"""Collection of classes as models and builder functions
-that provide classes as data representation for
-key data used in more than one place.
-"""
-
-from enum import Enum
-
-
 class LambdaContextModel:
     """A handful of Lambda Runtime Context fields
 
     Full Lambda Context object: https://docs.aws.amazon.com/lambda/latest/dg/python-context-object.html
-
-    NOTE
-    ----
-
-    Originally, memory_size is `int` but we cast to `str` in this model
-    due to aws_lambda_logging library use of `%` during formatting
-    Ref: https://gitlab.com/hadrien/aws_lambda_logging/blob/master/aws_lambda_logging.py#L47
 
     Parameters
     ----------
     function_name: str
         Lambda function name, by default "UNDEFINED"
         e.g. "test"
-    function_memory_size: str
-        Lambda function memory in MB, by default "UNDEFINED"
-        e.g. "128"
-        casting from int to str due to aws_lambda_logging using `%` when enumerating fields
+    function_memory_size: int
+        Lambda function memory in MB, by default 128
     function_arn: str
         Lambda function ARN, by default "UNDEFINED"
         e.g. "arn:aws:lambda:eu-west-1:809313241:function:test"
@@ -38,7 +21,7 @@ class LambdaContextModel:
     def __init__(
         self,
         function_name: str = "UNDEFINED",
-        function_memory_size: str = "UNDEFINED",
+        function_memory_size: int = 128,
         function_arn: str = "UNDEFINED",
         function_request_id: str = "UNDEFINED",
     ):
@@ -70,32 +53,3 @@ def build_lambda_context_model(context: object) -> LambdaContextModel:
     }
 
     return LambdaContextModel(**context)
-
-
-class MetricUnit(Enum):
-    Seconds = "Seconds"
-    Microseconds = "Microseconds"
-    Milliseconds = "Milliseconds"
-    Bytes = "Bytes"
-    Kilobytes = "Kilobytes"
-    Megabytes = "Megabytes"
-    Gigabytes = "Gigabytes"
-    Terabytes = "Terabytes"
-    Bits = "Bits"
-    Kilobits = "Kilobits"
-    Megabits = "Megabits"
-    Gigabits = "Gigabits"
-    Terabits = "Terabits"
-    Percent = "Percent"
-    Count = "Count"
-    BytesPerSecond = "Bytes/Second"
-    KilobytesPerSecond = "Kilobytes/Second"
-    MegabytesPerSecond = "Megabytes/Second"
-    GigabytesPerSecond = "Gigabytes/Second"
-    TerabytesPerSecond = "Terabytes/Second"
-    BitsPerSecond = "Bits/Second"
-    KilobitsPerSecond = "Kilobits/Second"
-    MegabitsPerSecond = "Megabits/Second"
-    GigabitsPerSecond = "Gigabits/Second"
-    TerabitsPerSecond = "Terabits/Second"
-    CountPerSecond = "Count/Second"

--- a/aws_lambda_powertools/logging/logger.py
+++ b/aws_lambda_powertools/logging/logger.py
@@ -1,6 +1,5 @@
 import copy
 import functools
-import json
 import logging
 import os
 import random
@@ -9,107 +8,12 @@ from distutils.util import strtobool
 from typing import Any, Callable, Dict, Union
 
 from .exceptions import InvalidLoggerSamplingRateError
+from .formatter import JsonFormatter
 from .lambda_context import build_lambda_context_model
 
 logger = logging.getLogger(__name__)
 
 is_cold_start = True
-
-
-def json_formatter(unserialized_value: Any):
-    """JSON custom serializer to cast unserialisable values to strings.
-
-    Example
-    -------
-
-    **Serialize unserialisable value to string**
-
-        class X: pass
-        value = {"x": X()}
-
-        json.dumps(value, default=json_formatter)
-
-    Parameters
-    ----------
-    unserialized_value: Any
-        Python object unserializable by JSON
-    """
-    return str(unserialized_value)
-
-
-class JsonFormatter(logging.Formatter):
-    """AWS Lambda Logging formatter.
-
-    Formats the log message as a JSON encoded string.  If the message is a
-    dict it will be used directly.  If the message can be parsed as JSON, then
-    the parse d value is used in the output record.
-
-    Originally taken from https://gitlab.com/hadrien/aws_lambda_logging/
-
-    """
-
-    def __init__(self, **kwargs):
-        """Return a JsonFormatter instance.
-
-        The `json_default` kwarg is used to specify a formatter for otherwise
-        unserialisable values.  It must not throw.  Defaults to a function that
-        coerces the value to a string.
-
-        Other kwargs are used to specify log field format strings.
-        """
-        datefmt = kwargs.pop("datefmt", None)
-
-        super(JsonFormatter, self).__init__(datefmt=datefmt)
-        self.reserved_keys = ["timestamp", "level", "location"]
-        self.format_dict = {
-            "timestamp": "%(asctime)s",
-            "level": "%(levelname)s",
-            "location": "%(funcName)s:%(lineno)d",
-        }
-        self.format_dict.update(kwargs)
-        self.default_json_formatter = kwargs.pop("json_default", json_formatter)
-
-    def format(self, record):  # noqa: A003
-        record_dict = record.__dict__.copy()
-        record_dict["asctime"] = self.formatTime(record, self.datefmt)
-
-        log_dict = {}
-        for key, value in self.format_dict.items():
-            if value and key in self.reserved_keys:
-                # converts default logging expr to its record value
-                # e.g. '%(asctime)s' to '2020-04-24 09:35:40,698'
-                log_dict[key] = value % record_dict
-            else:
-                log_dict[key] = value
-
-        if isinstance(record_dict["msg"], dict):
-            log_dict["message"] = record_dict["msg"]
-        else:
-            log_dict["message"] = record.getMessage()
-
-            # Attempt to decode the message as JSON, if so, merge it with the
-            # overall message for clarity.
-            try:
-                log_dict["message"] = json.loads(log_dict["message"])
-            except (json.decoder.JSONDecodeError, TypeError, ValueError):
-                pass
-
-        if record.exc_info:
-            # Cache the traceback text to avoid converting it multiple times
-            # (it's constant anyway)
-            # from logging.Formatter:format
-            if not record.exc_text:
-                record.exc_text = self.formatException(record.exc_info)
-
-        if record.exc_text:
-            log_dict["exception"] = record.exc_text
-
-        json_record = json.dumps(log_dict, default=self.default_json_formatter)
-
-        if hasattr(json_record, "decode"):  # pragma: no cover
-            json_record = json_record.decode("utf-8")
-
-        return json_record
 
 
 def _is_cold_start() -> bool:

--- a/aws_lambda_powertools/logging/logger.py
+++ b/aws_lambda_powertools/logging/logger.py
@@ -8,8 +8,8 @@ import sys
 from distutils.util import strtobool
 from typing import Any, Callable, Dict, Union
 
-from ..helper.models import build_lambda_context_model
 from .exceptions import InvalidLoggerSamplingRateError
+from .lambda_context import build_lambda_context_model
 
 logger = logging.getLogger(__name__)
 

--- a/aws_lambda_powertools/metrics/__init__.py
+++ b/aws_lambda_powertools/metrics/__init__.py
@@ -1,6 +1,6 @@
 """CloudWatch Embedded Metric Format utility
 """
-from ..helper.models import MetricUnit
+from .base import MetricUnit
 from .exceptions import MetricUnitError, MetricValueError, SchemaValidationError
 from .metric import single_metric
 from .metrics import Metrics

--- a/aws_lambda_powertools/metrics/__init__.py
+++ b/aws_lambda_powertools/metrics/__init__.py
@@ -1,7 +1,7 @@
 """CloudWatch Embedded Metric Format utility
 """
 from ..helper.models import MetricUnit
-from .exceptions import MetricUnitError, MetricValueError, SchemaValidationError, UniqueNamespaceError
+from .exceptions import MetricUnitError, MetricValueError, SchemaValidationError
 from .metric import single_metric
 from .metrics import Metrics
 
@@ -12,5 +12,4 @@ __all__ = [
     "MetricUnitError",
     "SchemaValidationError",
     "MetricValueError",
-    "UniqueNamespaceError",
 ]

--- a/aws_lambda_powertools/metrics/base.py
+++ b/aws_lambda_powertools/metrics/base.py
@@ -4,13 +4,12 @@ import logging
 import numbers
 import os
 import pathlib
-import warnings
 from typing import Dict, List, Union
 
 import fastjsonschema
 
 from ..helper.models import MetricUnit
-from .exceptions import MetricUnitError, MetricValueError, SchemaValidationError, UniqueNamespaceError
+from .exceptions import MetricUnitError, MetricValueError, SchemaValidationError
 
 logger = logging.getLogger(__name__)
 
@@ -45,8 +44,6 @@ class MetricManager:
         When metric metric isn't supported by CloudWatch
     MetricValueError
         When metric value isn't a number
-    UniqueNamespaceError
-        When an additional namespace is set
     SchemaValidationError
         When metric object fails EMF schema validation
     """
@@ -60,30 +57,6 @@ class MetricManager:
         self.service = service or os.environ.get("POWERTOOLS_SERVICE_NAME")
         self._metric_units = [unit.value for unit in MetricUnit]
         self._metric_unit_options = list(MetricUnit.__members__)
-
-    def add_namespace(self, name: str):
-        """Adds given metric namespace
-
-        Example
-        -------
-        **Add metric namespace**
-
-            metric.add_namespace(name="ServerlessAirline")
-
-        Parameters
-        ----------
-        name : str
-            Metric namespace
-        """
-        warnings.warn(
-            "add_namespace method is deprecated. Pass namespace to Metrics constructor instead", DeprecationWarning
-        )
-        if self.namespace is not None:
-            raise UniqueNamespaceError(
-                f"Namespace '{self.namespace}' already set - Only one namespace is allowed across metrics"
-            )
-        logger.debug(f"Adding metrics namespace: {name}")
-        self.namespace = name
 
     def add_metric(self, name: str, unit: MetricUnit, value: Union[float, int]):
         """Adds given metric

--- a/aws_lambda_powertools/metrics/base.py
+++ b/aws_lambda_powertools/metrics/base.py
@@ -4,11 +4,11 @@ import logging
 import numbers
 import os
 import pathlib
+from enum import Enum
 from typing import Dict, List, Union
 
 import fastjsonschema
 
-from ..helper.models import MetricUnit
 from .exceptions import MetricUnitError, MetricValueError, SchemaValidationError
 
 logger = logging.getLogger(__name__)
@@ -18,6 +18,35 @@ with _schema_path.open() as f:
     CLOUDWATCH_EMF_SCHEMA = json.load(f)
 
 MAX_METRICS = 100
+
+
+class MetricUnit(Enum):
+    Seconds = "Seconds"
+    Microseconds = "Microseconds"
+    Milliseconds = "Milliseconds"
+    Bytes = "Bytes"
+    Kilobytes = "Kilobytes"
+    Megabytes = "Megabytes"
+    Gigabytes = "Gigabytes"
+    Terabytes = "Terabytes"
+    Bits = "Bits"
+    Kilobits = "Kilobits"
+    Megabits = "Megabits"
+    Gigabits = "Gigabits"
+    Terabits = "Terabits"
+    Percent = "Percent"
+    Count = "Count"
+    BytesPerSecond = "Bytes/Second"
+    KilobytesPerSecond = "Kilobytes/Second"
+    MegabytesPerSecond = "Megabytes/Second"
+    GigabytesPerSecond = "Gigabytes/Second"
+    TerabytesPerSecond = "Terabytes/Second"
+    BitsPerSecond = "Bits/Second"
+    KilobitsPerSecond = "Kilobits/Second"
+    MegabitsPerSecond = "Megabits/Second"
+    GigabitsPerSecond = "Gigabits/Second"
+    TerabitsPerSecond = "Terabits/Second"
+    CountPerSecond = "Count/Second"
 
 
 class MetricManager:

--- a/aws_lambda_powertools/metrics/exceptions.py
+++ b/aws_lambda_powertools/metrics/exceptions.py
@@ -14,9 +14,3 @@ class MetricValueError(Exception):
     """When metric value isn't a valid number"""
 
     pass
-
-
-class UniqueNamespaceError(Exception):
-    """When an additional namespace is set"""
-
-    pass

--- a/aws_lambda_powertools/metrics/metric.py
+++ b/aws_lambda_powertools/metrics/metric.py
@@ -3,8 +3,7 @@ import logging
 from contextlib import contextmanager
 from typing import Dict
 
-from ..helper.models import MetricUnit
-from .base import MetricManager
+from .base import MetricManager, MetricUnit
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
**Issue #, if available:** #33 

## Description of changes:

* [x] Remove deprecated code in Metrics
* [x] Remove deprecated code in Logger
* [x] Remove deprecated Models
* [x] Bring remaining models into each core utility (MetricUnit, LambdaContextModel)
* [x] Separate Logger formatter into its own file
* [x] [Meet tenets criteria](https://awslabs.github.io/aws-lambda-powertools-python/#tenets)
* [x] Update tests
* [ ] Update docs
* [x] PR title follows [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-python/blob/376ec0a2ac0d2a40e0af5717bef42ff84ca0d1b9/.github/semantic.yml#L2)

## Breaking change checklist

> Ignore if it's not a breaking change

**RFC issue #**:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
