### PR TITLE
docs(data-classes): Fix anchor tags to be lower case

### DIFF
--- a/docs/utilities/data_classes.md
+++ b/docs/utilities/data_classes.md
@@ -33,8 +33,8 @@ Event Source | Data_class
 ------------------------------------------------- | ---------------------------------------------------------------------------------
 [API Gateway Proxy](#api-gateway-proxy) | `APIGatewayProxyEvent`
 [API Gateway Proxy event v2](#api-gateway-proxy-v2) | `APIGatewayProxyEventV2`
-[CloudWatch Logs](#cloudWatch-logs) | `CloudWatchLogsEvent`
-[Cognito User Pool](#cognito-user-pool-triggers) | Multiple available under `cognito_user_pool_event`
+[CloudWatch Logs](#cloudwatch-logs) | `CloudWatchLogsEvent`
+[Cognito User Pool](#cognito-user-pool) | Multiple available under `cognito_user_pool_event`
 [DynamoDB streams](#dynamodb-streams) | `DynamoDBStreamEvent`, `DynamoDBRecordEventName`
 [EventBridge](#eventbridge) | `EventBridgeEvent`
 [Kinesis Data Stream](#kinesis-streams) | `KinesisStreamEvent`

--- a/docs/utilities/data_classes.md
+++ b/docs/utilities/data_classes.md
@@ -35,13 +35,13 @@ Event Source | Data_class
 [API Gateway Proxy event v2](#api-gateway-proxy-v2) | `APIGatewayProxyEventV2`
 [CloudWatch Logs](#cloudWatch-logs) | `CloudWatchLogsEvent`
 [Cognito User Pool](#cognito-user-pool-triggers) | Multiple available under `cognito_user_pool_event`
-[DynamoDB streams](#dynamoDB-streams) | `DynamoDBStreamEvent`, `DynamoDBRecordEventName`
+[DynamoDB streams](#dynamodb-streams) | `DynamoDBStreamEvent`, `DynamoDBRecordEventName`
 [EventBridge](#eventbridge) | `EventBridgeEvent`
 [Kinesis Data Stream](#kinesis-streams) | `KinesisStreamEvent`
-[S3](#S3) | `S3Event`
-[SES](#SES) | `SESEvent`
-[SNS](#SNS) | `SNSEvent`
-[SQS](#SQS) | `SQSEvent`
+[S3](#s3) | `S3Event`
+[SES](#ses) | `SESEvent`
+[SNS](#sns) | `SNSEvent`
+[SQS](#sqs) | `SQSEvent`
 
 
 !!! info


### PR DESCRIPTION
## Description of changes:

Anchors casing need to match what is generated in the html, which is lower case.

eg: `S3` should be `s3`


> **NOTE:** This does not fix the anchor links on the logger.md as the toc level is 3, and no anchor tags are generated for the following

```markdown
[Service parameter](#the-service-parameter), [Inheriting Loggers](#inheriting-loggers), [Overriding Log records](#overriding-log-records), and [Logging exceptions](#logging-exceptions)
```

mkdocs.yml
```yml
  - toc:
      permalink: true
      toc_depth: 3
```

**Checklist**

<!--- Leave unchecked if your change doesn't seem to apply --> 

* [X] [Meet tenets criteria](https://awslabs.github.io/aws-lambda-powertools-python/#tenets)
* [X] Update tests
* [X] Update docs
* [X] PR title follows [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-python/blob/376ec0a2ac0d2a40e0af5717bef42ff84ca0d1b9/.github/semantic.yml#L2)

