### PR TITLE
docs: clarify Tracer auto_patch as per #108

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **Docs**: Clarify confusion on Tracer reuse and `auto_patch=False` statement
+
 ## [1.1.1] - 2020-08-14
 ### Fixed
 - **Logger**: Regression on `Logger` level not accepting `int` i.e. `Logger(level=logging.INFO)`

--- a/docs/content/core/tracer.mdx
+++ b/docs/content/core/tracer.mdx
@@ -199,6 +199,11 @@ async def collect_payment(charge_id):
 
 Tracer keeps a copy of its configuration after the first initialization. This is useful for scenarios where you want to use Tracer in more than one location across your code base.
 
+<Note type="warning">
+    When reusing Tracer in Lambda Layers, or in multiple modules, <strong>do not set <code>auto_patch=False</code></strong>, because import order matters.
+    <br/><br/>This can result in the first Tracer config being inherited by new instances, and their modules not being patched.
+</Note><br/>
+
 ```python:title=lambda_handler.py
 # handler.py
 from aws_lambda_powertools import Tracer
@@ -214,8 +219,8 @@ def handler(event, context):
 ```python:title=another_file.py
 from aws_lambda_powertools import Tracer
 # highlight-start
-# new instance using existing configuration with auto patching overriden
-tracer = Tracer(auto_patch=False)
+# new instance using existing configuration
+tracer = Tracer(service="payment")
 # highlight-end
 ```
 


### PR DESCRIPTION
**Issue #, if available:** #108 

## Description of changes:

<!--- One or two sentences as a summary of what's being changed -->

Clarifies `auto_patch=False` feature when reusing Tracer across multiple modules, or in Lambda Layers, where import order creates a side effect where no modules end up being patched.

![image](https://user-images.githubusercontent.com/3340292/90321265-6dbd8e00-df48-11ea-95a0-ccc640da3663.png)


**Checklist**

<!--- Leave unchecked if your change doesn't seem to apply --> 

* [ ] [Meet tenets criteria](https://awslabs.github.io/aws-lambda-powertools-python/#tenets)
* [ ] Update tests
* [x] Update docs
* [ ] PR title follows [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-python/blob/376ec0a2ac0d2a40e0af5717bef42ff84ca0d1b9/.github/semantic.yml#L2)

## Breaking change checklist

<!--- Ignore if it's not a breaking change -->

**RFC issue #**:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
