### PR TITLE
fix: prevent touching preconfigured loggers #249

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **Logger**: Bugfix to prevent parent loggers with the same name being configured more than once
+
 ## [1.9.0] - 2020-12-04
 
 ### Added

--- a/tests/functional/test_logger.py
+++ b/tests/functional/test_logger.py
@@ -2,6 +2,8 @@ import inspect
 import io
 import json
 import logging
+import random
+import string
 from collections import namedtuple
 
 import pytest
@@ -33,6 +35,12 @@ def lambda_event():
     return {"greeting": "hello"}
 
 
+@pytest.fixture
+def service_name():
+    chars = string.ascii_letters + string.digits
+    return "".join(random.SystemRandom().choice(chars) for _ in range(15))
+
+
 def capture_logging_output(stdout):
     return json.loads(stdout.getvalue().strip())
 
@@ -41,8 +49,7 @@ def capture_multiple_logging_statements_output(stdout):
     return [json.loads(line.strip()) for line in stdout.getvalue().split("\n") if line]
 
 
-def test_setup_service_name(stdout):
-    service_name = "payment"
+def test_setup_service_name(stdout, service_name):
     # GIVEN Logger is initialized
     # WHEN service is explicitly defined
     logger = Logger(service=service_name, stream=stdout)
@@ -54,20 +61,7 @@ def test_setup_service_name(stdout):
     assert service_name == log["service"]
 
 
-def test_setup_no_service_name(stdout):
-    # GIVEN Logger is initialized
-    # WHEN no service is explicitly defined
-    logger = Logger(stream=stdout)
-
-    logger.info("Hello")
-
-    # THEN service field should be "service_undefined"
-    log = capture_logging_output(stdout)
-    assert "service_undefined" == log["service"]
-
-
-def test_setup_service_env_var(monkeypatch, stdout):
-    service_name = "payment"
+def test_setup_service_env_var(monkeypatch, stdout, service_name):
     # GIVEN Logger is initialized
     # WHEN service is explicitly defined via POWERTOOLS_SERVICE_NAME env
     monkeypatch.setenv("POWERTOOLS_SERVICE_NAME", service_name)
@@ -80,12 +74,12 @@ def test_setup_service_env_var(monkeypatch, stdout):
     assert service_name == log["service"]
 
 
-def test_setup_sampling_rate_env_var(monkeypatch, stdout):
+def test_setup_sampling_rate_env_var(monkeypatch, stdout, service_name):
     # GIVEN Logger is initialized
     # WHEN samping rate is explicitly set to 100% via POWERTOOLS_LOGGER_SAMPLE_RATE env
     sampling_rate = "1"
     monkeypatch.setenv("POWERTOOLS_LOGGER_SAMPLE_RATE", sampling_rate)
-    logger = Logger(stream=stdout)
+    logger = Logger(service=service_name, stream=stdout)
     logger.debug("I am being sampled")
 
     # THEN sampling rate should be equals POWERTOOLS_LOGGER_SAMPLE_RATE value
@@ -97,9 +91,9 @@ def test_setup_sampling_rate_env_var(monkeypatch, stdout):
     assert "I am being sampled" == log["message"]
 
 
-def test_inject_lambda_context(lambda_context, stdout):
+def test_inject_lambda_context(lambda_context, stdout, service_name):
     # GIVEN Logger is initialized
-    logger = Logger(stream=stdout)
+    logger = Logger(service=service_name, stream=stdout)
 
     # WHEN a lambda function is decorated with logger
     @logger.inject_lambda_context
@@ -120,9 +114,9 @@ def test_inject_lambda_context(lambda_context, stdout):
         assert key in log
 
 
-def test_inject_lambda_context_log_event_request(lambda_context, stdout, lambda_event):
+def test_inject_lambda_context_log_event_request(lambda_context, stdout, lambda_event, service_name):
     # GIVEN Logger is initialized
-    logger = Logger(stream=stdout)
+    logger = Logger(service=service_name, stream=stdout)
 
     # WHEN a lambda function is decorated with logger instructed to log event
     @logger.inject_lambda_context(log_event=True)
