### PR TITLE
feat: add xray_trace_id key when tracing is active #137

### DIFF
--- a/aws_lambda_powertools/logging/formatter.py
+++ b/aws_lambda_powertools/logging/formatter.py
@@ -1,5 +1,6 @@
 import json
 import logging
+import os
 
 
 class JsonFormatter(logging.Formatter):
@@ -29,14 +30,27 @@ class JsonFormatter(logging.Formatter):
         # Set the default unserializable function, by default values will be cast as str.
         self.default_json_formatter = kwargs.pop("json_default", str)
         # Set the insertion order for the log messages
-        self.format_dict = dict.fromkeys(kwargs.pop("log_record_order", ["level", "location", "message", "timestamp"]))
+        self.format_dict = dict.fromkeys(
+            kwargs.pop("log_record_order", ["level", "location", "message", "xray_trace_id", "timestamp"])
+        )
+        self.reserved_keys = ["timestamp", "level", "location"]
         # Set the date format used by `asctime`
         super(JsonFormatter, self).__init__(datefmt=kwargs.pop("datefmt", None))
 
-        self.reserved_keys = ["timestamp", "level", "location"]
-        self.format_dict.update(
-            {"level": "%(levelname)s", "location": "%(funcName)s:%(lineno)d", "timestamp": "%(asctime)s", **kwargs}
-        )
+        self.format_dict.update(self._build_root_keys(**kwargs))
+
+    @staticmethod
+    def _build_root_keys(**kwargs):
+        xray_trace_id = os.getenv("_X_AMZN_TRACE_ID")
+        trace_id = xray_trace_id.split(";")[0].replace("Root=", "") if xray_trace_id else None
+
+        return {
+            "level": "%(levelname)s",
+            "location": "%(funcName)s:%(lineno)d",
+            "xray_trace_id": trace_id,
+            "timestamp": "%(asctime)s",
+            **kwargs,
+        }
 
     def update_formatter(self, **kwargs):
         self.format_dict.update(kwargs)

--- a/aws_lambda_powertools/logging/logger.py
+++ b/aws_lambda_powertools/logging/logger.py
@@ -235,14 +235,14 @@ class Logger(logging.Logger):  # lgtm [py/missing-call-to-init]
 
         @functools.wraps(lambda_handler)
         def decorate(event, context):
+            lambda_context = build_lambda_context_model(context)
+            cold_start = _is_cold_start()
+            self.structure_logs(append=True, cold_start=cold_start, **lambda_context.__dict__)
+
             if log_event:
                 logger.debug("Event received")
                 self.info(event)
 
-            lambda_context = build_lambda_context_model(context)
-            cold_start = _is_cold_start()
-
-            self.structure_logs(append=True, cold_start=cold_start, **lambda_context.__dict__)
             return lambda_handler(event, context)
 
         return decorate

--- a/docs/content/core/logger.mdx
+++ b/docs/content/core/logger.mdx
@@ -305,7 +305,7 @@ This can be fixed by either ensuring both has the `service` value as `payment`, 
 
 You might want to continue to use the same date formatting style, or override `location` to display the `package.function_name:line_number` as you previously had.
 
-Logger allows you to either change the format or suppress the following keys altogether at the initialization: `location`, `timestamp`, `level`, `xray_trace_id`, and `datefmt`
+Logger allows you to either change the format or suppress the following keys altogether at the initialization: `location`, `timestamp`, `level`, and `datefmt`
 
 ```python
 from aws_lambda_powertools import Logger
@@ -317,7 +317,7 @@ logger = Logger(stream=stdout, location="[%(funcName)s] %(module)s", datefmt="fa
 logger = Logger(stream=stdout, location=None) # highlight-line
 ```
 
-Alternatively, you can also change the order of the following log record keys via the `log_record_order` parameter: `level`, `location`, `message`, `xray_trace_id`, and `timestamp`
+Alternatively, you can also change the order of the following log record keys via the `log_record_order` parameter: `level`, `location`, `message`, and `timestamp`
 
 ```python
 from aws_lambda_powertools import Logger

--- a/docs/content/core/logger.mdx
+++ b/docs/content/core/logger.mdx
@@ -47,7 +47,7 @@ Logger(service="payment", level="INFO")
 
 ## Standard structured keys
 
-Your Logger will always include the following keys to your structured logging:
+Your Logger will include the following keys to your structured logging, by default:
 
 Key | Type | Example | Description
 ------------------------------------------------- | ------------------------------------------------- | --------------------------------------------------------------------------------- | -------------------------------------------------
@@ -57,6 +57,7 @@ Key | Type | Example | Description
 **service** | str | "payment" | Service name defined. "service_undefined" will be used if unknown
 **sampling_rate** | int |  0.1 | Debug logging sampling rate in percentage e.g. 10% in this case
 **message** | any |  "Collecting payment" | Log statement value. Unserializable JSON values will be casted to string
+**xray_trace_id** | str | "1-5759e988-bd862e3fe1be46a994272793" | X-Ray Trace ID when Lambda function has enabled Tracing
 
 ## Capturing Lambda context info
 
@@ -304,7 +305,7 @@ This can be fixed by either ensuring both has the `service` value as `payment`, 
 
 You might want to continue to use the same date formatting style, or override `location` to display the `package.function_name:line_number` as you previously had.
 
-Logger allows you to either change the format or suppress the following keys altogether at the initialization: `location`, `timestamp`, `level`, and `datefmt`
+Logger allows you to either change the format or suppress the following keys altogether at the initialization: `location`, `timestamp`, `level`, `xray_trace_id`, and `datefmt`
 
 ```python
 from aws_lambda_powertools import Logger
