### PR TITLE
docs: add info how to get layer versions from the SAR for the layers 

### DIFF
--- a/docs/content/index.mdx
+++ b/docs/content/index.mdx
@@ -44,6 +44,12 @@ If using SAM, you can include this SAR App as part of your shared Layers stack, 
         SemanticVersion: 1.3.1 # change to latest semantic version available in SAR
 ```
 
+You can fetch the available versions via the API with:
+
+```bash
+aws serverlessrepo list-application-versions --application-id arn:aws:serverlessrepo:eu-west-1:057560766410:applications/aws-lambda-powertools-python-layer
+```
+
 ## Features
 
 Utility | Description

--- a/docs/content/index.mdx
+++ b/docs/content/index.mdx
@@ -45,7 +45,7 @@ If using SAM, you can include this SAR App as part of your shared Layers stack, 
 ```
 
 This will add a nested app stack with an output parameter `LayerVersionArn`. You can not reference layer arn within the template on the first try, this is currently not supported.
-Either first run `sam deploy` and add `Layers` ARN property to the Lambda function after the deployment and run `sam deploy again`.
+Either first run `sam deploy` and add `Layers` ARN property to the Lambda function after the deployment and run `sam deploy` again.
 Or extract the `AWS::Serverless::Application` resource into a separate stack and use `Fn::ImportValue` to fetch the value.
 
 You can fetch the available versions via the API with:

--- a/docs/content/index.mdx
+++ b/docs/content/index.mdx
@@ -44,6 +44,10 @@ If using SAM, you can include this SAR App as part of your shared Layers stack, 
         SemanticVersion: 1.3.1 # change to latest semantic version available in SAR
 ```
 
+This will add a nested app stack with an output parameter `LayerVersionArn`. You can not reference layer arn within the template on the first try, this is currently not supported.
+Either first run `sam deploy` and add `Layers` ARN property to the Lambda function after the deployment and run `sam deploy again`.
+Or extract the `AWS::Serverless::Application` resource into a separate stack and use `Fn::ImportValue` to fetch the value.
+
 You can fetch the available versions via the API with:
 
 ```bash


### PR DESCRIPTION
**Issue #, if available:**

## Description of changes:

The AWS console does not show the available versions of the SAR app for the layers we have recently published. I added the CLI command this the ARN to fetch the available versions.

**Checklist**

<!--- Leave unchecked if your change doesn't seem to apply --> 

* [x] [Meet tenets criteria](https://awslabs.github.io/aws-lambda-powertools-python/#tenets)
* [ ] Update tests
* [x] Update docs
* [x] PR title follows [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-python/blob/376ec0a2ac0d2a40e0af5717bef42ff84ca0d1b9/.github/semantic.yml#L2)

## Breaking change checklist

<!--- Ignore if it's not a breaking change -->

**RFC issue #**:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
