### PR TITLE
feat(logger): customizing logger output

### DIFF
--- a/aws_lambda_powertools/logging/formatter.py
+++ b/aws_lambda_powertools/logging/formatter.py
@@ -1,27 +1,5 @@
 import json
 import logging
-from typing import Any
-
-
-def json_formatter(unserializable_value: Any):
-    """JSON custom serializer to cast unserializable values to strings.
-
-    Example
-    -------
-
-    **Serialize unserializable value to string**
-
-        class X: pass
-        value = {"x": X()}
-
-        json.dumps(value, default=json_formatter)
-
-    Parameters
-    ----------
-    unserializable_value: Any
-        Python object unserializable by JSON
-    """
-    return str(unserializable_value)
 
 
 class JsonFormatter(logging.Formatter):
@@ -44,17 +22,15 @@ class JsonFormatter(logging.Formatter):
 
         Other kwargs are used to specify log field format strings.
         """
-        self.default_json_formatter = kwargs.pop("json_default", json_formatter)
+        self.default_json_formatter = kwargs.pop("json_default", str)
         datefmt = kwargs.pop("datefmt", None)
 
         super(JsonFormatter, self).__init__(datefmt=datefmt)
         self.reserved_keys = ["timestamp", "level", "location"]
-        self.format_dict = {
-            "timestamp": "%(asctime)s",
-            "level": "%(levelname)s",
-            "location": "%(funcName)s:%(lineno)d",
-            "message": None,
-        }
+        self.format_dict = dict.fromkeys(kwargs.pop("format_key", ["level", "location", "message", "timestamp"]))
+        self.format_dict.update(
+            {"level": "%(levelname)s", "location": "%(funcName)s:%(lineno)d", "timestamp": "%(asctime)s"}
+        )
         self.format_dict.update(kwargs)
 
     def update_formatter(self, **kwargs):

--- a/aws_lambda_powertools/logging/formatter.py
+++ b/aws_lambda_powertools/logging/formatter.py
@@ -30,7 +30,7 @@ class JsonFormatter(logging.Formatter):
         self.default_json_formatter = kwargs.pop("json_default", str)
         # Set the insertion order for the log messages
         self.format_dict = dict.fromkeys(kwargs.pop("log_record_order", ["level", "location", "message", "timestamp"]))
-        # Set timestamp the date format
+        # Set the date format used by `asctime`
         super(JsonFormatter, self).__init__(datefmt=kwargs.pop("datefmt", None))
 
         self.reserved_keys = ["timestamp", "level", "location"]

--- a/aws_lambda_powertools/logging/formatter.py
+++ b/aws_lambda_powertools/logging/formatter.py
@@ -53,7 +53,7 @@ class JsonFormatter(logging.Formatter):
             "timestamp": "%(asctime)s",
             "level": "%(levelname)s",
             "location": "%(funcName)s:%(lineno)d",
-            "message": "",
+            "message": None,
         }
         self.format_dict.update(kwargs)
 

--- a/aws_lambda_powertools/logging/formatter.py
+++ b/aws_lambda_powertools/logging/formatter.py
@@ -27,7 +27,7 @@ class JsonFormatter(logging.Formatter):
 
         super(JsonFormatter, self).__init__(datefmt=datefmt)
         self.reserved_keys = ["timestamp", "level", "location"]
-        self.format_dict = dict.fromkeys(kwargs.pop("format_key", ["level", "location", "message", "timestamp"]))
+        self.format_dict = dict.fromkeys(kwargs.pop("format_keys", ["level", "location", "message", "timestamp"]))
         self.format_dict.update(
             {"level": "%(levelname)s", "location": "%(funcName)s:%(lineno)d", "timestamp": "%(asctime)s"}
         )
@@ -70,5 +70,8 @@ class JsonFormatter(logging.Formatter):
 
         if record.exc_text:
             log_dict["exception"] = record.exc_text
+
+        # Filter out top level key with values that are None
+        log_dict = {k: v for k, v in log_dict.items() if v is not None}
 
         return json.dumps(log_dict, default=self.default_json_formatter)

--- a/aws_lambda_powertools/logging/formatter.py
+++ b/aws_lambda_powertools/logging/formatter.py
@@ -53,6 +53,7 @@ class JsonFormatter(logging.Formatter):
             "timestamp": "%(asctime)s",
             "level": "%(levelname)s",
             "location": "%(funcName)s:%(lineno)d",
+            "message": "",
         }
         self.format_dict.update(kwargs)
 

--- a/aws_lambda_powertools/logging/formatter.py
+++ b/aws_lambda_powertools/logging/formatter.py
@@ -20,18 +20,23 @@ class JsonFormatter(logging.Formatter):
         unserializable values.  It must not throw.  Defaults to a function that
         coerces the value to a string.
 
+        The `log_record_order` kwarg is used to specify the order of the keys used in
+        the structured json logs. By default the order is: "level", "location", "message", "timestamp",
+        "service" and "sampling_rate".
+
         Other kwargs are used to specify log field format strings.
         """
+        # Set the default unserializable function, by default values will be cast as str.
         self.default_json_formatter = kwargs.pop("json_default", str)
