### PR TITLE
feat: logger inheritance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- **Logger**: Support for logger inheritance with `child` parameter
+
+### Fixed
+- **Logger**: Log level is now case insensitive via params and env var
 
 ## [1.0.2] - 2020-07-16
 ### Fixed

--- a/aws_lambda_powertools/logging/formatter.py
+++ b/aws_lambda_powertools/logging/formatter.py
@@ -56,6 +56,9 @@ class JsonFormatter(logging.Formatter):
         self.format_dict.update(kwargs)
         self.default_json_formatter = kwargs.pop("json_default", json_formatter)
 
+    def update_formatter(self, **kwargs):
+        self.format_dict.update(kwargs)
+
     def format(self, record):  # noqa: A003
         record_dict = record.__dict__.copy()
         record_dict["asctime"] = self.formatTime(record, self.datefmt)

--- a/aws_lambda_powertools/logging/logger.py
+++ b/aws_lambda_powertools/logging/logger.py
@@ -162,7 +162,7 @@ class Logger:
             )
 
     def inject_lambda_context(self, lambda_handler: Callable[[Dict, Any], Any] = None, log_event: bool = False):
-        """Decorator to capture Lambda contextual info and inject into struct logging
+        """Decorator to capture Lambda contextual info and inject into logger
 
         Parameters
         ----------
