### PR TITLE
fix: disable batching of X-Ray subsegments

### DIFF
--- a/aws_lambda_powertools/tracing/tracer.py
+++ b/aws_lambda_powertools/tracing/tracer.py
@@ -14,6 +14,10 @@ from ..shared.functions import resolve_truthy_env_var_choice
 
 is_cold_start = True
 logger = logging.getLogger(__name__)
+# Set the streaming threshold to 0 on the default recorder to force sending
+# subsegments individually, rather than batching them.
+# See https://github.com/awslabs/aws-lambda-powertools-python/issues/283
+aws_xray_sdk.core.xray_recorder.configure(streaming_threshold=0)
 
 
 class Tracer:


### PR DESCRIPTION
**Issue #, if available:** https://github.com/awslabs/aws-lambda-powertools-python/issues/283

## Description of changes:

Disable batching of X-Ray subsegments, thus preventing an issue where the total data sent in one go to the X-Ray daemon is too large and causes a "Message too long" error.

**Checklist**

<!--- Leave unchecked if your change doesn't seem to apply --> 

* [ ] [Meet tenets criteria](https://awslabs.github.io/aws-lambda-powertools-python/#tenets)
* [ ] Update tests
* [ ] Update docs
* [x] PR title follows [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-python/blob/376ec0a2ac0d2a40e0af5717bef42ff84ca0d1b9/.github/semantic.yml#L2)

## Breaking change checklist

<!--- Ignore if it's not a breaking change -->

**RFC issue #**:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