@@ -136,10 +130,12 @@ def test_inject_lambda_context_log_event_request(lambda_context, stdout, lambda_
     assert logged_event["message"] == lambda_event
 
 
-def test_inject_lambda_context_log_event_request_env_var(monkeypatch, lambda_context, stdout, lambda_event):
+def test_inject_lambda_context_log_event_request_env_var(
+    monkeypatch, lambda_context, stdout, lambda_event, service_name
+):
     # GIVEN Logger is initialized
     monkeypatch.setenv("POWERTOOLS_LOGGER_LOG_EVENT", "true")
-    logger = Logger(stream=stdout)
+    logger = Logger(service=service_name, stream=stdout)
 
     # WHEN a lambda function is decorated with logger instructed to log event
     # via POWERTOOLS_LOGGER_LOG_EVENT env
@@ -154,9 +150,11 @@ def test_inject_lambda_context_log_event_request_env_var(monkeypatch, lambda_con
     assert logged_event["message"] == lambda_event
 
 
-def test_inject_lambda_context_log_no_request_by_default(monkeypatch, lambda_context, stdout, lambda_event):
+def test_inject_lambda_context_log_no_request_by_default(
+    monkeypatch, lambda_context, stdout, lambda_event, service_name
+):
     # GIVEN Logger is initialized
-    logger = Logger(stream=stdout)
+    logger = Logger(service=service_name, stream=stdout)
 
     # WHEN a lambda function is decorated with logger
     @logger.inject_lambda_context
@@ -170,7 +168,7 @@ def test_inject_lambda_context_log_no_request_by_default(monkeypatch, lambda_con
     assert log["message"] != lambda_event
 
 
-def test_inject_lambda_cold_start(lambda_context, stdout):
+def test_inject_lambda_cold_start(lambda_context, stdout, service_name):
     # cold_start can be false as it's a global variable in Logger module
     # so we reset it to simulate the correct behaviour
     # since Lambda will only import our logger lib once per concurrent execution
@@ -179,7 +177,7 @@ def test_inject_lambda_cold_start(lambda_context, stdout):
     logger.is_cold_start = True
 
     # GIVEN Logger is initialized
-    logger = Logger(stream=stdout)
+    logger = Logger(service=service_name, stream=stdout)
 
     # WHEN a lambda function is decorated with logger, and called twice
     @logger.inject_lambda_context
@@ -225,9 +223,9 @@ def test_package_logger_format(capsys):
     assert logger.level == logging.DEBUG
 
 
-def test_logger_append_duplicated(stdout):
+def test_logger_append_duplicated(stdout, service_name):
     # GIVEN Logger is initialized with request_id field
-    logger = Logger(stream=stdout, request_id="value")
+    logger = Logger(service=service_name, stream=stdout, request_id="value")
 
     # WHEN `request_id` is appended to the existing structured log
     # using a different value
@@ -239,17 +237,17 @@ def test_logger_append_duplicated(stdout):
     assert "new_value" == log["request_id"]
 
 
-def test_logger_invalid_sampling_rate():
+def test_logger_invalid_sampling_rate(service_name):
     # GIVEN Logger is initialized
     # WHEN sampling_rate non-numeric value
     # THEN we should raise InvalidLoggerSamplingRateError
     with pytest.raises(InvalidLoggerSamplingRateError):
-        Logger(stream=stdout, sampling_rate="TEST")
+        Logger(service=service_name, stream=stdout, sampling_rate="TEST")
 
 
-def test_inject_lambda_context_with_structured_log(lambda_context, stdout):
+def test_inject_lambda_context_with_structured_log(lambda_context, stdout, service_name):
     # GIVEN Logger is initialized
-    logger = Logger(stream=stdout)
+    logger = Logger(service=service_name, stream=stdout)
 
     # WHEN structure_logs has been used to add an additional key upfront
     # and a lambda function is decorated with logger.inject_lambda_context
@@ -274,13 +272,13 @@ def test_inject_lambda_context_with_structured_log(lambda_context, stdout):
         assert key in log
 
 
-def test_logger_children_propagate_changes(stdout):
+def test_logger_children_propagate_changes(stdout, service_name):
     # GIVEN Loggers are initialized
     # create child logger before parent to mimick
     # importing logger from another module/file
     # as loggers are created in global scope
-    child = Logger(stream=stdout, service="order", child=True)
-    parent = Logger(stream=stdout, service="order")
+    child = Logger(stream=stdout, service=service_name, child=True)
+    parent = Logger(stream=stdout, service=service_name)
 
     # WHEN a child Logger adds an additional key
     child.structure_logs(append=True, customer_id="value")
@@ -293,14 +291,14 @@ def test_logger_children_propagate_changes(stdout):
     parent_log, child_log = capture_multiple_logging_statements_output(stdout)
     assert "customer_id" in parent_log
     assert "customer_id" in child_log
-    assert child.parent.name == "order"
+    assert child.parent.name == service_name
 
 
-def test_logger_child_not_set_returns_same_logger():
+def test_logger_child_not_set_returns_same_logger(stdout):
     # GIVEN two Loggers are initialized with the same service name
     # WHEN child param isn't set
-    logger_one = Logger(service="something")
-    logger_two = Logger(service="something")
+    logger_one = Logger(service="something", stream=stdout)
+    logger_two = Logger(service="something", stream=stdout)
 
     # THEN we should have two Logger instances
     # however inner logger wise should be the same
@@ -308,35 +306,42 @@ def test_logger_child_not_set_returns_same_logger():
     assert logger_one._logger is logger_two._logger
     assert logger_one.name is logger_two.name
 
+    # THEN we should also not see any duplicated logs
+    logger_one.info("One - Once")
+    logger_two.info("Two - Once")
 
-def test_logger_level_case_insensitive():
+    logs = list(capture_multiple_logging_statements_output(stdout))
+    assert len(logs) == 2
+
+
+def test_logger_level_case_insensitive(service_name):
     # GIVEN a Loggers is initialized
     # WHEN log level is set as "info" instead of "INFO"
-    logger = Logger(level="info")
+    logger = Logger(service=service_name, level="info")
 
     # THEN we should correctly set log level as INFO
     assert logger.level == logging.INFO
 
 
-def test_logger_level_not_set():
+def test_logger_level_not_set(service_name):
     # GIVEN a Loggers is initialized
     # WHEN no log level was passed
-    logger = Logger()
+    logger = Logger(service=service_name)
 
     # THEN we should default to INFO
     assert logger.level == logging.INFO
 
 
-def test_logger_level_as_int():
+def test_logger_level_as_int(service_name):
     # GIVEN a Loggers is initialized
     # WHEN log level is int
-    logger = Logger(level=logging.INFO)
+    logger = Logger(service=service_name, level=logging.INFO)
 
     # THEN we should be expected int (20, in this case)
     assert logger.level == logging.INFO
 
 
-def test_logger_level_env_var_as_int(monkeypatch):
+def test_logger_level_env_var_as_int(monkeypatch, service_name):
     # GIVEN Logger is initialized
     # WHEN log level is explicitly defined via LOG_LEVEL env as int
     # THEN Logger should propagate ValueError
@@ -344,12 +349,12 @@ def test_logger_level_env_var_as_int(monkeypatch):
     # and '50' is not a correct log level
     monkeypatch.setenv("LOG_LEVEL", 50)
     with pytest.raises(ValueError, match="Unknown level: '50'"):
-        Logger()
+        Logger(service=service_name)
 
 
-def test_logger_record_caller_location(stdout):
+def test_logger_record_caller_location(stdout, service_name):
     # GIVEN Logger is initialized
-    logger = Logger(stream=stdout)
+    logger = Logger(service=service_name, stream=stdout)
 
     # WHEN log statement is run
     logger.info("log")
@@ -361,13 +366,13 @@ def test_logger_record_caller_location(stdout):
     assert caller_fn_name in log["location"]
 
 
-def test_logger_do_not_log_twice_when_root_logger_is_setup(stdout):
+def test_logger_do_not_log_twice_when_root_logger_is_setup(stdout, service_name):
     # GIVEN Lambda configures the root logger with a handler
     root_logger = logging.getLogger()
     root_logger.addHandler(logging.StreamHandler(stream=stdout))
 
     # WHEN we create a new Logger and child Logger
-    logger = Logger(stream=stdout)
+    logger = Logger(service=service_name, stream=stdout)
     child_logger = Logger(child=True, stream=stdout)
     logger.info("hello")
     child_logger.info("hello again")


### PR DESCRIPTION
**Issue #, if available:** #249

## Description of changes:

<!--- One or two sentences as a summary of what's being changed -->

* Adds `init` attribute to parent Loggers to verify whether they've been previously configured
* Updates tests to ensure all `service_name` is unique
* Ensures there is only one test that doesn't define `service_name`

**Checklist**

<!--- Leave unchecked if your change doesn't seem to apply --> 

* [x] [Meet tenets criteria](https://awslabs.github.io/aws-lambda-powertools-python/#tenets)
* [x] Update tests
* [ ] Update docs
* [x] PR title follows [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-python/blob/376ec0a2ac0d2a40e0af5717bef42ff84ca0d1b9/.github/semantic.yml#L2)

## Breaking change checklist

<!--- Ignore if it's not a breaking change -->

**RFC issue #**:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