@@ -253,7 +253,7 @@ def set_package_logger(
 ):
     """Set an additional stream handler, formatter, and log level for aws_lambda_powertools package logger.
 
-    **Package log by default is supressed (NullHandler), this should only used for debugging.
+    **Package log by default is suppressed (NullHandler), this should only used for debugging.
     This is separate from application Logger class utility**
 
     Example

--- a/aws_lambda_powertools/logging/logger.py
+++ b/aws_lambda_powertools/logging/logger.py
@@ -119,7 +119,7 @@ class Logger:
     ):
         self.service = service or os.getenv("POWERTOOLS_SERVICE_NAME") or "service_undefined"
         self.sampling_rate = sampling_rate or os.getenv("POWERTOOLS_LOGGER_SAMPLE_RATE") or 0.0
-        self.log_level = level or os.getenv("LOG_LEVEL".upper()) or logging.INFO
+        self.log_level = self._get_log_level(level)
         self.child = child
         self._handler = logging.StreamHandler(stream) if stream is not None else logging.StreamHandler(sys.stdout)
         self._default_log_keys = {"service": self.service, "sampling_rate": self.sampling_rate}
@@ -131,6 +131,13 @@ class Logger:
         # Proxy attributes not found to actual logger to support backward compatibility
         # https://github.com/awslabs/aws-lambda-powertools-python/issues/97
         return getattr(self._logger, name)
+
+    def _get_log_level(self, level: str):
+        """ Returns preferred log level set by the customer in upper case """
+        log_level: str = level or os.getenv("LOG_LEVEL")
+        log_level = log_level.upper() if log_level is not None else logging.INFO
+
+        return log_level
 
     def _get_logger(self):
         """ Returns a Logger named {self.service}, or {self.service.filename} for child loggers"""

--- a/aws_lambda_powertools/logging/logger.py
+++ b/aws_lambda_powertools/logging/logger.py
@@ -119,7 +119,7 @@ class Logger:
         self.name = name or self.service
         self.sampling_rate = sampling_rate or os.getenv("POWERTOOLS_LOGGER_SAMPLE_RATE") or 0.0
         self.log_level = level or os.getenv("LOG_LEVEL".upper()) or logging.INFO
-        self.handler = logging.StreamHandler(stream) if stream is not None else logging.StreamHandler(sys.stdout)
+        self._handler = logging.StreamHandler(stream) if stream is not None else logging.StreamHandler(sys.stdout)
         self._default_log_keys = {"service": self.service, "sampling_rate": self.sampling_rate}
         self._logger = logging.getLogger(self.name)
 
@@ -141,7 +141,7 @@ class Logger:
         if self._logger.parent.name == "root" and not self._logger.handlers:
             self._configure_sampling()
             self._logger.setLevel(self.log_level)
-            self._logger.addHandler(self.handler)
+            self._logger.addHandler(self._handler)
             self.structure_logs(**kwargs)
 
     def _configure_sampling(self):

--- a/aws_lambda_powertools/logging/logger.py
+++ b/aws_lambda_powertools/logging/logger.py
@@ -89,19 +89,6 @@ class Logger(logging.Logger):
                 logger.structure_logs(append=True, payment_id=event["payment_id"])
                 logger.info("Hello")
 
-    Parameters
-    ----------
-    logging : logging.Logger
-        Inherits Logger
-    service: str
-        name of the service to create the logger for, "service_undefined" by default
-    level: str, int
-        log level, INFO by default
-    sampling_rate: float
-        debug log sampling rate, 0.0 by default
-    stream: sys.stdout
-        log stream, stdout by default
-
     Raises
     ------
     InvalidLoggerSamplingRateError

--- a/aws_lambda_powertools/logging/logger.py
+++ b/aws_lambda_powertools/logging/logger.py
@@ -118,7 +118,7 @@ class Logger(logging.Logger):
     ):
         self.service = service or os.getenv("POWERTOOLS_SERVICE_NAME") or "service_undefined"
         self.sampling_rate = sampling_rate or os.getenv("POWERTOOLS_LOGGER_SAMPLE_RATE") or 0.0
-        self.log_level = level or os.getenv("LOG_LEVEL") or logging.INFO
+        self.log_level = level or os.getenv("LOG_LEVEL".upper()) or logging.INFO
         self.handler = logging.StreamHandler(stream) if stream is not None else logging.StreamHandler(sys.stdout)
         self._default_log_keys = {"service": self.service, "sampling_rate": self.sampling_rate}
         self.log_keys = copy.copy(self._default_log_keys)

--- a/aws_lambda_powertools/logging/logger.py
+++ b/aws_lambda_powertools/logging/logger.py
@@ -54,7 +54,7 @@ class Logger:
         service name to be appended in logs, by default "service_undefined"
     level : str, optional
         logging.level, by default "INFO"
-    name: str
+    name: str, optional
         Logger name, "{service}" by default
     sample_rate: float, optional
         sample rate for debug calls within execution context defaults to 0.0

--- a/aws_lambda_powertools/logging/logger.py
+++ b/aws_lambda_powertools/logging/logger.py
@@ -133,7 +133,7 @@ class Logger:
         return getattr(self._logger, name)
 
     def _get_logger(self):
-        """ Returns a Logger named {self.service}, or {service.filename} for child loggers"""
+        """ Returns a Logger named {self.service}, or {self.service.filename} for child loggers"""
         logger_name = self.service
         if self.child:
             logger_name = f"{self.service}.{self._get_caller_filename()}"

--- a/docs/content/core/logger.mdx
+++ b/docs/content/core/logger.mdx
@@ -183,6 +183,41 @@ def handler(event, context):
 ```
 </details>
 
+## Reusing Logger across your code
+
+Logger supports inheritance via `child` parameter. This allows you to create multiple Loggers across your code base, and propagate changes such as new keys to all Loggers.
+
+```python:title=collect.py
+# POWERTOOLS_SERVICE_NAME: "payment"
+import shared # Creates a child logger named "payment.shared"
+from aws_lambda_powertools import Logger
+
+logger = Logger()
+
+def handler(event, context):
+  shared.inject_payment_id(event) # highlight-line
+  logger.structure_logs(append=True, order_id=event["order_id"]) # highlight-line
+      ...
+```
+
+```python:title=shared.py
+# POWERTOOLS_SERVICE_NAME: "payment"
+from aws_lambda_powertools import Logger
+
+logger = Logger(child=True) # highlight-line
+
+def inject_payment_id(event):
+    logger.structure_logs(append=True, payment_id=event["payment_id"])
+```
+
+In this example, `Logger` will create a parent logger named `payment` and a child logger named `payment.shared`. Any changes in the parent and child `Loggers` will be propagated among them.
+
+If you ever forget to use `child` param, we will return an existing `Logger` with the same `service` name.
+
+<Note type="info">
+	Child loggers will be named after the following convention <code>service.filename</code>.
+</Note><br/>
+
 ## Sampling debug logs
 
 You can dynamically set a percentage of your logs to **DEBUG** level using `sample_rate` param or via env var `POWERTOOLS_LOGGER_SAMPLE_RATE`.

--- a/tests/functional/test_aws_lambda_logging.py
+++ b/tests/functional/test_aws_lambda_logging.py
@@ -4,7 +4,7 @@ import json
 
 import pytest
 
-from .utility_functions import get_random_logger
+from aws_lambda_powertools import Logger
 
 
 @pytest.fixture
@@ -14,7 +14,7 @@ def stdout():
 
 @pytest.mark.parametrize("level", ["DEBUG", "WARNING", "ERROR", "INFO", "CRITICAL"])
 def test_setup_with_valid_log_levels(stdout, level):
-    logger = get_random_logger(level=level, stream=stdout, request_id="request id!", another="value")
+    logger = Logger(level=level, stream=stdout, request_id="request id!", another="value")
     msg = "This is a test"
     log_command = {
         "INFO": logger.info,
@@ -38,7 +38,7 @@ def test_setup_with_valid_log_levels(stdout, level):
 
 
 def test_logging_exception_traceback(stdout):
-    logger = get_random_logger(level="DEBUG", stream=stdout, request_id="request id!", another="value")
+    logger = Logger(level="DEBUG", stream=stdout, request_id="request id!", another="value")
 
     try:
         raise Exception("Boom")
@@ -53,7 +53,7 @@ def test_logging_exception_traceback(stdout):
 
 def test_setup_with_invalid_log_level(stdout):
     with pytest.raises(ValueError) as e:
-        get_random_logger(level="not a valid log level")
+        Logger(level="not a valid log level")
         assert "Unknown level" in e.value.args[0]
 
 
@@ -65,7 +65,7 @@ def check_log_dict(log_dict):
 
 
 def test_with_dict_message(stdout):
-    logger = get_random_logger(level="DEBUG", stream=stdout)
+    logger = Logger(level="DEBUG", stream=stdout)
 
     msg = {"x": "isx"}
     logger.critical(msg)
@@ -76,7 +76,7 @@ def test_with_dict_message(stdout):
 
 
 def test_with_json_message(stdout):
-    logger = get_random_logger(stream=stdout)
+    logger = Logger(stream=stdout)
 
     msg = {"x": "isx"}
     logger.info(json.dumps(msg))
@@ -87,7 +87,7 @@ def test_with_json_message(stdout):
 
 
 def test_with_unserialisable_value_in_message(stdout):
-    logger = get_random_logger(level="DEBUG", stream=stdout)
+    logger = Logger(level="DEBUG", stream=stdout)
 
     class X:
         pass

--- a/tests/functional/test_logger.py
+++ b/tests/functional/test_logger.py
@@ -294,3 +294,19 @@ def test_logger_children_do_not_propagate_changes(stdout):
     assert "customer_id" not in parent_log
     assert "customer_id" in child_log
     assert child.parent.name == "order"
+
+
+def test_logger_name_not_set(stdout):
+    # GIVEN Logger is initialized
+    # WHEN name isn't set
+    logger = Logger(stream=stdout, service="something")
+
+    # THEN Logger should function just as fine
+    # and access to its properties should be
+    # proxied to the inner Logger
+    logger.info("Hello")
+
+    log = capture_logging_output(stdout)
+    assert "Hello" == log["message"]
+    assert logger.parent.name == "root"
+    assert logger.name == "something"

--- a/tests/functional/test_logger.py
+++ b/tests/functional/test_logger.py
@@ -306,3 +306,21 @@ def test_logger_child_not_set_returns_same_logger(stdout):
     assert id(logger_one) != id(logger_two)
     assert logger_one._logger is logger_two._logger
     assert logger_one.name is logger_two.name
+
+
+def test_logger_level_case_insensitive(stdout):
+    # GIVEN a Loggers is initialized
+    # WHEN log level is set as "info" instead of "INFO"
+    logger = Logger(level="info")
+
+    # THEN we should correctly set log level as INFO
+    assert logger.level == logging.INFO
+
+
+def test_logger_level_not_set(stdout):
+    # GIVEN a Loggers is initialized
+    # WHEN no log level was passed
+    logger = Logger(level="info")
+
+    # THEN we should default to INFO
+    assert logger.level == logging.INFO

--- a/tests/functional/test_logger.py
+++ b/tests/functional/test_logger.py
@@ -295,8 +295,8 @@ def test_logger_children_propagate_changes(stdout):
     assert child.parent.name == "order"
 
 
-def test_logger_child_not_set(stdout):
-    # GIVEN two Loggers are initialized
+def test_logger_child_not_set_returns_same_logger(stdout):
+    # GIVEN two Loggers are initialized with the same service name
     # WHEN child param isn't set
     logger_one = Logger(service="something")
     logger_two = Logger(service="something")

--- a/tests/functional/utility_functions.py
+++ b/tests/functional/utility_functions.py
@@ -1,8 +1,0 @@
-import secrets
-
-from aws_lambda_powertools import Logger
-
-
-def get_random_logger(**kwargs):
-    """Return vanilla logger w/ random name"""
-    return Logger(name=secrets.token_urlsafe(), **kwargs)

--- a/tests/functional/utility_functions.py
+++ b/tests/functional/utility_functions.py
@@ -1,0 +1,8 @@
+import secrets
+
+from aws_lambda_powertools import Logger
+
+
+def get_random_logger(**kwargs):
+    """Return vanilla logger w/ random name"""
+    return Logger(name=secrets.token_urlsafe(), **kwargs)


### PR DESCRIPTION
**Issue #, if available:** #97 

## Description of changes:

<!--- One or two sentences as a summary of what's being changed -->

This addresses a common issue when trying to use `Logger` across multiple modules while wanting to:

* **Create a new child Logger** to inherit parent Logger's configuration (handler, formatter, custom keys, sampling)
* **Reuse the same Logger**, where Logger is enriched iteratively across the code base

For this, we've introduced a new parameter, `child`, when initializing a new Logger, and some internal changes while keeping the same UX and backwards compatibility.

* **[Internal]** Direct access to methods, handlers, etc work as before, except that we proxy properties access to `._logger`

## UX

**Key aspects**:

* We support logging inheritance via the `child` parameter, and the `Logger` will be named after `<service>.<caller_file_name>`
* Calling `Logger` with the same `service` name (explicit or via environment variable) returns the same `Logger`
* Changes to either Child `Logger` or Parent `Logger` will be propagated to all instances

### Creating a child Logger

Child logger can be created in any other as long as a parent is created too - This supports customers using Layers or different file names to create child loggers.

```python
# lambda_handler.py
from aws_lambda_powertools import Logger
import collect

logger = Logger(service="payment") # parent Logger just like before, named 'payment'
...

# collect.py
from aws_lambda_powertools import Logger

logger = Logger(service="payment", child=True) # child Logger named 'payment.collect'

# a_new_key will now be available both in this child logger as well as the parent
logger.structure_logs(append=True, a_new_key="value") 
...
```

### Reusing the same Logger

```python
# lambda_handler.py
from aws_lambda_powertools import Logger
import collect

logger = Logger(service="payment") # parent Logger just like before, named 'payment'

# collect.py
from aws_lambda_powertools import Logger

logger = Logger(service="payment") # returns the existing 'payment' Logger
...
```

**Checklist**

<!--- Leave unchecked if your change doesn't seem to apply --> 

- [x] [Meet tenets criteria](https://awslabs.github.io/aws-lambda-powertools-python/#tenets)
- [x] Update tests
- [ ] Update docs
- [x] PR title follows [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-python/blob/376ec0a2ac0d2a40e0af5717bef42ff84ca0d1b9/.github/semantic.yml#L2)

**Changes**

- [x] Register logger via `getLogger` to allow inheritance
- [x] Encapsulate logger initialization/config in a new method
- [x] Remove Logger sub-classing
  - [x] Proxy calls to underneath Logger instead
- [x] ~~Create `name` parameter for hierarchy~~
  - [x] ~~Use `service` if `name` is empty~~
- [x] Test on Lambda locally
  - [x] Single Logger, no code changes
  - [x] Two Loggers in different files
  - [x] Additional Logger in a package that is imported on main entry-point
  - [x] Lambda Layer
- [x] Only add a handler if there isn't one
- [x] Only add a handler if parent is root
- [x] Update Formatter to append new keys
- [x] Make `handler` private
- [x] Remove `log_keys`
- [x] Remove duplicate Parameters in docstring
- [x] Double check Debug w/ getattr perf impact
- [x] Docs: Document inheriting Loggers
- [x] Docs: Changelog (doc random logger for tests)
- [x] Test: Logger hierarchy via logger.parent
- [x] Remove `name` parameter
- [x] Allow logger child propagation
- [x] Introduce `child` boolean param
- [x] Don't add a handler nor evaluate sampling if it's a `child` Logger
- [x] Name `child` Loggers based on `<service>.<caller_file_name>` to mimick `getLogger(__name__)`
- [x] Update tests to remove Handler on every test
- [x] Update tests to remove `getRandomLogger` utility function

**Optional**

- [x] Ensure log level input is case insensitive

## Benchmark

> **TL;DR**: For the average use case we have a slight performance decrease, but all negligible in all cases (0.10 nano seconds). 

Quick checks as we've removed `logging.Logger` sub-classing, respect Logging inheritance, and are proxying calls to inner Logger.

### Basic logger

* **Script**: `python -m timeit -s 'from aws_lambda_powertools import Logger; logger = Logger(); logger.info("hello world")'`
* **Before**: 50000000 loops, best of 5: **6.12 nsec** per loop
* **After with Logger proxy object, no sub-classing**: 50000000 loops, best of 5: **6.22 nsec** per loop

### Inheritance

* **Script**: `python -m timeit -s 'from aws_lambda_powertools import Logger; logger = Logger(); l = Logger(); l.info("hello world")'`
* **Same logger**: 50000000 loops, best of 5: **6.28 nsec** per loop
* **Random child logger name + fixup**: 50000000 loops, best of 5: **6.14 nsec** per loop
    - **Script**: `python -m timeit -s 'from aws_lambda_powertools import Logger; logger = Logger(child=True); l = Logger(); l.info("hello world")'`


## Breaking change checklist

<!--- Ignore if it's not a breaking change -->

**RFC issue #**:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
