### PR TITLE
docs: correct example usage of SES data class

### DIFF
--- a/docs/content/utilities/data_classes.mdx
+++ b/docs/content/utilities/data_classes.mdx
@@ -207,7 +207,7 @@ def lambda_handler(event, context):
     # Multiple records can be delivered in a single event
     for record in event.records:
         mail = record.ses.mail
-        common_headers = list(mail.common_headers)
+        common_headers = mail.common_headers
 
         do_something_with(common_headers.to, common_headers.subject)
 


### PR DESCRIPTION
**Issue #, if available:** #208

## Description of changes: Fix incorrect documentation of SES dataclass example.

<!--- One or two sentences as a summary of what's being changed -->

**Checklist**

<!--- Leave unchecked if your change doesn't seem to apply --> 

* [X] [Meet tenets criteria](https://awslabs.github.io/aws-lambda-powertools-python/#tenets)
* [X] Update tests
* [X] Update docs
* [X] PR title follows [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-python/blob/376ec0a2ac0d2a40e0af5717bef42ff84ca0d1b9/.github/semantic.yml#L2)

## Breaking change checklist

<!--- Ignore if it's not a breaking change -->

**RFC issue #**:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
