### PR TITLE
fix: remove root logger handler set by Lambda #115

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.1.3] - 2020-08-18
+### Fixed
+- **Logger**: Logs emitted twice, structured and unstructured, due to Lambda configuring the root handler
+
 ## [1.1.2] - 2020-08-16
 ### Fixed
 - **Docs**: Clarify confusion on Tracer reuse and `auto_patch=False` statement

--- a/aws_lambda_powertools/logging/logger.py
+++ b/aws_lambda_powertools/logging/logger.py
@@ -168,6 +168,13 @@ class Logger(logging.Logger):  # lgtm [py/missing-call-to-init]
     def _init_logger(self, **kwargs):
         """Configures new logger"""
 
+        # Lambda by default configures the root logger handler
+        # therefore, we need to remove it to prevent messages being logged twice
+        # when customers use our Logger
+        logger.debug("Removing Lambda root handler whether it exists")
+        root_logger = logging.getLogger()
+        root_logger.handlers.clear()
+
         # Skip configuration if it's a child logger to prevent
         # multiple handlers being attached as well as different sampling mechanisms
         # and multiple messages from being logged as handlers can be duplicated


### PR DESCRIPTION
**Issue #, if available:** #115 

## Description of changes:

<!--- One or two sentences as a summary of what's being changed -->

**Checklist**

* [x] Remove root logger handler whether it exists upon Logger initialization
* [x] Create test to replicate Lambda behaviour

<!--- Leave unchecked if your change doesn't seem to apply --> 

* [x] [Meet tenets criteria](https://awslabs.github.io/aws-lambda-powertools-python/#tenets)
* [x] Update tests
* [ ] Update docs
* [x] PR title follows [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-python/blob/376ec0a2ac0d2a40e0af5717bef42ff84ca0d1b9/.github/semantic.yml#L2)

## Breaking change checklist

<!--- Ignore if it's not a breaking change -->

**RFC issue #**:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
