### PR TITLE
feat(idempotent): Include function name in the idempotent key

### DIFF
--- a/aws_lambda_powertools/utilities/idempotency/config.py
+++ b/aws_lambda_powertools/utilities/idempotency/config.py
@@ -33,8 +33,6 @@ class IdempotencyConfig:
             Max number of items to store in local cache, by default 1024
         hash_function: str, optional
             Function to use for calculating hashes, by default md5.
-        include_function_name: bool, optional
-            Whether to include the function name in the idempotent key
         """
         self.event_key_jmespath = event_key_jmespath
         self.payload_validation_jmespath = payload_validation_jmespath
@@ -44,4 +42,3 @@ class IdempotencyConfig:
         self.use_local_cache = use_local_cache
         self.local_cache_max_items = local_cache_max_items
         self.hash_function = hash_function
-        self.include_function_name = include_function_name

--- a/aws_lambda_powertools/utilities/idempotency/config.py
+++ b/aws_lambda_powertools/utilities/idempotency/config.py
@@ -12,6 +12,7 @@ class IdempotencyConfig:
         use_local_cache: bool = False,
         local_cache_max_items: int = 256,
         hash_function: str = "md5",
+        include_function_name: bool = True,
     ):
         """
         Initialize the base persistence layer
@@ -32,6 +33,8 @@ class IdempotencyConfig:
             Max number of items to store in local cache, by default 1024
         hash_function: str, optional
             Function to use for calculating hashes, by default md5.
+        include_function_name: bool, optional
+            Whether to include the function name in the idempotent key
         """
         self.event_key_jmespath = event_key_jmespath
         self.payload_validation_jmespath = payload_validation_jmespath
@@ -41,3 +44,4 @@ class IdempotencyConfig:
         self.use_local_cache = use_local_cache
         self.local_cache_max_items = local_cache_max_items
         self.hash_function = hash_function
+        self.include_function_name = include_function_name

--- a/aws_lambda_powertools/utilities/idempotency/config.py
+++ b/aws_lambda_powertools/utilities/idempotency/config.py
@@ -12,7 +12,6 @@ class IdempotencyConfig:
         use_local_cache: bool = False,
         local_cache_max_items: int = 256,
         hash_function: str = "md5",
-        include_function_name: bool = True,
     ):
         """
         Initialize the base persistence layer

--- a/aws_lambda_powertools/utilities/idempotency/idempotency.py
+++ b/aws_lambda_powertools/utilities/idempotency/idempotency.py
@@ -151,7 +151,7 @@ class IdempotencyHandler:
 
         """
         try:
-            event_record = self.persistence_store.get_record(self.event, self.context)
+            event_record = self.persistence_store.get_record(event=self.event, context=self.context)
         except IdempotencyItemNotFoundError:
             # This code path will only be triggered if the record is removed between save_inprogress and get_record.
             logger.debug(

--- a/aws_lambda_powertools/utilities/idempotency/persistence/base.py
+++ b/aws_lambda_powertools/utilities/idempotency/persistence/base.py
@@ -182,11 +182,11 @@ class BasePersistenceLayer(ABC):
                 raise IdempotencyKeyError("No data found to create a hashed idempotency_key")
             warnings.warn(f"No value found for idempotency_key. jmespath: {self.event_key_jmespath}")
 
-        generated_hard = self._generate_hash(data)
+        generated_hash = self._generate_hash(data)
         if self.include_function_name:
-            return f"{context.function_name}#{generated_hard}"
+            return f"{context.function_name}#{generated_hash}"
         else:
-            return generated_hard
+            return generated_hash
 
     @staticmethod
     def is_missing_idempotency_key(data) -> bool:

--- a/aws_lambda_powertools/utilities/idempotency/persistence/base.py
+++ b/aws_lambda_powertools/utilities/idempotency/persistence/base.py
@@ -122,7 +122,6 @@ class BasePersistenceLayer(ABC):
         self.use_local_cache = False
         self._cache: Optional[LRUDict] = None
         self.hash_function = None
-        self.include_function_name = True
 
     def configure(self, config: IdempotencyConfig) -> None:
         """
@@ -153,7 +152,6 @@ class BasePersistenceLayer(ABC):
         if self.use_local_cache:
             self._cache = LRUDict(max_items=config.local_cache_max_items)
         self.hash_function = getattr(hashlib, config.hash_function)
