### PR TITLE
improv: add log filter in root handler to prevent child log records duplication

### DIFF
--- a/aws_lambda_powertools/logging/filters.py
+++ b/aws_lambda_powertools/logging/filters.py
@@ -6,7 +6,11 @@ class SuppressFilter(logging.Filter):
         self.logger = logger
 
     def filter(self, record):  # noqa: A003
-        """Suppress Log Records from registered logger"""
-        if self.logger in record.name:
-            return False
-        return True
+        """Suppress Log Records from registered logger
+
+        It rejects log records from registered logger e.g. a child logger
+        otherwise it honours log propagation from any log record
+        created by loggers who don't have a handler.
+        """
+        logger = record.name
+        return False if self.logger in logger else True

--- a/aws_lambda_powertools/logging/filters.py
+++ b/aws_lambda_powertools/logging/filters.py
@@ -1,0 +1,12 @@
+import logging
+
+
+class SuppressFilter(logging.Filter):
+    def __init__(self, logger):
+        self.logger = logger
+
+    def filter(self, record):  # noqa: A003
+        """Suppress Log Records from registered logger"""
+        if self.logger in record.name:
+            return False
+        return True

--- a/aws_lambda_powertools/logging/logger.py
+++ b/aws_lambda_powertools/logging/logger.py
@@ -159,6 +159,9 @@ class Logger(logging.Logger):  # lgtm [py/missing-call-to-init]
 
             logger.debug("Adding filter in root logger to suppress child logger records to bubble up")
             for handler in logging.root.handlers:
+                # It'll add a filter to suppress any child logger from self.service
+                # Where service is Order, it'll reject parent logger Order,
+                # and child loggers such as Order.checkout, Order.shared
                 handler.addFilter(SuppressFilter(self.service))
 
     def _configure_sampling(self):

--- a/aws_lambda_powertools/logging/logger.py
+++ b/aws_lambda_powertools/logging/logger.py
@@ -8,6 +8,7 @@ from distutils.util import strtobool
 from typing import Any, Callable, Dict, Union
 
 from .exceptions import InvalidLoggerSamplingRateError
+from .filters import SuppressFilter
 from .formatter import JsonFormatter
 from .lambda_context import build_lambda_context_model
 
@@ -147,13 +148,6 @@ class Logger(logging.Logger):  # lgtm [py/missing-call-to-init]
     def _init_logger(self, **kwargs):
         """Configures new logger"""
 
-        # Lambda by default configures the root logger handler
-        # therefore, we need to remove it to prevent messages being logged twice
-        # when customers use our Logger
-        logger.debug("Removing Lambda root handler whether it exists")
-        root_logger = logging.getLogger()
-        root_logger.handlers.clear()
-
         # Skip configuration if it's a child logger to prevent
         # multiple handlers being attached as well as different sampling mechanisms
         # and multiple messages from being logged as handlers can be duplicated
@@ -162,6 +156,10 @@ class Logger(logging.Logger):  # lgtm [py/missing-call-to-init]
             self._logger.setLevel(self.log_level)
             self._logger.addHandler(self._handler)
             self.structure_logs(**kwargs)
+
+            logger.debug("Adding filter in root logger to suppress child logger records to bubble up")
+            for handler in logging.root.handlers:
+                handler.addFilter(SuppressFilter(self.service))
 
     def _configure_sampling(self):
         """Dynamically set log level based on sampling rate

--- a/tests/functional/test_logger.py
+++ b/tests/functional/test_logger.py
@@ -361,18 +361,18 @@ def test_logger_record_caller_location(stdout):
     assert caller_fn_name in log["location"]
 
 
-def test_logger_do_not_log_twice(stdout):
+def test_logger_do_not_log_twice_when_root_logger_is_setup(stdout):
     # GIVEN Lambda configures the root logger with a handler
-    logging.basicConfig(format="%(asctime)-15s %(clientip)s %(user)-8s %(message)s", level="INFO")
     root_logger = logging.getLogger()
     root_logger.addHandler(logging.StreamHandler(stream=stdout))
 
-    # WHEN we create a new Logger
+    # WHEN we create a new Logger and child Logger
     logger = Logger(stream=stdout)
+    child_logger = Logger(child=True, stream=stdout)
     logger.info("hello")
+    child_logger.info("hello again")
 
-    # THEN it should fail to unpack because root logger handler
-    # should be removed as part of our Logger initialization
-    assert not root_logger.handlers
-    with pytest.raises(ValueError, match=r".*expected 2, got 1.*"):
-        [log_one, log_two] = stdout.getvalue().strip().split("\n")
+    # THEN it should only contain only two log entries
+    # since child's log records propagated to root logger should be rejected
+    logs = list(stdout.getvalue().strip().split("\n"))
+    assert len(logs) == 2


### PR DESCRIPTION
**Issue #, if available:** #194

## Description of changes:

<!--- One or two sentences as a summary of what's being changed -->

This PR adds a log filter in the root logger to reject any log record coming from our Logger - This will prevent child logger to propagate log records to their parents as well as root loggers leading to duplicated log entries.

This unblocks issue described in 194 when customers assume root logger to be configured as per Lambda docs.

**Checklist**

<!--- Leave unchecked if your change doesn't seem to apply --> 

* [ ] [Meet tenets criteria](https://awslabs.github.io/aws-lambda-powertools-python/#tenets)
* [x] Update logger test 
* [ ] Update docs to reflect that
* [x] PR title follows [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-python/blob/376ec0a2ac0d2a40e0af5717bef42ff84ca0d1b9/.github/semantic.yml#L2)

## Breaking change checklist

<!--- Ignore if it's not a breaking change -->

**RFC issue #**:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
