### PR TITLE
feat(logging): inject correlation_id

### DIFF
--- a/tests/functional/test_logger.py
+++ b/tests/functional/test_logger.py
@@ -437,3 +437,21 @@ def test_logger_exception_extract_exception_name(stdout, service_name):
     # THEN we expect a "exception_name" to be "ValueError"
     log = capture_logging_output(stdout)
     assert "ValueError" == log["exception_name"]
+
+
+def test_logger_correlation_id(lambda_context, stdout, service_name):
+    # GIVEN
+    logger = Logger(service=service_name, stream=stdout)
+    request_id = "xxx"
+    mock_event = {"requestContext": {"requestId": request_id}}
+
+    @logger.inject_lambda_context(correlation_id_path="requestContext.requestId")
+    def handler(_1, _2):
+        logger.info("Foo")
+
+    # WHEN
+    handler(mock_event, lambda_context)
+
+    # THEN
+    log = capture_logging_output(stdout)
+    assert request_id == log["correlation_id"]


### PR DESCRIPTION

**Issue #, if available:**

#9 

## Description of changes:

Prototype idea for correlation_id support in logger.

> NOTE: I am just using `inject_lambda_context` for demo purposes, i am not sure if this should be a new decorator?

Example API Gateway Proxy Event
```json5
{
    "requestContext":{
        "requestId":"13B398ED-FABA-4D50-A4A1-6CD39BDA85E5"
    }
}
```

Usage:

```python3
@logger.inject_lambda_context(correlation_id_path="requestContext.requestId")
def handler(_1, _2):
    logger.info("My message")

```

Cloudwatch log
```json
{
    "level":"INFO",
    "location":"handler:450",
    "message":"My message",
    "timestamp":"2021-03-09 15:12:32,652",
    "service":"81shAbHB2IPQTex",
    "sampling_rate":0.0,
    "cold_start":true,
    "function_name":"test",
    "function_memory_size":128,
    "function_arn":"arn:aws:lambda:eu-west-1:809313241:function:test",
    "function_request_id":"52fdfc07-2182-154f-163f-5f0f9a621d72",
    "correlation_id":"13B398ED-FABA-4D50-A4A1-6CD39BDA85E5"
}
```

**Checklist**

<!--- Leave unchecked if your change doesn't seem to apply --> 

* [ ] [Meet tenets criteria](https://awslabs.github.io/aws-lambda-powertools-python/#tenets)
* [ ] Update tests
* [ ] Update docs
* [ ] PR title follows [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-python/blob/376ec0a2ac0d2a40e0af5717bef42ff84ca0d1b9/.github/semantic.yml#L2)

## Breaking change checklist

<!--- Ignore if it's not a breaking change -->

**RFC issue #**:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