-        datefmt = kwargs.pop("datefmt", None)
+        # Set the insertion order for the log messages
+        self.format_dict = dict.fromkeys(kwargs.pop("log_record_order", ["level", "location", "message", "timestamp"]))
+        # Set timestamp the date format
+        super(JsonFormatter, self).__init__(datefmt=kwargs.pop("datefmt", None))
 
-        super(JsonFormatter, self).__init__(datefmt=datefmt)
         self.reserved_keys = ["timestamp", "level", "location"]
-        self.format_dict = dict.fromkeys(kwargs.pop("format_keys", ["level", "location", "message", "timestamp"]))
         self.format_dict.update(
-            {"level": "%(levelname)s", "location": "%(funcName)s:%(lineno)d", "timestamp": "%(asctime)s"}
+            {"level": "%(levelname)s", "location": "%(funcName)s:%(lineno)d", "timestamp": "%(asctime)s", **kwargs}
         )
-        self.format_dict.update(kwargs)
 
     def update_formatter(self, **kwargs):
         self.format_dict.update(kwargs)

--- a/aws_lambda_powertools/logging/logger.py
+++ b/aws_lambda_powertools/logging/logger.py
@@ -123,7 +123,7 @@ class Logger(logging.Logger):  # lgtm [py/missing-call-to-init]
     ):
         self.service = service or os.getenv("POWERTOOLS_SERVICE_NAME") or "service_undefined"
         self.sampling_rate = sampling_rate or os.getenv("POWERTOOLS_LOGGER_SAMPLE_RATE") or 0.0
-        self.log_level = _get_log_level(level)
+        self.log_level = self._get_log_level(level)
         self.child = child
         self._handler = logging.StreamHandler(stream) if stream is not None else logging.StreamHandler(sys.stdout)
         self._default_log_keys = {"service": self.service, "sampling_rate": self.sampling_rate}
@@ -140,7 +140,7 @@ class Logger(logging.Logger):  # lgtm [py/missing-call-to-init]
         """ Returns a Logger named {self.service}, or {self.service.filename} for child loggers"""
         logger_name = self.service
         if self.child:
-            logger_name = f"{self.service}.{_get_caller_filename()}"
+            logger_name = f"{self.service}.{self._get_caller_filename()}"
 
         return logging.getLogger(logger_name)
 
@@ -272,28 +272,28 @@ class Logger(logging.Logger):  # lgtm [py/missing-call-to-init]
                 # Set a new formatter for a logger handler
                 handler.setFormatter(JsonFormatter(**self._default_log_keys, **kwargs))
 
+    @staticmethod
+    def _get_log_level(level: Union[str, int]) -> Union[str, int]:
+        """ Returns preferred log level set by the customer in upper case """
+        if isinstance(level, int):
+            return level
 
-def _get_log_level(level: Union[str, int]) -> Union[str, int]:
-    """ Returns preferred log level set by the customer in upper case """
-    if isinstance(level, int):
-        return level
+        log_level: str = level or os.getenv("LOG_LEVEL")
+        log_level = log_level.upper() if log_level is not None else logging.INFO
 
-    log_level: str = level or os.getenv("LOG_LEVEL")
-    log_level = log_level.upper() if log_level is not None else logging.INFO
+        return log_level
 
-    return log_level
+    @staticmethod
+    def _get_caller_filename():
+        """ Return caller filename by finding the caller frame """
+        # Current frame         => _get_logger()
+        # Previous frame        => logger.py
+        # Before previous frame => Caller
+        frame = inspect.currentframe()
+        caller_frame = frame.f_back.f_back.f_back
+        filename = caller_frame.f_globals["__name__"]
 
