### PR TITLE
docs(data-classes): Correct import for DynamoDBRecordEventName

### DIFF
--- a/docs/utilities/data_classes.md
+++ b/docs/utilities/data_classes.md
@@ -142,7 +142,7 @@ attributes values (`AttributeValue`), as well as enums for stream view type (`St
 === "lambda_app.py"
 
     ```python
-    from aws_lambda_powertools.utilities.data_classes import DynamoDBStreamEvent, DynamoDBRecordEventName
+    from aws_lambda_powertools.utilities.data_classes.dynamo_db_stream_event import DynamoDBStreamEvent, DynamoDBRecordEventName
 
     def lambda_handler(event, context):
         event: DynamoDBStreamEvent = DynamoDBStreamEvent(event)


### PR DESCRIPTION
**Issue #, if available:**
#298

## Description of changes:

Correct import for DynamoDBRecordEventName, should be: 

```python3
from aws_lambda_powertools.utilities.data_classes.dynamo_db_stream_event import DynamoDBStreamEvent, DynamoDBRecordEventName
```

**Checklist**


* [X] [Meet tenets criteria](https://awslabs.github.io/aws-lambda-powertools-python/#tenets)
* [X] Update tests
* [X] Update docs
* [X] PR title follows [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-python/blob/376ec0a2ac0d2a40e0af5717bef42ff84ca0d1b9/.github/semantic.yml#L2)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
