### PR TITLE
fix: import statement in documentation

### DIFF
--- a/docs/content/utilities/data_classes.mdx
+++ b/docs/content/utilities/data_classes.mdx
@@ -119,7 +119,7 @@ Create Auth Challenge | `data_classes.cognito_user_pool_event.CreateAuthChalleng
 Verify Auth Challenge | `data_classes.cognito_user_pool_event.VerifyAuthChallengeResponseTriggerEvent`
 
 ```python:title=lambda_app.py
-from aws_lambda_powertools.utilities.cognito_user_pool_event import PostConfirmationTriggerEvent
+from aws_lambda_powertools.utilities.data_classes.cognito_user_pool_event import PostConfirmationTriggerEvent
 
 def lambda_handler(event, context):
     event: PostConfirmationTriggerEvent = PostConfirmationTriggerEvent(event)


### PR DESCRIPTION
## Description of changes:

This PR fixes an import statement in the documentation.

**Checklist**

* [x] [Meet tenets criteria](https://awslabs.github.io/aws-lambda-powertools-python/#tenets)
* [ ] Update tests
* [x] Update docs
* [x] PR title follows [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-python/blob/376ec0a2ac0d2a40e0af5717bef42ff84ca0d1b9/.github/semantic.yml#L2)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.