### PR TITLE
chore: Correct the docs location for the labeller

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -15,7 +15,7 @@ area/metrics:
   - aws_lambda_powertools_python/metrics/*
  
 documentation:
-  - aws_lambda_powertools_python/docs/*
+  - docs/*
   - ./mkdocs.yml
  
 internal:


### PR DESCRIPTION
## Description of changes:

Update to the correct location of `docs/*` for the documentation labels

**Checklist**

* [X] [Meet tenets criteria](https://awslabs.github.io/aws-lambda-powertools-python/#tenets)
* [X] Update tests
* [X] Update docs
* [X] PR title follows [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-python/blob/376ec0a2ac0d2a40e0af5717bef42ff84ca0d1b9/.github/semantic.yml#L2)