### PR TITLE
docs: add minimal permission set for using layer

### DIFF
--- a/docs/content/index.mdx
+++ b/docs/content/index.mdx
@@ -51,7 +51,7 @@ This will add a nested app stack with an output parameter `LayerVersionArn`, tha
     - !GetAtt AwsLambdaPowertoolsPythonLayer.Outputs.LayerVersionArn
 ```
 
-Here is the list of IAM permissions that you need to add to your deployment IAM role to use the layer, keep in mind to replace the placeholders:
+Here is the list of IAM permissions that you need to add to your deployment IAM role to use the layer:
 
 ```yaml
 Version: '2012-10-17'
@@ -67,12 +67,17 @@ Statement:
       - serverlessrepo:CreateCloudFormationTemplate
       - serverlessrepo:GetCloudFormationTemplate
     Resource:
+      # this is arn of the powertools SAR app
       - arn:aws:serverlessrepo:eu-west-1:057560766410:applications/aws-lambda-powertools-python-layer
   - Sid: S3AccessLayer
     Effect: Allow
     Action:
       - s3:GetObject
     Resource:
+      # AWS publishes to an external S3 bucket locked down to your account ID
+      # The below example is us publishing lambda powertools
+      # Bucket: awsserverlessrepo-changesets-plntc6bfnfj
+      # Key: *****/arn:aws:serverlessrepo:eu-west-1:057560766410:applications-aws-lambda-powertools-python-layer-versions-1.6.0/aeeccf50-****-****-****-*********
       - arn:aws:s3:::awsserverlessrepo-changesets-*/*
   - Sid: GetLayerVersion
     Effect: Allow
@@ -80,9 +85,10 @@ Statement:
       - lambda:PublishLayerVersion
       - lambda:GetLayerVersion
     Resource:
-      - arn:aws:lambda:YOUR_AWS_REGION:YOUR_AWS_ACCOUNT:layer:aws-lambda-powertools-python-layer*
-
+      - !Sub arn:aws:lambda:${AWS::Region}:${AWS::AccoundId}:layer:aws-lambda-powertools-python-layer*
 ```
+
+> Credits to [mwarkentin](https://github.com/mwarkentin) for providing the scoped down IAM permissions.
 
 The region and the account id for `CloudFormationTransform` and `GetCfnTemplat` are fixed.
 

--- a/docs/content/index.mdx
+++ b/docs/content/index.mdx
@@ -51,6 +51,41 @@ This will add a nested app stack with an output parameter `LayerVersionArn`, tha
     - !GetAtt AwsLambdaPowertoolsPythonLayer.Outputs.LayerVersionArn
 ```
 
+Here is the list of IAM permissions that you need to add to your deployment IAM role to use the layer, keep in mind to replace the placeholders:
+
+```yaml
+Version: '2012-10-17'
+Statement:
+  - Sid: CloudFormationTransform
+    Effect: Allow
+    Action: cloudformation:CreateChangeSet
+    Resource:
+      - arn:aws:cloudformation:us-east-1:aws:transform/Serverless-2016-10-31
+  - Sid: GetCfnTemplate
+    Effect: Allow
+    Action:
+      - serverlessrepo:CreateCloudFormationTemplate
+      - serverlessrepo:GetCloudFormationTemplate
+    Resource:
+      - arn:aws:serverlessrepo:eu-west-1:057560766410:applications/aws-lambda-powertools-python-layer
+  - Sid: S3AccessLayer
+    Effect: Allow
+    Action:
+      - s3:GetObject
+    Resource:
+      - arn:aws:s3:::awsserverlessrepo-changesets-*/*
+  - Sid: GetLayerVersion
+    Effect: Allow
+    Action:
+      - lambda:PublishLayerVersion
+      - lambda:GetLayerVersion
+    Resource:
+      - arn:aws:lambda:YOUR_AWS_REGION:YOUR_AWS_ACCOUNT:layer:aws-lambda-powertools-python-layer*
+
+```
+
+The region and the account id for `CloudFormationTransform` and `GetCfnTemplat` are fixed.
+
 You can fetch the available versions via the API with:
 
 ```bash


### PR DESCRIPTION
**Issue #, if available:** #203 

## Description of changes:

Added the necessary permission one need to add to he IAM policy in order to use the powertools layer. 

**Checklist**

<!--- Leave unchecked if your change doesn't seem to apply --> 

* [x] [Meet tenets criteria](https://awslabs.github.io/aws-lambda-powertools-python/#tenets)
* [ ] Update tests
* [x] Update docs
* [x] PR title follows [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-python/blob/376ec0a2ac0d2a40e0af5717bef42ff84ca0d1b9/.github/semantic.yml#L2)

## Breaking change checklist

<!--- Ignore if it's not a breaking change -->

**RFC issue #**:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
