### PR TITLE
fix: accessing boolean value in dynamodb utility class

### DIFF
--- a/aws_lambda_powertools/utilities/data_classes/dynamo_db_stream_event.py
+++ b/aws_lambda_powertools/utilities/data_classes/dynamo_db_stream_event.py
@@ -35,7 +35,7 @@ class AttributeValue(DictWrapper):
         Example:
             >>> {"BOOL": True}
         """
-        item = self.get("bool")
+        item = self.get("BOOL")
         return None if item is None else bool(item)
 
     @property


### PR DESCRIPTION
It seems that when accessing boolean value from dynamodb index name `bool` is used instead of correct one `BOOL`.
Have a look at https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_AttributeValue.html to see list of available attribute values

**Issue #, if available:**

## Description of changes:

<!--- One or two sentences as a summary of what's being changed -->

**Checklist**

<!--- Leave unchecked if your change doesn't seem to apply --> 

* [ ] [Meet tenets criteria](https://awslabs.github.io/aws-lambda-powertools-python/#tenets)
* [ ] Update tests
* [ ] Update docs
* [ ] PR title follows [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-python/blob/376ec0a2ac0d2a40e0af5717bef42ff84ca0d1b9/.github/semantic.yml#L2)

## Breaking change checklist

<!--- Ignore if it's not a breaking change -->

**RFC issue #**:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
