### PR TITLE
improv: Added __eq__ function to DictWrapper for better equality checks

### DIFF
--- a/aws_lambda_powertools/utilities/data_classes/common.py
+++ b/aws_lambda_powertools/utilities/data_classes/common.py
@@ -12,7 +12,7 @@ class DictWrapper:
 
     def __eq__(self, other: Any) -> bool:
         if not isinstance(other, DictWrapper):
-            return NotImplemented
+            return False
 
         return self._data == other._data
 

--- a/aws_lambda_powertools/utilities/data_classes/common.py
+++ b/aws_lambda_powertools/utilities/data_classes/common.py
@@ -10,6 +10,12 @@ class DictWrapper:
     def __getitem__(self, key: str) -> Any:
         return self._data[key]
 
+    def __eq__(self, other):
+        if not isinstance(other, DictWrapper):
+            return NotImplemented
+
+        return self._data == other._data
+
     def get(self, key: str) -> Optional[Any]:
         return self._data.get(key)
 

--- a/aws_lambda_powertools/utilities/data_classes/common.py
+++ b/aws_lambda_powertools/utilities/data_classes/common.py
@@ -10,7 +10,7 @@ class DictWrapper:
     def __getitem__(self, key: str) -> Any:
         return self._data[key]
 
-    def __eq__(self, other):
+    def __eq__(self, other: Any) -> bool:
         if not isinstance(other, DictWrapper):
             return NotImplemented
 


### PR DESCRIPTION
**Issue #, if available:**

## Description of changes:

This change is to allow easier testing of data classes by adding an __eq__ function to the base DictWrapper class. This new function will check the equality of the data contained in the object opposed to the memory location.

**Checklist**

<!--- Leave unchecked if your change doesn't seem to apply --> 

* [x] [Meet tenets criteria](https://awslabs.github.io/aws-lambda-powertools-python/#tenets)
* [ ] Update tests
* [ ] Update docs
* [x] PR title follows [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-python/blob/376ec0a2ac0d2a40e0af5717bef42ff84ca0d1b9/.github/semantic.yml#L2)

## Breaking change checklist

<!--- Ignore if it's not a breaking change -->

**RFC issue #**:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
