### PR TITLE
feat: emf multiple metric values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **Metrics**: Support adding multiple metric values to a metric name
+
 ## [1.5.0] - 2020-09-04
 
 ### Added

--- a/aws_lambda_powertools/metrics/base.py
+++ b/aws_lambda_powertools/metrics/base.py
@@ -4,6 +4,7 @@ import logging
 import numbers
 import os
 import pathlib
+from collections import defaultdict
 from enum import Enum
 from typing import Any, Dict, List, Union
 
@@ -124,7 +125,9 @@ class MetricManager:
             raise MetricValueError(f"{value} is not a valid number")
 
         unit = self.__extract_metric_unit_value(unit=unit)
-        metric = {"Unit": unit, "Value": float(value)}
+        metric = self.metric_set.get(name, defaultdict(list))
+        metric["Unit"] = unit
+        metric["Value"].append(float(value))
         logger.debug(f"Adding metric: {name} with {metric}")
         self.metric_set[name] = metric
 

--- a/aws_lambda_powertools/metrics/base.py
+++ b/aws_lambda_powertools/metrics/base.py
@@ -94,7 +94,7 @@ class MetricManager:
         self._metric_unit_options = list(MetricUnit.__members__)
         self.metadata_set = self.metadata_set if metadata_set is not None else {}
 
-    def add_metric(self, name: str, unit: Union[MetricUnit, str], value: Union[float, int]):
+    def add_metric(self, name: str, unit: Union[MetricUnit, str], value: float):
         """Adds given metric
 
         Example
@@ -113,7 +113,7 @@ class MetricManager:
             Metric name
         unit : Union[MetricUnit, str]
             `aws_lambda_powertools.helper.models.MetricUnit`
-        value : Union[float, int]
+        value : float
             Metric value
 
         Raises

--- a/aws_lambda_powertools/metrics/base.py
+++ b/aws_lambda_powertools/metrics/base.py
@@ -94,7 +94,7 @@ class MetricManager:
         self._metric_unit_options = list(MetricUnit.__members__)
         self.metadata_set = self.metadata_set if metadata_set is not None else {}
 
-    def add_metric(self, name: str, unit: MetricUnit, value: Union[float, int]):
+    def add_metric(self, name: str, unit: Union[MetricUnit, str], value: Union[float, int]):
         """Adds given metric
 
         Example
@@ -111,7 +111,7 @@ class MetricManager:
         ----------
         name : str
             Metric name
-        unit : MetricUnit
+        unit : Union[MetricUnit, str]
             `aws_lambda_powertools.helper.models.MetricUnit`
         value : Union[float, int]
             Metric value

--- a/tests/functional/test_metrics.py
+++ b/tests/functional/test_metrics.py
@@ -689,7 +689,7 @@ def test_log_multiple_metrics(capsys, metrics_same_name, dimensions, namespace):
         my_metrics.add_dimension(**dimension)
 
     # WHEN we utilize log_metrics to serialize
-    # and flush all metrics at the end of a function execution
+    # and flush multiple metrics with the same name at the end of a function execution
     @my_metrics.log_metrics
     def lambda_handler(evt, ctx):
         for metric in metrics_same_name:
@@ -725,7 +725,7 @@ def test_serialize_metric_set_metric_definition_multiple_values(
         "test_dimension": "test",
     }
 
-    # GIVEN Metrics is initialized
+    # GIVEN Metrics is initialized and multiple metrics are added with the same name
     my_metrics = Metrics(service=service, namespace=namespace)
     for metric in metrics_same_name:
         my_metrics.add_metric(**metric)


### PR DESCRIPTION
**Issue #, if available:** #165 

## Description of changes:

Update metrics utility to support multiple values for the same metric name. 

**Checklist**

<!--- Leave unchecked if your change doesn't seem to apply --> 

* [X] [Meet tenets criteria](https://awslabs.github.io/aws-lambda-powertools-python/#tenets)
* [X] Update tests
* [ ] Update docs
* [X] PR title follows [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-python/blob/376ec0a2ac0d2a40e0af5717bef42ff84ca0d1b9/.github/semantic.yml#L2)

## Breaking change checklist

<!--- Ignore if it's not a breaking change -->

**RFC issue #**:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
