### PR TITLE
docs(metrics): Corrections to the docstrings code examples

### DIFF
--- a/aws_lambda_powertools/metrics/base.py
+++ b/aws_lambda_powertools/metrics/base.py
@@ -197,7 +197,7 @@ class MetricManager:
             metric_names_and_units.append({"Name": metric_name, "Unit": metric_unit})
             metric_names_and_values.update({metric_name: metric_value})
 
-        embedded_metrics_object = {
+        return {
             "_aws": {
                 "Timestamp": int(datetime.datetime.now().timestamp() * 1000),  # epoch
                 "CloudWatchMetrics": [
@@ -212,8 +212,6 @@ class MetricManager:
             **metadata,  # "username": "test"
             **metric_names_and_values,  # "single_metric": 1.0
         }
-
-        return embedded_metrics_object
 
     def add_dimension(self, name: str, value: str):
         """Adds given dimension to all metrics

--- a/aws_lambda_powertools/metrics/metric.py
+++ b/aws_lambda_powertools/metrics/metric.py
@@ -27,9 +27,9 @@ class SingleMetric(MetricManager):
     -------
     **Creates cold start metric with function_version as dimension**
 
-        from aws_lambda_powertools.metrics import SingleMetric, MetricUnit
         import json
-        metric = Single_Metric(namespace="ServerlessAirline")
+        from aws_lambda_powertools.metrics import single_metric, MetricUnit
+        metric = single_metric(namespace="ServerlessAirline")
 
         metric.add_metric(name="ColdStart", unit=MetricUnit.Count, value=1)
         metric.add_dimension(name="function_version", value=47)
@@ -72,7 +72,7 @@ def single_metric(name: str, unit: MetricUnit, value: float, namespace: str = No
         from aws_lambda_powertools.metrics import MetricUnit
 
         with single_metric(name="ColdStart", unit=MetricUnit.Count, value=1, namespace="ServerlessAirline") as metric:
-                metric.add_dimension(name="function_version", value=47)
+            metric.add_dimension(name="function_version", value="47")
 
     **Same as above but set namespace using environment variable**
 
@@ -82,7 +82,7 @@ def single_metric(name: str, unit: MetricUnit, value: float, namespace: str = No
         from aws_lambda_powertools.metrics import MetricUnit
 
         with single_metric(name="ColdStart", unit=MetricUnit.Count, value=1) as metric:
-                metric.add_dimension(name="function_version", value=47)
+            metric.add_dimension(name="function_version", value="47")
 
     Parameters
     ----------

--- a/aws_lambda_powertools/metrics/metrics.py
+++ b/aws_lambda_powertools/metrics/metrics.py
@@ -39,14 +39,13 @@ class Metrics(MetricManager):
         metrics.add_dimension(name="function_version", value="$LATEST")
         ...
 
-        @tracer.capture_lambda_handler
         @metrics.log_metrics()
         def lambda_handler():
-                do_something()
-                return True
+               do_something()
+               return True
 
         def do_something():
-                metrics.add_metric(name="Something", unit="Count", value=1)
+               metrics.add_metric(name="Something", unit="Count", value=1)
 
     Environment variables
     ---------------------
@@ -111,12 +110,14 @@ class Metrics(MetricManager):
         -------
         **Lambda function using tracer and metrics decorators**
 
+            from aws_lambda_powertools import Metrics, Tracer
+
             metrics = Metrics(service="payment")
             tracer = Tracer(service="payment")
 
             @tracer.capture_lambda_handler
             @metrics.log_metrics
-                def handler(event, context):
+            def handler(event, context):
                     ...
 
         Parameters


### PR DESCRIPTION
## Description of changes:

Correct some of the code examples in the doc string

eg:

```python3
from aws_lambda_powertools.metrics import SingleMetric, MetricUnit
```

vs

```python3
from aws_lambda_powertools.metrics import single_metric, MetricUnit
```

**Checklist**

<!--- Leave unchecked if your change doesn't seem to apply --> 

* [X] [Meet tenets criteria](https://awslabs.github.io/aws-lambda-powertools-python/#tenets)
* [X] Update tests
* [X] Update docs
* [X] PR title follows [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-python/blob/376ec0a2ac0d2a40e0af5717bef42ff84ca0d1b9/.github/semantic.yml#L2)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
