### PR TITLE
fix: correct behaviour to avoid caching "INPROGRESS" records

### DIFF
--- a/aws_lambda_powertools/utilities/idempotency/persistence/base.py
+++ b/aws_lambda_powertools/utilities/idempotency/persistence/base.py
@@ -7,6 +7,7 @@ import hashlib
 import json
 import logging
 from abc import ABC, abstractmethod
+from types import MappingProxyType
 from typing import Any, Dict
 
 import jmespath
@@ -21,7 +22,7 @@ from aws_lambda_powertools.utilities.idempotency.exceptions import (
 
 logger = logging.getLogger(__name__)
 
-STATUS_CONSTANTS = {"INPROGRESS": "INPROGRESS", "COMPLETED": "COMPLETED", "EXPIRED": "EXPIRED"}
+STATUS_CONSTANTS = MappingProxyType({"INPROGRESS": "INPROGRESS", "COMPLETED": "COMPLETED", "EXPIRED": "EXPIRED"})
 
 
 class DataRecord:

--- a/aws_lambda_powertools/utilities/idempotency/persistence/base.py
+++ b/aws_lambda_powertools/utilities/idempotency/persistence/base.py
@@ -82,8 +82,7 @@ class DataRecord:
         """
         if self.is_expired:
             return STATUS_CONSTANTS["EXPIRED"]
-
-        if self._status in STATUS_CONSTANTS.values():
+        elif self._status in STATUS_CONSTANTS.values():
             return self._status
         else:
             raise IdempotencyInvalidStatusError(self._status)
@@ -222,7 +221,7 @@ class BasePersistenceLayer(ABC):
         """
         if self.payload_validation_enabled:
             lambda_payload_hash = self._get_hashed_payload(lambda_event)
-            if not data_record.payload_hash == lambda_payload_hash:
+            if data_record.payload_hash != lambda_payload_hash:
                 raise IdempotencyValidationError("Payload does not match stored record for this event key")
 
     def _get_expiry_timestamp(self) -> int:
@@ -263,7 +262,7 @@ class BasePersistenceLayer(ABC):
     def _retrieve_from_cache(self, idempotency_key: str):
         cached_record = self._cache.get(idempotency_key)
         if cached_record:
-            if all((not cached_record.is_expired, not cached_record.status == "INPROGRESS")):
+            if not cached_record.is_expired:
                 return cached_record
             logger.debug(f"Removing expired local cache record for idempotency key: {idempotency_key}")
             self._delete_from_cache(idempotency_key)

--- a/docs/utilities/idempotency.md
+++ b/docs/utilities/idempotency.md
@@ -3,8 +3,11 @@ title: Idempotency
 description: Utility
 ---
 
-This utility provides a simple solution to convert your Lambda functions into idempotent operations which are safe to
-retry.
+!!! attention
+    **This utility is currently in beta**. Please open an [issue in GitHub](https://github.com/awslabs/aws-lambda-powertools-python/issues/new/choose) for any bugs or feature requests.
+
+The idempotency utility provides a simple solution to convert your Lambda functions into idempotent operations which
+are safe to retry.
 
 ## Terminology
 
@@ -31,31 +34,31 @@ storage layer, so you'll need to create a table first.
 > Example using AWS Serverless Application Model (SAM)
 
 === "template.yml"
-```yaml
-Resources:
-  HelloWorldFunction:
-  Type: AWS::Serverless::Function
-  Properties:
-    Runtime: python3.8
-    ...
-    Policies:
-      - DynamoDBCrudPolicy:
-          TableName: !Ref IdempotencyTable
-  IdempotencyTable:
-    Type: AWS::DynamoDB::Table
-    Properties:
-      AttributeDefinitions:
-        -   AttributeName: id
-            AttributeType: S
-      BillingMode: PAY_PER_REQUEST
-      KeySchema:
-        -   AttributeName: id
-            KeyType: HASH
-      TableName: "IdempotencyTable"
-      TimeToLiveSpecification:
-        AttributeName: expiration
-        Enabled: true
-```
+    ```yaml
+    Resources:
+      HelloWorldFunction:
+      Type: AWS::Serverless::Function
+      Properties:
+        Runtime: python3.8
+        ...
+        Policies:
+          - DynamoDBCrudPolicy:
+              TableName: !Ref IdempotencyTable
+      IdempotencyTable:
+        Type: AWS::DynamoDB::Table
+        Properties:
+          AttributeDefinitions:
+            -   AttributeName: id
+                AttributeType: S
+          BillingMode: PAY_PER_REQUEST
+          KeySchema:
+            -   AttributeName: id
+                KeyType: HASH
+          TableName: "IdempotencyTable"
+          TimeToLiveSpecification:
+            AttributeName: expiration
+            Enabled: true
+    ```
 
 !!! warning
     When using this utility with DynamoDB, your lambda responses must always be smaller than 400kb. Larger items cannot

--- a/tests/unit/test_json_encoder.py
+++ b/tests/unit/test_json_encoder.py
@@ -1,6 +1,8 @@
 import decimal
 import json
 
+import pytest
+
 from aws_lambda_powertools.shared.json_encoder import Encoder
 
 
@@ -12,3 +14,11 @@ def test_jsonencode_decimal():
 def test_jsonencode_decimal_nan():
     result = json.dumps({"val": decimal.Decimal("NaN")}, cls=Encoder)
     assert result == '{"val": NaN}'
+
+
+def test_jsonencode_calls_default():
+    class CustomClass:
+        pass
+
+    with pytest.raises(TypeError):
+        json.dumps({"val": CustomClass()}, cls=Encoder)


### PR DESCRIPTION
**Issue #, if available:**

## Description of changes:

This fixes an issue with caching in the unreleased idempotency util. We were mistakenly caching in progress records, meaning execution environments could get "stuck" with in progress records in the cache. Records in this state shouldn't be included in the cache, as we've no way to reflect changes from outside the execution environment in the local caches.

**Checklist**

<!--- Leave unchecked if your change doesn't seem to apply --> 

* [X] [Meet tenets criteria](https://awslabs.github.io/aws-lambda-powertools-python/#tenets)
* [X] Update tests
* [X] Update docs
* [X] PR title follows [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-python/blob/376ec0a2ac0d2a40e0af5717bef42ff84ca0d1b9/.github/semantic.yml#L2)

## Breaking change checklist

<!--- Ignore if it's not a breaking change -->

**RFC issue #**:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
