### PR TITLE
docs: Clarify Logger keys that cannot be suppressed

### DIFF
--- a/docs/content/core/logger.mdx
+++ b/docs/content/core/logger.mdx
@@ -353,6 +353,8 @@ logger = Logger(stream=stdout, log_record_order=["message"]) # highlight-line
 logger = Logger(stream=stdout, log_record_order=["level","location","message","timestamp"]) # highlight-line
 ```
 
+Some keys cannot be supressed in the Log records: `sampling_rate` is part of the specification and cannot be supressed; `xray_trace_id` is supressed automatically if X-Ray is not enabled in the Lambda function, and added automatically if it is.
+
 ### Logging exceptions
 
 When logging exceptions, Logger will add a new key named `exception`, and will serialize the full traceback as a string.


### PR DESCRIPTION
Add clarification on the documents around Log keys that cannot be suppressed

Issue #217 , re: #215

## Description of changes:

Added document reference about Logger keys that cannot be suppressed in the Log output.

**Checklist**

* [ ] [Meet tenets criteria](https://awslabs.github.io/aws-lambda-powertools-python/#tenets)
* [ ] Update tests
* [x] Update docs
* [x] PR title follows [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-python/blob/376ec0a2ac0d2a40e0af5717bef42ff84ca0d1b9/.github/semantic.yml#L2)

## Breaking change checklist

<!--- Ignore if it's not a breaking change -->

**RFC issue #**:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
