### PR TITLE
feat(data_classes): case insensitive header lookup

### DIFF
--- a/aws_lambda_powertools/utilities/data_classes/common.py
+++ b/aws_lambda_powertools/utilities/data_classes/common.py
@@ -48,7 +48,9 @@ class BaseProxyEvent(DictWrapper):
         params = self.query_string_parameters
         return default_value if params is None else params.get(name, default_value)
 
-    def get_header_value(self, name: str, default_value: Optional[str] = None) -> Optional[str]:
+    def get_header_value(
+        self, name: str, default_value: Optional[str] = None, case_sensitive: Optional[bool] = False
+    ) -> Optional[str]:
         """Get header value by name
 
         Parameters
@@ -57,9 +59,14 @@ class BaseProxyEvent(DictWrapper):
             Header name
         default_value: str, optional
             Default value if no value was found by name
+        case_sensitive: bool
+            Whether to use a case sensitive look up
         Returns
         -------
         str, optional
             Header value
         """
-        return self.headers.get(name, default_value)
+        if case_sensitive:
+            return self.headers.get(name, default_value)
+
+        return next((value for key, value in self.headers.items() if name.lower() == key.lower()), default_value)

--- a/tests/functional/test_lambda_trigger_events.py
+++ b/tests/functional/test_lambda_trigger_events.py
@@ -579,10 +579,37 @@ def test_base_proxy_event_get_header_value():
     value = event.get_header_value("test", default_value)
     assert value == set_value
 
+    # Verify that the default look is case insensitive
+    value = event.get_header_value("Test")
+    assert value == set_value
+
     value = event.get_header_value("unknown", default_value)
     assert value == default_value
 
     value = event.get_header_value("unknown")
+    assert value is None
+
+
+def test_base_proxy_event_get_header_value_case_insensitive():
+    default_value = "default"
+    set_value = "value"
+
+    event = BaseProxyEvent({"headers": {}})
+
+    event._data["headers"] = {"Test": set_value}
+    value = event.get_header_value("test", case_sensitive=True)
+    assert value is None
+
+    value = event.get_header_value("test", default_value=default_value, case_sensitive=True)
+    assert value == default_value
+
+    value = event.get_header_value("Test", case_sensitive=True)
+    assert value == set_value
+
+    value = event.get_header_value("unknown", default_value, case_sensitive=True)
+    assert value == default_value
+
+    value = event.get_header_value("unknown", case_sensitive=True)
     assert value is None
 
 


### PR DESCRIPTION
**Issue #, if available:**
#185

## Description of changes:

Update BaseProxyEvent `get_header_value` method to be case insensitive
by default and add a flag for case sensitive lookups

**Checklist**

<!--- Leave unchecked if your change doesn't seem to apply --> 

* [X] [Meet tenets criteria](https://awslabs.github.io/aws-lambda-powertools-python/#tenets)
* [X] Update tests
* [X] Update docs
* [X] PR title follows [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-python/blob/376ec0a2ac0d2a40e0af5717bef42ff84ca0d1b9/.github/semantic.yml#L2)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
