### PR TITLE
fix: remove DeleteMessageBatch call to SQS api if there are no messages to delete

### DIFF
--- a/aws_lambda_powertools/utilities/batch/sqs.py
+++ b/aws_lambda_powertools/utilities/batch/sqs.py
@@ -115,7 +115,9 @@ class PartialSQSProcessor(BasePartialProcessor):
         queue_url = self._get_queue_url()
         entries_to_remove = self._get_entries_to_clean()
 
-        delete_message_response = self.client.delete_message_batch(QueueUrl=queue_url, Entries=entries_to_remove)
+        delete_message_response = None
+        if entries_to_remove:
+            delete_message_response = self.client.delete_message_batch(QueueUrl=queue_url, Entries=entries_to_remove)
 
         if self.suppress_exception:
             logger.debug(f"{len(self.fail_messages)} records failed processing, but exceptions are suppressed")

--- a/tests/functional/test_utilities_batch.py
+++ b/tests/functional/test_utilities_batch.py
@@ -275,3 +275,18 @@ def test_sqs_batch_processor_middleware_suppressed_exception(
 
     stubber.assert_no_pending_responses()
     assert result is True
+
+
+def test_partial_sqs_processor_context_only_failure(sqs_event_factory, record_handler, partial_processor):
+    """
+    Test processor with only failures
+    """
+    first_record = sqs_event_factory("fail")
+    second_record = sqs_event_factory("fail")
+
+    records = [first_record, second_record]
+    with pytest.raises(SQSBatchProcessingError) as error:
+        with partial_processor(records, record_handler) as ctx:
+            ctx.process()
+
+    assert len(error.value.args[0]) == 2


### PR DESCRIPTION
**Issue #, if available:** #169 

## Description of changes: Add a check to make sure there are messages to delete before calling SQS DeleteMessageBatch API.

<!--- One or two sentences as a summary of what's being changed -->

**Checklist**

<!--- Leave unchecked if your change doesn't seem to apply --> 

* [X] [Meet tenets criteria](https://awslabs.github.io/aws-lambda-powertools-python/#tenets)
* [X] Update tests
* [ ] Update docs
* [X] PR title follows [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-python/blob/376ec0a2ac0d2a40e0af5717bef42ff84ca0d1b9/.github/semantic.yml#L2)

## Breaking change checklist

<!--- Ignore if it's not a breaking change -->

**RFC issue #**:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
