### PR TITLE
fix: batch processing exceptions

### DIFF
--- a/aws_lambda_powertools/utilities/batch/base.py
+++ b/aws_lambda_powertools/utilities/batch/base.py
@@ -85,7 +85,7 @@ class BasePartialProcessor(ABC):
         self.success_messages.append(record)
         return entry
 
-    def failure_handler(self, record: Any, exception: Exception):
+    def failure_handler(self, record: Any, exception: Tuple):
         """
         Failure callback
 
@@ -94,8 +94,9 @@ class BasePartialProcessor(ABC):
         tuple
             "fail", exceptions args, original record
         """
-        entry = ("fail", exception.args, record)
-        logger.debug(f"Record processing exception: {exception}")
+        exception_string = f"{exception[0]}:{exception[1]}"
+        entry = ("fail", exception_string, record)
+        logger.debug(f"Record processing exception: {exception_string}")
         self.exceptions.append(exception)
         self.fail_messages.append(record)
         return entry

--- a/aws_lambda_powertools/utilities/batch/exceptions.py
+++ b/aws_lambda_powertools/utilities/batch/exceptions.py
@@ -1,7 +1,28 @@
 """
 Batch processing exceptions
 """
+import traceback
 
 
 class SQSBatchProcessingError(Exception):
     """When at least one message within a batch could not be processed"""
+
+    def __init__(self, msg="", child_exceptions=()):
+        super().__init__(msg)
+        self.msg = msg
+        self.child_exceptions = child_exceptions
+
+    def __str__(self):
+        parent_exception_str = super(SQSBatchProcessingError, self).__str__()
+        exception_list = [f"{parent_exception_str}\n"]
+
+        for exception in self.child_exceptions:
+            extype, ex, tb = exception
+            formatted = "".join(traceback.format_exception(extype, ex, tb))
+            exception_list.append(formatted)
+
+        return "\n".join(exception_list)
+
+    def log(self):
+        for exc in self.child_exceptions:
+            print(exc)

--- a/aws_lambda_powertools/utilities/batch/exceptions.py
+++ b/aws_lambda_powertools/utilities/batch/exceptions.py
@@ -15,14 +15,9 @@ class SQSBatchProcessingError(Exception):
     def __str__(self):
         parent_exception_str = super(SQSBatchProcessingError, self).__str__()
         exception_list = [f"{parent_exception_str}\n"]
-
         for exception in self.child_exceptions:
             extype, ex, tb = exception
             formatted = "".join(traceback.format_exception(extype, ex, tb))
             exception_list.append(formatted)
 
         return "\n".join(exception_list)
-
-    def log(self):
-        for exc in self.child_exceptions:
-            print(exc)

--- a/aws_lambda_powertools/utilities/batch/exceptions.py
+++ b/aws_lambda_powertools/utilities/batch/exceptions.py
@@ -12,6 +12,8 @@ class SQSBatchProcessingError(Exception):
         self.msg = msg
         self.child_exceptions = child_exceptions
 
+    # Overriding this method so we can output all child exception tracebacks when we raise this exception to prevent
+    # errors being lost. See https://github.com/awslabs/aws-lambda-powertools-python/issues/275
     def __str__(self):
         parent_exception_str = super(SQSBatchProcessingError, self).__str__()
         exception_list = [f"{parent_exception_str}\n"]

--- a/aws_lambda_powertools/utilities/batch/sqs.py
+++ b/aws_lambda_powertools/utilities/batch/sqs.py
@@ -91,10 +91,10 @@ class PartialSQSProcessor(BasePartialProcessor):
             An object to be processed.
         """
         try:
-            result = self.handler(record)
-            return self.success_handler(record, result)
+            result = self.handler(record=record)
+            return self.success_handler(record=record, result=result)
         except Exception:
-            return self.failure_handler(record, sys.exc_info())
+            return self.failure_handler(record=record, exception=sys.exc_info())
 
     def _prepare(self):
         """

--- a/aws_lambda_powertools/utilities/batch/sqs.py
+++ b/aws_lambda_powertools/utilities/batch/sqs.py
@@ -4,6 +4,7 @@
 Batch SQS utilities
 """
 import logging
+import sys
 from typing import Callable, Dict, List, Optional, Tuple
 
 import boto3
@@ -92,8 +93,8 @@ class PartialSQSProcessor(BasePartialProcessor):
         try:
             result = self.handler(record)
             return self.success_handler(record, result)
-        except Exception as exc:
-            return self.failure_handler(record, exc)
+        except Exception:
+            return self.failure_handler(record, sys.exc_info())
 
     def _prepare(self):
         """
@@ -123,7 +124,11 @@ class PartialSQSProcessor(BasePartialProcessor):
             logger.debug(f"{len(self.fail_messages)} records failed processing, but exceptions are suppressed")
         else:
             logger.debug(f"{len(self.fail_messages)} records failed processing, raising exception")
-            raise SQSBatchProcessingError(list(self.exceptions))
+            raise SQSBatchProcessingError(
+                msg=f"Not all records processed succesfully. {len(self.exceptions)} individual errors logged "
+                f"separately below.",
+                child_exceptions=self.exceptions,
+            )
 
         return delete_message_response
 

