### PR TITLE
improv: disable tracer when using the Chalice CLI

### DIFF
--- a/aws_lambda_powertools/tracing/tracer.py
+++ b/aws_lambda_powertools/tracing/tracer.py
@@ -622,6 +622,7 @@ class Tracer:
         """
         logger.debug("Verifying whether Tracing has been disabled")
         is_lambda_sam_cli = os.getenv("AWS_SAM_LOCAL")
+        is_chalice_cli = os.getenv("AWS_CHALICE_CLI_MODE")
         env_option = str(os.getenv("POWERTOOLS_TRACE_DISABLED", "false"))
         disabled_env = strtobool(env_option)
 
@@ -629,7 +630,7 @@ class Tracer:
             logger.debug("Tracing has been disabled via env var POWERTOOLS_TRACE_DISABLED")
             return disabled_env
 
-        if is_lambda_sam_cli:
+        if is_lambda_sam_cli or is_chalice_cli:
             logger.debug("Running under SAM CLI env or not in Lambda env; disabling Tracing")
             return True
 

--- a/tests/functional/test_tracing.py
+++ b/tests/functional/test_tracing.py
@@ -61,6 +61,20 @@ def test_tracer_lambda_emulator(monkeypatch, dummy_response):
     handler({}, {})
 
 
+def test_tracer_chalice_cli_mode(monkeypatch, dummy_response):
+    # GIVEN tracer runs locally
+    monkeypatch.setenv("AWS_CHALICE_CLI_MODE", "true")
+    tracer = Tracer()
+
+    # WHEN a lambda function is run through the Chalice CLI.
+    @tracer.capture_lambda_handler
+    def handler(event, context):
+        return dummy_response
+
+    # THEN tracer should run in disabled mode, and not raise an Exception
+    handler({}, {})
+
+
 def test_tracer_metadata_disabled(dummy_response):
     # GIVEN tracer is disabled, and annotations/metadata are used
     tracer = Tracer(disabled=True)


### PR DESCRIPTION
**Issue #, if available:**

## Description of changes:

Disable tracer when using the Chalice CLI.  This enables customers to run `chalice deploy`, `chalice local`, and other Chalice CLI commands without having to explicitly disable the tracer.

**Checklist**

<!--- Leave unchecked if your change doesn't seem to apply --> 

* [x] [Meet tenets criteria](https://awslabs.github.io/aws-lambda-powertools-python/#tenets)
* [x] Update tests
* [ ] Update docs
* [x] PR title follows [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-python/blob/376ec0a2ac0d2a40e0af5717bef42ff84ca0d1b9/.github/semantic.yml#L2)

## Breaking change checklist

<!--- Ignore if it's not a breaking change -->

**RFC issue #**:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