@@ -316,7 +317,7 @@ logger = Logger(stream=stdout, location="[%(funcName)s] %(module)s", datefmt="fa
 logger = Logger(stream=stdout, location=None) # highlight-line
 ```
 
-Alternatively, you can also change the order of the following log record keys via the `log_record_order` parameter: `level`, location`, message`, and timestamp`
+Alternatively, you can also change the order of the following log record keys via the `log_record_order` parameter: `level`, `location`, `message`, `xray_trace_id`, and `timestamp`
 
 ```python
 from aws_lambda_powertools import Logger

--- a/tests/functional/test_aws_lambda_logging.py
+++ b/tests/functional/test_aws_lambda_logging.py
@@ -170,3 +170,34 @@ def test_log_dict_key_strip_nones(stdout):
 
     # THEN the keys should only include `level`, `message`, `service`, `sampling_rate`
     assert sorted(log_dict.keys()) == ["level", "message", "sampling_rate", "service"]
+
+
+def test_log_dict_xray_is_present_when_tracing_is_enabled(stdout, monkeypatch):
+    # GIVEN a logger is initialized within a Lambda function with X-Ray enabled
+    trace_id = "1-5759e988-bd862e3fe1be46a994272793"
+    trace_header = f"Root={trace_id};Parent=53995c3f42cd8ad8;Sampled=1"
+    monkeypatch.setenv(name="_X_AMZN_TRACE_ID", value=trace_header)
+    logger = Logger(stream=stdout)
+
+    # WHEN logging a message
+    logger.info("foo")
+
+    log_dict: dict = json.loads(stdout.getvalue())
+
+    # THEN `xray_trace_id`` key should be present
+    assert log_dict["xray_trace_id"] == trace_id
+
+    monkeypatch.delenv(name="_X_AMZN_TRACE_ID")
+
+
+def test_log_dict_xray_is_not_present_when_tracing_is_disabled(stdout, monkeypatch):
+    # GIVEN a logger is initialized within a Lambda function with X-Ray disabled (default)
+    logger = Logger(stream=stdout)
+
+    # WHEN logging a message
+    logger.info("foo")
+
+    log_dict: dict = json.loads(stdout.getvalue())
+
+    # THEN `xray_trace_id`` key should not be present
+    assert "xray_trace_id" not in log_dict


### PR DESCRIPTION
**Issue #, if available:** #137 

## Description of changes:

<!--- One or two sentences as a summary of what's being changed -->

When X-Ray is enabled, Logger will include a `xray_trace_id` key with the value of the Trace ID captured from the environment.

**UPDATE**: Given X-Ray Trace ID will change on a per invocation we cannot support changing the order of `xray_trace_id`. If you don't enable X-Ray this will key only appear.

**When enabled**

```json
{
    "level": "INFO",
    "location": "<module>:7",
    "message": "Testing x-ray id...",
    "timestamp": "2020-08-30 17:03:12,653",
    "service": "blah",
    "sampling_rate": 0.0,
    "xray_trace_id": "1-5759e988-bd862e3fe1be46a994272793"
}
```

**Checklist**

<!--- Leave unchecked if your change doesn't seem to apply --> 

* [x] [Meet tenets criteria](https://awslabs.github.io/aws-lambda-powertools-python/#tenets)
* [x] Update tests
* [x] Update docs
* [x] PR title follows [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-python/blob/376ec0a2ac0d2a40e0af5717bef42ff84ca0d1b9/.github/semantic.yml#L2)
* [x] Ensure X-Ray Trace ID is updated upon every invocation (`lambda_inject_context`)
* [x] Dummy manual E2E test w/ Service Lens

## Breaking change checklist

<!--- Ignore if it's not a breaking change -->

**RFC issue #**:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
