### PR TITLE
test: DictWrapper equals method

### DIFF
--- a/tests/functional/test_lambda_trigger_events.py
+++ b/tests/functional/test_lambda_trigger_events.py
@@ -28,7 +28,7 @@ from aws_lambda_powertools.utilities.data_classes.cognito_user_pool_event import
     UserMigrationTriggerEvent,
     VerifyAuthChallengeResponseTriggerEvent,
 )
-from aws_lambda_powertools.utilities.data_classes.common import BaseProxyEvent
+from aws_lambda_powertools.utilities.data_classes.common import BaseProxyEvent, DictWrapper
 from aws_lambda_powertools.utilities.data_classes.dynamo_db_stream_event import (
     AttributeValue,
     DynamoDBRecordEventName,
@@ -41,6 +41,16 @@ def load_event(file_name: str) -> dict:
     full_file_name = os.path.dirname(os.path.realpath(__file__)) + "/../events/" + file_name
     with open(full_file_name) as fp:
         return json.load(fp)
+
+
+def test_dict_wrapper_equals():
+    class DataClassSample(DictWrapper):
+        @property
+        def message(self) -> str:
+            return self.get("message")
+
+    assert DataClassSample({"message": "foo1"}) == DataClassSample({"message": "foo1"})
+    assert DataClassSample({"message": "foo1"}) != DataClassSample({"message": "foo2"})
 
 
 def test_cloud_watch_trigger_event():

--- a/tests/functional/test_lambda_trigger_events.py
+++ b/tests/functional/test_lambda_trigger_events.py
@@ -49,10 +49,13 @@ def test_dict_wrapper_equals():
         def message(self) -> str:
             return self.get("message")
 
-    assert DataClassSample({"message": "foo1"}) == DataClassSample({"message": "foo1"})
-    assert DataClassSample({"message": "foo1"}) != DataClassSample({"message": "foo2"})
-    assert DataClassSample({"message": "foo1"}) is not object()
-    assert object() is not DataClassSample({"message": "foo1"})
+    data1 = {"message": "foo1"}
+    data2 = {"message": "foo2"}
+
+    assert DataClassSample(data1) == DataClassSample(data1)
+    assert DataClassSample(data1) != DataClassSample(data2)
+    assert DataClassSample(data1) is not data1
+    assert data1 is not DataClassSample(data1)
 
 
 def test_cloud_watch_trigger_event():

--- a/tests/functional/test_lambda_trigger_events.py
+++ b/tests/functional/test_lambda_trigger_events.py
@@ -51,6 +51,8 @@ def test_dict_wrapper_equals():
 
     assert DataClassSample({"message": "foo1"}) == DataClassSample({"message": "foo1"})
     assert DataClassSample({"message": "foo1"}) != DataClassSample({"message": "foo2"})
+    assert DataClassSample({"message": "foo1"}) is not object()
+    assert object() is not DataClassSample({"message": "foo1"})
 
 
 def test_cloud_watch_trigger_event():


### PR DESCRIPTION
**Issue #, if available:** #233

## Description of changes:

Added a equals test to  test the `__eq__` method.

**Checklist**

<!--- Leave unchecked if your change doesn't seem to apply --> 

* [ ] [Meet tenets criteria](https://awslabs.github.io/aws-lambda-powertools-python/#tenets)
* [x] Update tests
* [ ] Update docs
* [x] PR title follows [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-python/blob/376ec0a2ac0d2a40e0af5717bef42ff84ca0d1b9/.github/semantic.yml#L2)

## Breaking change checklist

<!--- Ignore if it's not a breaking change -->

**RFC issue #**:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
