### PR TITLE
fix(idempotency): TypeError when calling is_missing_idempotency_key with an int

### DIFF
--- a/aws_lambda_powertools/utilities/idempotency/persistence/base.py
+++ b/aws_lambda_powertools/utilities/idempotency/persistence/base.py
@@ -183,7 +183,14 @@ class BasePersistenceLayer(ABC):
 
     @staticmethod
     def is_missing_idempotency_key(data) -> bool:
-        return data is None or not data or (type(data).__name__ in ("tuple", "list") and all(x is None for x in data))
+        if data is None:
+            return True
+        elif not data:
+            return True
+        elif type(data).__name__ in ("tuple", "list", "dict"):
+            return all(x is None for x in data)
+        else:
+            return False
 
     def _get_hashed_payload(self, lambda_event: Dict[str, Any]) -> str:
         """

--- a/aws_lambda_powertools/utilities/idempotency/persistence/base.py
+++ b/aws_lambda_powertools/utilities/idempotency/persistence/base.py
@@ -183,11 +183,9 @@ class BasePersistenceLayer(ABC):
 
     @staticmethod
     def is_missing_idempotency_key(data) -> bool:
-        if not data:
-            return True
         if type(data).__name__ in ("tuple", "list", "dict"):
             return all(x is None for x in data)
-        return False
+        return not data
 
     def _get_hashed_payload(self, lambda_event: Dict[str, Any]) -> str:
         """

--- a/aws_lambda_powertools/utilities/idempotency/persistence/base.py
+++ b/aws_lambda_powertools/utilities/idempotency/persistence/base.py
@@ -183,7 +183,7 @@ class BasePersistenceLayer(ABC):
 
     @staticmethod
     def is_missing_idempotency_key(data) -> bool:
-        return data is None or not data or all(x is None for x in data)
+        return data is None or not data or (type(data).__name__ in ("tuple", "list") and all(x is None for x in data))
 
     def _get_hashed_payload(self, lambda_event: Dict[str, Any]) -> str:
         """

--- a/aws_lambda_powertools/utilities/idempotency/persistence/base.py
+++ b/aws_lambda_powertools/utilities/idempotency/persistence/base.py
@@ -183,14 +183,11 @@ class BasePersistenceLayer(ABC):
 
     @staticmethod
     def is_missing_idempotency_key(data) -> bool:
-        if data is None:
+        if data is None or not data:
             return True
-        elif not data:
-            return True
-        elif type(data).__name__ in ("tuple", "list", "dict"):
+        if type(data).__name__ in ("tuple", "list", "dict"):
             return all(x is None for x in data)
-        else:
-            return False
+        return False
 
     def _get_hashed_payload(self, lambda_event: Dict[str, Any]) -> str:
         """

--- a/aws_lambda_powertools/utilities/idempotency/persistence/base.py
+++ b/aws_lambda_powertools/utilities/idempotency/persistence/base.py
@@ -183,7 +183,7 @@ class BasePersistenceLayer(ABC):
 
     @staticmethod
     def is_missing_idempotency_key(data) -> bool:
-        if data is None or not data:
+        if not data:
             return True
         if type(data).__name__ in ("tuple", "list", "dict"):
             return all(x is None for x in data)

--- a/tests/functional/idempotency/test_idempotency.py
+++ b/tests/functional/idempotency/test_idempotency.py
@@ -696,6 +696,8 @@ def test_is_missing_idempotency_key():
     assert BasePersistenceLayer.is_missing_idempotency_key([None, None])
     # GIVEN a tuples of Nones THEN is_missing_idempotency_key is True
     assert BasePersistenceLayer.is_missing_idempotency_key((None, None))
+    # GIVEN a dict of Nones THEN is_missing_idempotency_key is True
+    assert BasePersistenceLayer.is_missing_idempotency_key({None: None})
 
     # GIVEN a str THEN is_missing_idempotency_key is False
     assert BasePersistenceLayer.is_missing_idempotency_key("Value") is False

