### PR TITLE
feat: add support for tracing of generators using capture_method decorator

### DIFF
--- a/docs/content/core/tracer.mdx
+++ b/docs/content/core/tracer.mdx
@@ -14,7 +14,7 @@ Tracer is an opinionated thin wrapper for [AWS X-Ray Python SDK](https://github.
 * Capture cold start as annotation, and responses as well as full exceptions as metadata
 * Run functions locally with SAM CLI without code change to disable tracing
 * Explicitly disable tracing via env var `POWERTOOLS_TRACE_DISABLED="true"`
-* Support tracing async methods
+* Support tracing async methods, generators, and context managers
 * Auto patch supported modules, or a tuple of explicit modules supported by AWS X-Ray
 
 ## Initialization
@@ -111,16 +111,18 @@ def collect_payment(charge_id):
 ...
 ```
 
-## Asynchronous functions
+## Asynchronous and generator functions
 
 <Note type="warning">
   <strong>We do not support async Lambda handler</strong> - Lambda handler itself must be synchronous
 </Note><br/>
 
-You can trace an asynchronous function using the `capture_method`. The decorator will detect whether your function is asynchronous, and adapt its behaviour accordingly.
+You can trace asynchronous functions and generator functions (including context managers) using `capture_method`.
+The decorator will detect whether your function is asynchronous, a generator, or a  context manager and adapt its behaviour accordingly.
 
 ```python:title=lambda_handler_with_async_code.py
 import asyncio
+import contextlib
 from aws_lambda_powertools import Tracer
 tracer = Tracer()
 
@@ -130,9 +132,29 @@ async def collect_payment():
     ...
 # highlight-end
 
+# highlight-start
+@contextlib.contextmanager
+@tracer.capture_method
+def collect_payment_ctxman():
+    yield result
+    ...
+# highlight-end
+
+# highlight-start
+@tracer.capture_method
+def collect_payment_gen():
+    yield result
+    ...
+# highlight-end
+
 @tracer.capture_lambda_handler
 def handler(evt, ctx): # highlight-line
     asyncio.run(collect_payment())
+
+    with collect_payment_ctxman as result:
+        do_something_with(result)
+
+    another_result = list(collect_payment_gen())
 ```
 
 ## Tracing aiohttp requests

--- a/example/tests/test_handler.py
+++ b/example/tests/test_handler.py
@@ -4,6 +4,14 @@ from dataclasses import dataclass
 
 import pytest
 
+from aws_lambda_powertools import Tracer
+
+
+@pytest.fixture(scope="function", autouse=True)
+def reset_tracing_config():
+    Tracer._reset_config()
+    yield
+
 
 @pytest.fixture()
 def env_vars(monkeypatch):


### PR DESCRIPTION

**Issue #, if available:** #112 

## Description of changes:

Added checks to capture_method to test if decorated function is a generator (and/or a context manager) and handle those cases appropriately.

**Checklist**

<!--- Leave unchecked if your change doesn't seem to apply --> 

* [X] [Meet tenets criteria](https://awslabs.github.io/aws-lambda-powertools-python/#tenets)
* [X] Update tests
* [ ] Update docs
* [X] PR title follows [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-python/blob/376ec0a2ac0d2a40e0af5717bef42ff84ca0d1b9/.github/semantic.yml#L2)

## Breaking change checklist

<!--- Ignore if it's not a breaking change -->

**RFC issue #**:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
