### PR TITLE
docs: fix log sampling percentage wording

### DIFF
--- a/docs/content/core/logger.mdx
+++ b/docs/content/core/logger.mdx
@@ -55,7 +55,7 @@ Key | Type | Example | Description
 **level** | str | "INFO" | Logging level
 **location** | str | "collect.handler:1" | Source code location where statement was executed
 **service** | str | "payment" | Service name defined. "service_undefined" will be used if unknown
-**sampling_rate** | int |  0.1 | Debug logging sampling rate in percentage e.g. 1% in this case
+**sampling_rate** | int |  0.1 | Debug logging sampling rate in percentage e.g. 10% in this case
 **message** | any |  "Collecting payment" | Log statement value. Unserializable JSON values will be casted to string
 
 ## Capturing Lambda context info
@@ -232,7 +232,7 @@ Sampling calculation happens at the Logger class initialization. This means, whe
 ```python:title=collect.py
 from aws_lambda_powertools import Logger
 
-# Sample 1% of debug logs e.g. 0.1
+# Sample 10% of debug logs e.g. 0.1
 logger = Logger(sample_rate=0.1) # highlight-line
 
 def handler(event, context):


### PR DESCRIPTION
**Issue #, if available:**

## Description of changes:

Correct Documentation on log sampling

**Checklist**

<!--- Leave unchecked if your change doesn't seem to apply --> 

* [x] [Meet tenets criteria](https://awslabs.github.io/aws-lambda-powertools-python/#tenets)
* [x] Update tests
* [x] Update docs
* [x] PR title follows [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-python/blob/376ec0a2ac0d2a40e0af5717bef42ff84ca0d1b9/.github/semantic.yml#L2)

## Breaking change checklist

<!--- Ignore if it's not a breaking change -->

**RFC issue #**:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
