### PR TITLE
fix(idempotency): Correctly handle save_inprogress errors

### DIFF
--- a/aws_lambda_powertools/utilities/idempotency/idempotency.py
+++ b/aws_lambda_powertools/utilities/idempotency/idempotency.py
@@ -135,6 +135,8 @@ class IdempotencyHandler:
             # Now we know the item already exists, we can retrieve it
             record = self._get_idempotency_record()
             return self._handle_for_status(record)
+        except Exception as exc:
+            raise IdempotencyPersistenceLayerError("Failed to save in progress record to idempotency store") from exc
 
         return self._call_lambda_handler()
 


### PR DESCRIPTION
## Description of changes:

GIVEN a miss configured persistence layer
like no table was created for the idempotency persistence layer
WHEN handling the idempotent call
AND save_inprogress raises a ClientError
THEN idempotent should raise an IdempotencyPersistenceLayerError


**Checklist**

<!--- Leave unchecked if your change doesn't seem to apply --> 

* [x] [Meet tenets criteria](https://awslabs.github.io/aws-lambda-powertools-python/#tenets)
* [x] Update tests
* [x] Update docs
* [x] PR title follows [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-python/blob/376ec0a2ac0d2a40e0af5717bef42ff84ca0d1b9/.github/semantic.yml#L2)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
