### PR TITLE
fix: Export missing DynamoDBRecordEventName class

### DIFF
--- a/aws_lambda_powertools/utilities/data_classes/__init__.py
+++ b/aws_lambda_powertools/utilities/data_classes/__init__.py
@@ -1,8 +1,7 @@
 from .alb_event import ALBEvent
 from .api_gateway_proxy_event import APIGatewayProxyEvent, APIGatewayProxyEventV2
 from .cloud_watch_logs_event import CloudWatchLogsEvent
-from .dynamo_db_stream_event import DynamoDBStreamEvent
-from .dynamo_db_stream_event import DynamoDBRecordEventName
+from .dynamo_db_stream_event import DynamoDBStreamEvent, DynamoDBRecordEventName
 from .event_bridge_event import EventBridgeEvent
 from .kinesis_stream_event import KinesisStreamEvent
 from .s3_event import S3Event

--- a/aws_lambda_powertools/utilities/data_classes/__init__.py
+++ b/aws_lambda_powertools/utilities/data_classes/__init__.py
@@ -2,6 +2,7 @@ from .alb_event import ALBEvent
 from .api_gateway_proxy_event import APIGatewayProxyEvent, APIGatewayProxyEventV2
 from .cloud_watch_logs_event import CloudWatchLogsEvent
 from .dynamo_db_stream_event import DynamoDBStreamEvent
+from .dynamo_db_stream_event import DynamoDBRecordEventName
 from .event_bridge_event import EventBridgeEvent
 from .kinesis_stream_event import KinesisStreamEvent
 from .s3_event import S3Event
@@ -15,6 +16,7 @@ __all__ = [
     "ALBEvent",
     "CloudWatchLogsEvent",
     "DynamoDBStreamEvent",
+    "DynamoDBRecordEventName",
     "EventBridgeEvent",
     "KinesisStreamEvent",
     "S3Event",


### PR DESCRIPTION
## Description of changes:

The DynamoDBRecordEventName is not being exported, causing the following error
```
Traceback:
tests/test_lambda_handler.py:1: in <module>
    from src.lambda_handler import lambda_handler
src/lambda_handler.py:1: in <module>
    from aws_lambda_powertools.utilities.data_classes import (
E   ImportError: cannot import name 'DynamoDBRecordEventName' from 'aws_lambda_powertools.utilities.data_classes' (..../.venv/lib/python3.8/site-packages/aws_lambda_powertools/utilities/data_classes/__init__.py)
```
**Checklist**

<!--- Leave unchecked if your change doesn't seem to apply --> 

* [x] [Meet tenets criteria](https://awslabs.github.io/aws-lambda-powertools-python/#tenets)
* [ ] Update tests
* [ ] Update docs
* [x] PR title follows [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-python/blob/376ec0a2ac0d2a40e0af5717bef42ff84ca0d1b9/.github/semantic.yml#L2)

## Breaking change checklist

<!--- Ignore if it's not a breaking change -->

**RFC issue #**:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