--- a/tests/functional/idempotency/test_idempotency.py
+++ b/tests/functional/idempotency/test_idempotency.py
@@ -677,22 +677,36 @@ def test_delete_from_cache_when_empty(
 
 
 def test_is_missing_idempotency_key():
+    # GIVEN an empty tuple THEN is_missing_idempotency_key is True
+    assert BasePersistenceLayer.is_missing_idempotency_key(())
+    # GIVEN an empty list THEN is_missing_idempotency_key is True
+    assert BasePersistenceLayer.is_missing_idempotency_key([])
+    # GIVEN an empty dictionary THEN is_missing_idempotency_key is True
+    assert BasePersistenceLayer.is_missing_idempotency_key({})
+    # GIVEN an empty str THEN is_missing_idempotency_key is True
+    assert BasePersistenceLayer.is_missing_idempotency_key("")
+    # GIVEN False THEN is_missing_idempotency_key is True
+    assert BasePersistenceLayer.is_missing_idempotency_key(False)
+    # GIVEN number 0 THEN is_missing_idempotency_key is True
+    assert BasePersistenceLayer.is_missing_idempotency_key(0)
+
     # GIVEN None THEN is_missing_idempotency_key is True
     assert BasePersistenceLayer.is_missing_idempotency_key(None)
     # GIVEN a list of Nones THEN is_missing_idempotency_key is True
     assert BasePersistenceLayer.is_missing_idempotency_key([None, None])
-    # GIVEN a list of all not None THEN is_missing_idempotency_key is false
-    assert BasePersistenceLayer.is_missing_idempotency_key([None, "Value"]) is False
-    # GIVEN a str THEN is_missing_idempotency_key is false
+    # GIVEN a tuples of Nones THEN is_missing_idempotency_key is True
+    assert BasePersistenceLayer.is_missing_idempotency_key((None, None))
+
+    # GIVEN a str THEN is_missing_idempotency_key is False
     assert BasePersistenceLayer.is_missing_idempotency_key("Value") is False
-    # GIVEN an empty tuple THEN is_missing_idempotency_key is false
-    assert BasePersistenceLayer.is_missing_idempotency_key(())
-    # GIVEN an empty list THEN is_missing_idempotency_key is false
-    assert BasePersistenceLayer.is_missing_idempotency_key([])
-    # GIVEN an empty dictionary THEN is_missing_idempotency_key is false
-    assert BasePersistenceLayer.is_missing_idempotency_key({})
-    # GIVEN an empty str THEN is_missing_idempotency_key is false
-    assert BasePersistenceLayer.is_missing_idempotency_key("")
+    # GIVEN str "False" THEN is_missing_idempotency_key is False
+    assert BasePersistenceLayer.is_missing_idempotency_key("False") is False
+    # GIVEN an number THEN is_missing_idempotency_key is False
+    assert BasePersistenceLayer.is_missing_idempotency_key(1000) is False
+    # GIVEN a float THEN is_missing_idempotency_key is False
+    assert BasePersistenceLayer.is_missing_idempotency_key(10.01) is False
+    # GIVEN a list of all not None THEN is_missing_idempotency_key is False
+    assert BasePersistenceLayer.is_missing_idempotency_key([None, "Value"]) is False
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Description of changes:

Fix for `is_missing_idempotency_key` which  can raise a `TypeError: 'int' object is not iterable` 
for the follow code

```python3
BasePersistenceLayer.is_missing_idempotency_key(1000)
```


**Checklist**

<!--- Leave unchecked if your change doesn't seem to apply --> 

* [x] [Meet tenets criteria](https://awslabs.github.io/aws-lambda-powertools-python/#tenets)
* [x] Update tests
* [x] Update docs
* [x] PR title follows [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-python/blob/376ec0a2ac0d2a40e0af5717bef42ff84ca0d1b9/.github/semantic.yml#L2)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
