### PR TITLE
docs: fix broken link for github

### DIFF
--- a/docs/src/gatsby-theme-apollo-docs/components/page-content.js
+++ b/docs/src/gatsby-theme-apollo-docs/components/page-content.js
@@ -179,7 +179,9 @@ export default function PageContent(props) {
         );
     });
 
-    const githubUrl = props.githubUrl.replace("master", "master/docs")
+   const githubUrl = props.githubUrl.replace("tree/", "blob/")
+        .replace("/content/", "/docs/content/")
+
     const editLink = githubUrl && (
         <AsideLink href={githubUrl}>
             <IconGithub /> Edit on GitHub


### PR DESCRIPTION
**Issue #, if available:**

Closes #220 

## Description of changes:

<!--- One or two sentences as a summary of what's being changed -->

**Checklist**

<!--- Leave unchecked if your change doesn't seem to apply --> 

* [x] [Meet tenets criteria](https://awslabs.github.io/aws-lambda-powertools-python/#tenets)
* [ ] Update tests
* [x] Update docs
* [x] PR title follows [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-python/blob/376ec0a2ac0d2a40e0af5717bef42ff84ca0d1b9/.github/semantic.yml#L2)

## Breaking change checklist

<!--- Ignore if it's not a breaking change -->

**RFC issue #**:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