-
-def _get_caller_filename():
-    """ Return caller filename by finding the caller frame """
-    # Current frame         => _get_logger()
-    # Previous frame        => logger.py
-    # Before previous frame => Caller
-    frame = inspect.currentframe()
-    caller_frame = frame.f_back.f_back.f_back
-    filename = caller_frame.f_globals["__name__"]
-
-    return filename
+        return filename
 
 
 def set_package_logger(

--- a/tests/functional/test_aws_lambda_logging.py
+++ b/tests/functional/test_aws_lambda_logging.py
@@ -116,3 +116,16 @@ def test_with_unserializable_value_in_message_custom(stdout):
     # THEN json_default should not be in the log message and the custom unserializable handler should be used
     assert log_dict["message"]["x"] == "<non-serializable: Unserializable>"
     assert "json_default" not in log_dict
+
+
+def test_log_dict_key_seq(stdout):
+    # GIVEN any logger configuration
+    logger = Logger(level="INFO", stream=stdout, another="xxx")
+
+    # WHEN logging a message
+    logger.info("Message")
+
+    log_dict: dict = json.loads(stdout.getvalue())
+
+    # THEN the key sequence should be `timestamp,level,location,message`
+    assert ",".join(list(log_dict.keys())[:4]) == "timestamp,level,location,message"

--- a/tests/functional/test_aws_lambda_logging.py
+++ b/tests/functional/test_aws_lambda_logging.py
@@ -119,8 +119,8 @@ def test_with_unserializable_value_in_message_custom(stdout):
 
 
 def test_log_dict_key_seq(stdout):
-    # GIVEN any logger configuration
-    logger = Logger(level="INFO", stream=stdout, another="xxx")
+    # GIVEN the default logger configuration
+    logger = Logger(stream=stdout)
 
     # WHEN logging a message
     logger.info("Message")
@@ -133,7 +133,7 @@ def test_log_dict_key_seq(stdout):
 
 def test_log_dict_key_custom_seq(stdout):
     # GIVEN a logger configuration with format_keys set to ["message"]
-    logger = Logger(stream=stdout, format_keys=["message"])
+    logger = Logger(stream=stdout, log_record_order=["message"])
 
     # WHEN logging a message
     logger.info("Message")
@@ -145,21 +145,23 @@ def test_log_dict_key_custom_seq(stdout):
 
 
 def test_log_custom_formatting(stdout):
-    # GIVEN a logger where we have a custom location format
-    logger = Logger(stream=stdout, location="[%(funcName)s] %(module)s")
+    # GIVEN a logger where we have a custom `location`, 'datefmt' format
+    logger = Logger(stream=stdout, location="[%(funcName)s] %(module)s", datefmt="fake-datefmt")
 
     # WHEN logging a message
     logger.info("foo")
 
     log_dict: dict = json.loads(stdout.getvalue())
 
-    # THEN the `location` match the formatting
+    # THEN the `location` and "timestamp" should match the formatting
     assert log_dict["location"] == "[test_log_custom_formatting] test_aws_lambda_logging"
+    assert log_dict["timestamp"] == "fake-datefmt"
 
 
 def test_log_dict_key_strip_nones(stdout):
     # GIVEN a logger confirmation where we set `location` and `timestamp` to None
-    logger = Logger(stream=stdout, location=None, timestamp=None)
+    # Note: level, sampling_rate and service can not be suppressed
+    logger = Logger(stream=stdout, level=None, location=None, timestamp=None, sampling_rate=None, service=None)
 
     # WHEN logging a message
     logger.info("foo")

--- a/tests/functional/test_aws_lambda_logging.py
+++ b/tests/functional/test_aws_lambda_logging.py
@@ -127,5 +127,18 @@ def test_log_dict_key_seq(stdout):
 
     log_dict: dict = json.loads(stdout.getvalue())
 
-    # THEN the key sequence should be `timestamp,level,location,message`
-    assert ",".join(list(log_dict.keys())[:4]) == "timestamp,level,location,message"
+    # THEN the key sequence should be `level,location,message,timestamp`
+    assert ",".join(list(log_dict.keys())[:4]) == "level,location,message,timestamp"
+
+
+def test_log_dict_key_custom_seq(stdout):
+    # GIVEN any logger configuration
+    logger = Logger(level="INFO", stream=stdout, another="xxx", format_key=["message"])
+
+    # WHEN logging a message
+    logger.info("Message")
+
+    log_dict: dict = json.loads(stdout.getvalue())
+
+    # THEN the key sequence should be `level,location,message,timestamp`
+    assert ",".join(list(log_dict.keys())[:4]) == "message,level,location,timestamp"


### PR DESCRIPTION
**Issue #, if available:** #138 and #143

## Description of changes:

> **NOTE:** `sampling_rate` and `service` can not be suppressed

Ensure that the initial key seq is: `level,location,message,timestamp` so by default messages in Cloudwatch logs are easier to read:

```python3
>>> logger = Logger()
>>> logger.info("Eggs")
{'level': 'INFO', 'location': 'method_name:126', 'message': 'Eggs', 'timestamp': '2020-08-27 15:32:51,285', 'service': 'app', 'sampling_rate': 0.0}
```

Also allow for reordering override via `format_keys`

```python3
>>> logger = Logger(format_keys=["message"])
>>> logger.info("Foo")
{'message': 'Message', 'level': 'INFO', 'location': 'method_name:139', 'timestamp': '2020-08-27 15:36:11,494', 'service': 'app', 'sampling_rate': 0.0}
```

You can also suppress `timestamp` or `location` fields by passing them in as `None`

```python3
>>> logger = Logger(stream=stdout, location=None, timestamp=None)
>>> logger.info("magnus")
{"level": "INFO", "message": "magnus", "service": "app", "sampling_rate": 0.0}
```

Finally you can already customize the format for `location` and `timestamp`. So putting it all together:
  
```python3
>>> logger = Logger(location="%(module)s.%(funcName)s:%(lineno)d", timestamp=None, format_keys=["location", "message"])
>>> logger.info("takeoff")
{"location": "space.fly:7", "message": "takeoff", "level": "INFO", "service": "falcon", "sampling_rate": 0.0}
```

**Checklist**

<!--- Leave unchecked if your change doesn't seem to apply --> 

* [x] [Meet tenets criteria](https://awslabs.github.io/aws-lambda-powertools-python/#tenets)
* [x] Update tests
* [x] Update docs
* [x] PR title follows [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-python/blob/376ec0a2ac0d2a40e0af5717bef42ff84ca0d1b9/.github/semantic.yml#L2)