-        self.include_function_name = config.include_function_name
 
     def _get_hashed_idempotency_key(self, event: Dict[str, Any], context: LambdaContext) -> str:
         """
@@ -183,10 +181,7 @@ class BasePersistenceLayer(ABC):
             warnings.warn(f"No value found for idempotency_key. jmespath: {self.event_key_jmespath}")
 
         generated_hash = self._generate_hash(data)
-        if self.include_function_name:
-            return f"{context.function_name}#{generated_hash}"
-        else:
-            return generated_hash
+        return f"{context.function_name}#{generated_hash}"
 
     @staticmethod
     def is_missing_idempotency_key(data) -> bool:

--- a/aws_lambda_powertools/utilities/idempotency/persistence/base.py
+++ b/aws_lambda_powertools/utilities/idempotency/persistence/base.py
@@ -180,7 +180,7 @@ class BasePersistenceLayer(ABC):
                 raise IdempotencyKeyError("No data found to create a hashed idempotency_key")
             warnings.warn(f"No value found for idempotency_key. jmespath: {self.event_key_jmespath}")
 
-        return context.function_name + "#" + self._generate_hash(data)
+        return f"{context.function_name}#{self._generate_hash(data)}"
 
     @staticmethod
     def is_missing_idempotency_key(data) -> bool:

--- a/tests/functional/idempotency/conftest.py
+++ b/tests/functional/idempotency/conftest.py
@@ -40,7 +40,7 @@ def lambda_context():
     lambda_context = {
         "function_name": "test-func",
         "memory_limit_in_mb": 128,
-        "invoked_function_arn": "arn:aws:lambda:eu-west-1:809313241:function:test",
+        "invoked_function_arn": "arn:aws:lambda:eu-west-1:809313241234:function:test-func",
         "aws_request_id": "52fdfc07-2182-154f-163f-5f0f9a621d72",
     }
 

--- a/tests/functional/idempotency/test_idempotency.py
+++ b/tests/functional/idempotency/test_idempotency.py
@@ -828,16 +828,3 @@ def test_idempotent_lambda_save_inprogress_error(persistence_store: DynamoDBPers
     stubber.assert_no_pending_responses()
     stubber.deactivate()
     assert "Failed to save in progress record to idempotency store" == e.value.args[0]
-
-
-def test_include_function_name_false(persistence_store: DynamoDBPersistenceLayer):
-    # GIVEN include_function_name=False
-    persistence_store.configure(IdempotencyConfig(event_key_jmespath="body", include_function_name=False))
-    value = "true"
-    api_gateway_proxy_event = {"body": value}
-
-    # WHEN
-    result = persistence_store._get_hashed_idempotency_key(api_gateway_proxy_event, None)
-
-    # THEN
-    assert result == persistence_store._generate_hash(value)

--- a/tests/functional/idempotency/test_idempotency.py
+++ b/tests/functional/idempotency/test_idempotency.py
@@ -828,3 +828,16 @@ def test_idempotent_lambda_save_inprogress_error(persistence_store: DynamoDBPers
     stubber.assert_no_pending_responses()
     stubber.deactivate()
     assert "Failed to save in progress record to idempotency store" == e.value.args[0]
+
+
+def test_include_function_name_false(persistence_store: DynamoDBPersistenceLayer):
+    # GIVEN include_function_name=False
+    persistence_store.configure(IdempotencyConfig(event_key_jmespath="body", include_function_name=False))
+    value = "true"
+    api_gateway_proxy_event = {"body": value}
+
+    # WHEN
+    result = persistence_store._get_hashed_idempotency_key(api_gateway_proxy_event, None)
+
+    # THEN
+    assert result == persistence_store._generate_hash(value)


### PR DESCRIPTION
**Issue #, if available:**
https://github.com/awslabs/aws-lambda-powertools-python/issues/318

## Description of changes:

Prefix the `hashed_idempotency_key` with the context function name:

```python
f"{context.function_name}#{self._generate_hash(data)}"
```

> **NOTE:** Rather than hash this prefix, I kept it in the clear to make debugging a little easier and I did not make 
this configurable, as this makes sense as the default

HOWEVER: You _MIGHT_  get edge cases where the function name has been changed while keeping an existing datastore

**Checklist**

<!--- Leave unchecked if your change doesn't seem to apply --> 

* [X] [Meet tenets criteria](https://awslabs.github.io/aws-lambda-powertools-python/#tenets)
* [X] Update tests
* [x] Update docs
* [X] PR title follows [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-python/blob/376ec0a2ac0d2a40e0af5717bef42ff84ca0d1b9/.github/semantic.yml#L2)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
