### PR TITLE
docs: add info about extras layer

### DIFF
--- a/docs/content/index.mdx
+++ b/docs/content/index.mdx
@@ -28,10 +28,13 @@ sam init --location https://github.com/aws-samples/cookiecutter-aws-sam-python
 ### Lambda Layer
 
 Powertools is also available as a Lambda Layer. It is distributed via the [AWS Serverless Application Repository (SAR)](https://docs.aws.amazon.com/serverlessrepo/latest/devguide/what-is-serverlessrepo.html).
+We have two layers available, one with core dependencies `aws-lambda-powertools-python-layer` and one with extras `aws-lambda-powertools-python-layer-extras` such as `pydantic` which is required for the parser.
+The extras layer is 22.4MB zipped and ~155MB unzipped big.
 
 App | ARN
 ----------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------
 [aws-lambda-powertools-python-layer](https://serverlessrepo.aws.amazon.com/applications/eu-west-1/057560766410/aws-lambda-powertools-python-layer) | arn:aws:serverlessrepo:eu-west-1:057560766410:applications/aws-lambda-powertools-python-layer
+[aws-lambda-powertools-python-layer-extras](https://serverlessrepo.aws.amazon.com/applications/eu-west-1/057560766410/aws-lambda-powertools-python-layer-extras) | arn:aws:serverlessrepo:eu-west-1:057560766410:applications/aws-lambda-powertools-python-layer-extras
 
 If using SAM, you can include this SAR App as part of your shared Layers stack, and lock to a specific semantic version. Once deployed, it'll be available across the account this is deployed to.
 
@@ -41,8 +44,9 @@ If using SAM, you can include this SAR App as part of your shared Layers stack, 
     Properties:
       Location:
         ApplicationId: arn:aws:serverlessrepo:eu-west-1:057560766410:applications/aws-lambda-powertools-python-layer
-        SemanticVersion: 1.3.1 # change to latest semantic version available in SAR
+        SemanticVersion: 1.9.0 # change to latest semantic version available in SAR
 ```
+
 
 This will add a nested app stack with an output parameter `LayerVersionArn`, that you can reference inside your Lambda function definition:
 
@@ -50,6 +54,8 @@ This will add a nested app stack with an output parameter `LayerVersionArn`, tha
   Layers:
     - !GetAtt AwsLambdaPowertoolsPythonLayer.Outputs.LayerVersionArn
 ```
+
+The layer for the co
 
 Here is the list of IAM permissions that you need to add to your deployment IAM role to use the layer:
 

--- a/docs/content/index.mdx
+++ b/docs/content/index.mdx
@@ -29,7 +29,8 @@ sam init --location https://github.com/aws-samples/cookiecutter-aws-sam-python
 
 Powertools is also available as a Lambda Layer. It is distributed via the [AWS Serverless Application Repository (SAR)](https://docs.aws.amazon.com/serverlessrepo/latest/devguide/what-is-serverlessrepo.html).
 We have two layers available, one with core dependencies `aws-lambda-powertools-python-layer` and one with extras `aws-lambda-powertools-python-layer-extras` such as `pydantic` which is required for the parser.
-The extras layer is 22.4MB zipped and ~155MB unzipped big.
+
+> **NOTE**: Extras layer support does not support Python 3.6 runtime. This layer is also  includes all extra dependencies and is 22.4MB zipped, ~155MB unzipped big.
 
 App | ARN
 ----------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------

--- a/docs/content/index.mdx
+++ b/docs/content/index.mdx
@@ -55,7 +55,6 @@ This will add a nested app stack with an output parameter `LayerVersionArn`, tha
     - !GetAtt AwsLambdaPowertoolsPythonLayer.Outputs.LayerVersionArn
 ```
 
-The layer for the co
 
 Here is the list of IAM permissions that you need to add to your deployment IAM role to use the layer:
 


### PR DESCRIPTION
**Issue #, if available:** #210

## Description of changes:
We have now an additional layer with extra dependencies such as `pydantic` that you need for the validation feature. Keep in mind that the size of the extras layer is ~155MB unzipped. 

**Checklist**

<!--- Leave unchecked if your change doesn't seem to apply --> 

* [x] [Meet tenets criteria](https://awslabs.github.io/aws-lambda-powertools-python/#tenets)
* [ ] Update tests
* [x] Update docs
* [x] PR title follows [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-python/blob/376ec0a2ac0d2a40e0af5717bef42ff84ca0d1b9/.github/semantic.yml#L2)

## Breaking change checklist

<!--- Ignore if it's not a breaking change -->

**RFC issue #**:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