--- a/tests/functional/test_utilities_batch.py
+++ b/tests/functional/test_utilities_batch.py
@@ -85,7 +85,7 @@ def test_partial_sqs_processor_context_with_failure(sqs_event_factory, record_ha
             with partial_processor(records, record_handler) as ctx:
                 ctx.process()
 
-        assert len(error.value.args[0]) == 1
+        assert len(error.value.child_exceptions) == 1
         stubber.assert_no_pending_responses()
 
 
@@ -144,7 +144,7 @@ def test_batch_processor_middleware_with_partial_sqs_processor(sqs_event_factory
         with pytest.raises(SQSBatchProcessingError) as error:
             lambda_handler(event, {})
 
-        assert len(error.value.args[0]) == 2
+        assert len(error.value.child_exceptions) == 2
         stubber.assert_no_pending_responses()
 
 
@@ -171,7 +171,7 @@ def test_sqs_batch_processor_middleware(
     with pytest.raises(SQSBatchProcessingError) as error:
         lambda_handler(event, {})
 
-    assert len(error.value.args[0]) == 1
+    assert len(error.value.child_exceptions) == 1
     stubber.assert_no_pending_responses()
 
 
@@ -203,7 +203,7 @@ def test_batch_processor_middleware_with_custom_processor(capsys, sqs_event_fact
 
         stubber.assert_no_pending_responses()
 
-    assert len(error.value.args[0]) == 1
+    assert len(error.value.child_exceptions) == 1
     assert capsys.readouterr().out == "Oh no ! It's a failure.\n"
 
 
@@ -289,4 +289,4 @@ def test_partial_sqs_processor_context_only_failure(sqs_event_factory, record_ha
         with partial_processor(records, record_handler) as ctx:
             ctx.process()
 
-    assert len(error.value.args[0]) == 2
+    assert len(error.value.child_exceptions) == 2

--- a/tests/unit/test_utilities_batch.py
+++ b/tests/unit/test_utilities_batch.py
@@ -99,8 +99,12 @@ def test_partial_sqs_process_record_failure(mocker, partial_sqs_processor):
     result = partial_sqs_processor._process_record(record)
 
     handler_mock.assert_called_once_with(record)
-    failure_handler_mock.assert_called_once_with(record, failure_result)
 
+    failure_handler_called_with_args, _ = failure_handler_mock.call_args
+    failure_handler_mock.assert_called_once()
+    assert (failure_handler_called_with_args[0]) == record
+    assert isinstance(failure_handler_called_with_args[1], tuple)
+    assert failure_handler_called_with_args[1][1] == failure_result
     assert result == expected_value
 
 

--- a/tests/unit/test_utilities_batch.py
+++ b/tests/unit/test_utilities_batch.py
@@ -81,8 +81,8 @@ def test_partial_sqs_process_record_success(mocker, partial_sqs_processor):
 
     result = partial_sqs_processor._process_record(record)
 
-    handler_mock.assert_called_once_with(record)
-    success_handler_mock.assert_called_once_with(record, success_result)
+    handler_mock.assert_called_once_with(record=record)
+    success_handler_mock.assert_called_once_with(record=record, result=success_result)
 
     assert result == expected_value
 
@@ -98,13 +98,13 @@ def test_partial_sqs_process_record_failure(mocker, partial_sqs_processor):
 
     result = partial_sqs_processor._process_record(record)
 
-    handler_mock.assert_called_once_with(record)
+    handler_mock.assert_called_once_with(record=record)
 
-    failure_handler_called_with_args, _ = failure_handler_mock.call_args
+    _, failure_handler_called_with_args = failure_handler_mock.call_args
     failure_handler_mock.assert_called_once()
-    assert (failure_handler_called_with_args[0]) == record
-    assert isinstance(failure_handler_called_with_args[1], tuple)
-    assert failure_handler_called_with_args[1][1] == failure_result
+    assert (failure_handler_called_with_args["record"]) == record
+    assert isinstance(failure_handler_called_with_args["exception"], tuple)
+    assert failure_handler_called_with_args["exception"][1] == failure_result
     assert result == expected_value
 
 


### PR DESCRIPTION
**Issue #, if available:** #275

## Description of changes:

Update batch exception handling to include more detail of the actual exceptions raised in users processing code.

_Why not just log the exception one-by-one as we catch them?_
By default, the aws_lambda_powertools package logger is suppressed. Logging from package modules would require users to take [additional steps](https://awslabs.github.io/aws-lambda-powertools-python/#debug-mode) to see those logs.

**Checklist**

<!--- Leave unchecked if your change doesn't seem to apply --> 

* [X] [Meet tenets criteria](https://awslabs.github.io/aws-lambda-powertools-python/#tenets)
* [X] Update tests
* [X] Update docs
* [X] PR title follows [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-python/blob/376ec0a2ac0d2a40e0af5717bef42ff84ca0d1b9/.github/semantic.yml#L2)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
