### PR TITLE
fix: regression 104 and revert docstring

### DIFF
--- a/aws_lambda_powertools/logging/logger.py
+++ b/aws_lambda_powertools/logging/logger.py
@@ -44,7 +44,7 @@ class Logger:
     ---------------------
     POWERTOOLS_SERVICE_NAME : str
         service name
-    LOG_LEVEL: str, int
+    LOG_LEVEL: str
         logging level (e.g. INFO, DEBUG)
     POWERTOOLS_LOGGER_SAMPLE_RATE: float
         samping rate ranging from 0 to 1, 1 being 100% sampling

--- a/tests/functional/test_logger.py
+++ b/tests/functional/test_logger.py
@@ -333,3 +333,14 @@ def test_logger_level_as_int():
 
     # THEN we should be expected int (20, in this case)
     assert logger.level == logging.INFO
+
+
+def test_logger_level_env_var_as_int(monkeypatch):
+    # GIVEN Logger is initialized
+    # WHEN log level is explicitly defined via LOG_LEVEL env as int
+    # THEN Logger should propagate ValueError
+    # since env vars can only be string
+    # and '50' is not a correct log level
+    monkeypatch.setenv("LOG_LEVEL", 50)
+    with pytest.raises(ValueError, match="Unknown level: '50'"):
+        Logger()


### PR DESCRIPTION
**Issue #, if available:** #104 

## Description of changes:

<!--- One or two sentences as a summary of what's being changed -->

- [x] Revert docstring to **str** as env var values cannot be **int**
- [x] Add tests to confirm that's always the case, and propagates Unknown log level error up

**Checklist**

<!--- Leave unchecked if your change doesn't seem to apply --> 

* [x] [Meet tenets criteria](https://awslabs.github.io/aws-lambda-powertools-python/#tenets)
* [x] Update tests
* [ ] Update docs
* [x] PR title follows [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-python/blob/376ec0a2ac0d2a40e0af5717bef42ff84ca0d1b9/.github/semantic.yml#L2)

## Breaking change checklist

<!--- Ignore if it's not a breaking change -->

**RFC issue #**:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
