### PR TITLE
docs(data-classes): Add more cognito code examples

### DIFF
--- a/aws_lambda_powertools/utilities/data_classes/common.py
+++ b/aws_lambda_powertools/utilities/data_classes/common.py
@@ -20,8 +20,8 @@ class DictWrapper:
         return self._data.get(key)
 
     @property
-    def data(self) -> Dict[str, Any]:
-        """The original event dict"""
+    def raw_event(self) -> Dict[str, Any]:
+        """The original raw event dict"""
         return self._data
 
 

--- a/aws_lambda_powertools/utilities/data_classes/common.py
+++ b/aws_lambda_powertools/utilities/data_classes/common.py
@@ -19,6 +19,11 @@ class DictWrapper:
     def get(self, key: str) -> Optional[Any]:
         return self._data.get(key)
 
+    @property
+    def data(self) -> Dict[str, Any]:
+        """The original event dict"""
+        return self._data
+
 
 def get_header_value(headers: Dict[str, str], name: str, default_value: str, case_sensitive: bool) -> Optional[str]:
     """Get header value by name"""

--- a/docs/utilities/data_classes.md
+++ b/docs/utilities/data_classes.md
@@ -258,34 +258,34 @@ Verify Auth Challenge | `data_classes.cognito_user_pool_event.VerifyAuthChalleng
     from aws_lambda_powertools.utilities.data_classes.cognito_user_pool_event import DefineAuthChallengeTriggerEvent
 
     def handler(event, context):
-        _event: DefineAuthChallengeTriggerEvent = DefineAuthChallengeTriggerEvent(event)
+        event: DefineAuthChallengeTriggerEvent = DefineAuthChallengeTriggerEvent(event)
         if (
-            len(_event.request.session) == 1
-            and _event.request.session[0].challenge_name == "SRP_A"
+            len(event.request.session) == 1
+            and event.request.session[0].challenge_name == "SRP_A"
         ):
-            _event.response.issue_tokens = False
-            _event.response.fail_authentication = False
-            _event.response.challenge_name = "PASSWORD_VERIFIER"
+            event.response.issue_tokens = False
+            event.response.fail_authentication = False
+            event.response.challenge_name = "PASSWORD_VERIFIER"
         elif (
-            len(_event.request.session) == 2
-            and _event.request.session[1].challenge_name == "PASSWORD_VERIFIER"
-            and _event.request.session[1].challenge_result
+            len(event.request.session) == 2
+            and event.request.session[1].challenge_name == "PASSWORD_VERIFIER"
+            and event.request.session[1].challenge_result
         ):
-            _event.response.issue_tokens = False
-            _event.response.fail_authentication = False
-            _event.response.challenge_name = "CUSTOM_CHALLENGE"
+            event.response.issue_tokens = False
+            event.response.fail_authentication = False
+            event.response.challenge_name = "CUSTOM_CHALLENGE"
         elif (
-            len(_event.request.session) == 3
-            and _event.request.session[2].challenge_name == "CUSTOM_CHALLENGE"
-            and _event.request.session[2].challenge_result
+            len(event.request.session) == 3
+            and event.request.session[2].challenge_name == "CUSTOM_CHALLENGE"
+            and event.request.session[2].challenge_result
         ):
-            _event.response.issue_tokens = True
-            _event.response.fail_authentication = False
+            event.response.issue_tokens = True
+            event.response.fail_authentication = False
         else:
-            _event.response.issue_tokens = False
-            _event.response.fail_authentication = True
+            event.response.issue_tokens = False
+            event.response.fail_authentication = True
 
-        return event
+        return event.data
     ```
 === "SPR_A response"
 
@@ -410,12 +410,12 @@ Verify Auth Challenge | `data_classes.cognito_user_pool_event.VerifyAuthChalleng
     from aws_lambda_powertools.utilities.data_classes.cognito_user_pool_event import CreateAuthChallengeTriggerEvent
 
     def handler(event, context):
-        _event: CreateAuthChallengeTriggerEvent = CreateAuthChallengeTriggerEvent(event)
-        if _event.request.challenge_name == "CUSTOM_CHALLENGE":
-            _event.response.public_challenge_parameters = {"captchaUrl": "url/123.jpg"}
-            _event.response.private_challenge_parameters = {"answer": "5"}
-            _event.response.challenge_metadata = "CAPTCHA_CHALLENGE"
-        return event
+        event: CreateAuthChallengeTriggerEvent = CreateAuthChallengeTriggerEvent(event)
+        if event.request.challenge_name == "CUSTOM_CHALLENGE":
+            event.response.public_challenge_parameters = {"captchaUrl": "url/123.jpg"}
+            event.response.private_challenge_parameters = {"answer": "5"}
+            event.response.challenge_metadata = "CAPTCHA_CHALLENGE"
+        return event.data
     ```
 
 #### Verify Auth Challenge Response Example
@@ -426,11 +426,11 @@ Verify Auth Challenge | `data_classes.cognito_user_pool_event.VerifyAuthChalleng
     from aws_lambda_powertools.utilities.data_classes.cognito_user_pool_event import VerifyAuthChallengeResponseTriggerEvent
 
     def handler(event, context):
-        _event: VerifyAuthChallengeResponseTriggerEvent = VerifyAuthChallengeResponseTriggerEvent(event)
-        _event.response.answer_correct = (
-            _event.request.private_challenge_parameters.get("answer") == _event.request.challenge_answer
+        event: VerifyAuthChallengeResponseTriggerEvent = VerifyAuthChallengeResponseTriggerEvent(event)
+        event.response.answer_correct = (
+            event.request.private_challenge_parameters.get("answer") == event.request.challenge_answer
         )
-        return event
+        return event.data
     ```
 
 ### Connect Contact Flow

--- a/docs/utilities/data_classes.md
+++ b/docs/utilities/data_classes.md
@@ -253,7 +253,7 @@ Verify Auth Challenge | `data_classes.cognito_user_pool_event.VerifyAuthChalleng
 #### Define Auth Challenge Example
 
 !!! warning "NOTE "
-    In this example we are modifying the wrapped dict response fields, so we need to return the json serializable wrapped `event.data`
+    In this example we are modifying the wrapped dict response fields, so we need to return the json serializable wrapped event in `event.raw_event`
 
 !!! info "NOTE "
     This example is based on the AWS Cognito docs for [Define Auth Challenge Lambda Trigger](https://docs.aws.amazon.com/cognito/latest/developerguide/user-pool-lambda-define-auth-challenge.html){target="_blank"}
@@ -291,7 +291,7 @@ Verify Auth Challenge | `data_classes.cognito_user_pool_event.VerifyAuthChalleng
             event.response.issue_tokens = False
             event.response.fail_authentication = True
 
-        return event.data
+        return event.raw_event
     ```
 === "SPR_A response"
 
@@ -424,7 +424,7 @@ Verify Auth Challenge | `data_classes.cognito_user_pool_event.VerifyAuthChalleng
             event.response.public_challenge_parameters = {"captchaUrl": "url/123.jpg"}
             event.response.private_challenge_parameters = {"answer": "5"}
             event.response.challenge_metadata = "CAPTCHA_CHALLENGE"
-        return event.data
+        return event.raw_event
     ```
 
 #### Verify Auth Challenge Response Example
@@ -442,7 +442,7 @@ Verify Auth Challenge | `data_classes.cognito_user_pool_event.VerifyAuthChalleng
         event.response.answer_correct = (
             event.request.private_challenge_parameters.get("answer") == event.request.challenge_answer
         )
-        return event.data
+        return event.raw_event
     ```
 
 ### Connect Contact Flow

--- a/docs/utilities/data_classes.md
+++ b/docs/utilities/data_classes.md
@@ -252,12 +252,15 @@ Verify Auth Challenge | `data_classes.cognito_user_pool_event.VerifyAuthChalleng
 
 #### Define Auth Challenge Example
 
+> **NOTE:** In this example we are modifying the wrapped dict response fields, so we need to return the json serializable
+> wrapped `event.data`
+
 === "app.py"
 
     ```python
     from aws_lambda_powertools.utilities.data_classes.cognito_user_pool_event import DefineAuthChallengeTriggerEvent
 
-    def handler(event, context):
+    def handler(event: dict, context) -> dict:
         event: DefineAuthChallengeTriggerEvent = DefineAuthChallengeTriggerEvent(event)
         if (
             len(event.request.session) == 1
@@ -409,7 +412,7 @@ Verify Auth Challenge | `data_classes.cognito_user_pool_event.VerifyAuthChalleng
     ```python
     from aws_lambda_powertools.utilities.data_classes.cognito_user_pool_event import CreateAuthChallengeTriggerEvent
 
-    def handler(event, context):
+    def handler(event: dict, context) -> dict:
         event: CreateAuthChallengeTriggerEvent = CreateAuthChallengeTriggerEvent(event)
         if event.request.challenge_name == "CUSTOM_CHALLENGE":
             event.response.public_challenge_parameters = {"captchaUrl": "url/123.jpg"}
@@ -425,7 +428,7 @@ Verify Auth Challenge | `data_classes.cognito_user_pool_event.VerifyAuthChalleng
     ```python
     from aws_lambda_powertools.utilities.data_classes.cognito_user_pool_event import VerifyAuthChallengeResponseTriggerEvent
 
-    def handler(event, context):
+    def handler(event: dict, context) -> dict:
         event: VerifyAuthChallengeResponseTriggerEvent = VerifyAuthChallengeResponseTriggerEvent(event)
         event.response.answer_correct = (
             event.request.private_challenge_parameters.get("answer") == event.request.challenge_answer

--- a/docs/utilities/data_classes.md
+++ b/docs/utilities/data_classes.md
@@ -252,8 +252,11 @@ Verify Auth Challenge | `data_classes.cognito_user_pool_event.VerifyAuthChalleng
 
 #### Define Auth Challenge Example
 
-> **NOTE:** In this example we are modifying the wrapped dict response fields, so we need to return the json serializable
-> wrapped `event.data`
+!!! warning "NOTE "
+    In this example we are modifying the wrapped dict response fields, so we need to return the json serializable wrapped `event.data`
+
+!!! info "NOTE "
+    This example is based on the AWS Cognito docs for [Define Auth Challenge Lambda Trigger](https://docs.aws.amazon.com/cognito/latest/developerguide/user-pool-lambda-define-auth-challenge.html){target="_blank"}
 
 === "app.py"
 
@@ -407,6 +410,9 @@ Verify Auth Challenge | `data_classes.cognito_user_pool_event.VerifyAuthChalleng
 
 #### Create Auth Challenge Example
 
+!!! info "NOTE "
+    This example is based on the AWS Cognito docs for [Create Auth Challenge Lambda Trigger](https://docs.aws.amazon.com/cognito/latest/developerguide/user-pool-lambda-create-auth-challenge.html){target="_blank"}
+
 === "app.py"
 
     ```python
@@ -422,6 +428,9 @@ Verify Auth Challenge | `data_classes.cognito_user_pool_event.VerifyAuthChalleng
     ```
 
 #### Verify Auth Challenge Response Example
+
+!!! info "NOTE "
+    This example is based on the AWS Cognito docs for [Verify Auth Challenge Response Lambda Trigger](https://docs.aws.amazon.com/cognito/latest/developerguide/user-pool-lambda-verify-auth-challenge-response.html){target="_blank"}
 
 === "app.py"
 

--- a/tests/functional/test_lambda_trigger_events.py
+++ b/tests/functional/test_lambda_trigger_events.py
@@ -73,7 +73,7 @@ def test_dict_wrapper_equals():
     assert DataClassSample(data1) is not data1
     assert data1 is not DataClassSample(data1)
 
-    assert DataClassSample(data1).data is data1
+    assert DataClassSample(data1).raw_event is data1
 
 
 def test_cloud_watch_trigger_event():
@@ -83,7 +83,7 @@ def test_cloud_watch_trigger_event():
     assert event.decompress_logs_data == decompressed_logs_data
 
     json_logs_data = event.parse_logs_data()
-    assert event.parse_logs_data().data == json_logs_data.data
+    assert event.parse_logs_data().raw_event == json_logs_data.raw_event
     log_events = json_logs_data.log_events
     log_event = log_events[0]
 
@@ -99,7 +99,7 @@ def test_cloud_watch_trigger_event():
     assert log_event.extracted_fields is None
 
     event2 = CloudWatchLogsEvent(load_event("cloudWatchLogEvent.json"))
-    assert event.data == event2.data
+    assert event.raw_event == event2.raw_event
 
 
 def test_cognito_pre_signup_trigger_event():
@@ -495,7 +495,7 @@ def test_s3_trigger_event():
     assert s3.get_object.version_id is None
     assert s3.get_object.sequencer == "0C0F6F405D6ED209E1"
     assert record.glacier_event_data is None
-    assert event.record.data == event["Records"][0]
+    assert event.record.raw_event == event["Records"][0]
     assert event.bucket_name == "lambda-artifacts-deafc19498e3f2df"
     assert event.object_key == "b21b84d653bb07b05b1e6b33684dc11b"
 
@@ -561,7 +561,7 @@ def test_ses_trigger_event():
     assert headers[0].value == "<janedoe@example.com>"
     common_headers = mail.common_headers
     assert common_headers.return_path == "janedoe@example.com"
-    assert common_headers.get_from == common_headers.data["from"]
+    assert common_headers.get_from == common_headers.raw_event["from"]
     assert common_headers.date == "Wed, 7 Oct 2015 12:34:56 -0700"
     assert common_headers.to == [expected_address]
     assert common_headers.message_id == "<0123456789example.com>"
@@ -575,12 +575,12 @@ def test_ses_trigger_event():
     assert receipt.spf_verdict.status == "PASS"
     assert receipt.dmarc_verdict.status == "PASS"
     action = receipt.action
-    assert action.get_type == action.data["type"]
-    assert action.function_arn == action.data["functionArn"]
-    assert action.invocation_type == action.data["invocationType"]
-    assert event.record.data == event["Records"][0]
-    assert event.mail.data == event["Records"][0]["ses"]["mail"]
-    assert event.receipt.data == event["Records"][0]["ses"]["receipt"]
+    assert action.get_type == action.raw_event["type"]
+    assert action.function_arn == action.raw_event["functionArn"]
+    assert action.invocation_type == action.raw_event["invocationType"]
+    assert event.record.raw_event == event["Records"][0]
+    assert event.mail.raw_event == event["Records"][0]["ses"]["mail"]
+    assert event.receipt.raw_event == event["Records"][0]["ses"]["receipt"]
 
 
 def test_sns_trigger_event():
@@ -606,7 +606,7 @@ def test_sns_trigger_event():
     assert sns.unsubscribe_url == "https://sns.us-east-2.amazonaws.com/?Action=Unsubscribe"
     assert sns.topic_arn == "arn:aws:sns:us-east-2:123456789012:sns-lambda"
     assert sns.subject == "TestInvoke"
-    assert event.record.data == event["Records"][0]
+    assert event.record.raw_event == event["Records"][0]
     assert event.sns_message == "Hello from SNS!"
 
 

--- a/tests/functional/test_lambda_trigger_events.py
+++ b/tests/functional/test_lambda_trigger_events.py
@@ -73,6 +73,8 @@ def test_dict_wrapper_equals():
     assert DataClassSample(data1) is not data1
     assert data1 is not DataClassSample(data1)
 
+    assert DataClassSample(data1).data is data1
+
 
 def test_cloud_watch_trigger_event():
     event = CloudWatchLogsEvent(load_event("cloudWatchLogEvent.json"))
@@ -81,7 +83,7 @@ def test_cloud_watch_trigger_event():
     assert event.decompress_logs_data == decompressed_logs_data
 
     json_logs_data = event.parse_logs_data()
-    assert event.parse_logs_data()._data == json_logs_data._data
+    assert event.parse_logs_data().data == json_logs_data.data
     log_events = json_logs_data.log_events
     log_event = log_events[0]
 
@@ -97,7 +99,7 @@ def test_cloud_watch_trigger_event():
     assert log_event.extracted_fields is None
 
     event2 = CloudWatchLogsEvent(load_event("cloudWatchLogEvent.json"))
-    assert event._data == event2._data
+    assert event.data == event2.data
 
 
 def test_cognito_pre_signup_trigger_event():
@@ -493,7 +495,7 @@ def test_s3_trigger_event():
     assert s3.get_object.version_id is None
     assert s3.get_object.sequencer == "0C0F6F405D6ED209E1"
     assert record.glacier_event_data is None
-    assert event.record._data == event["Records"][0]
+    assert event.record.data == event["Records"][0]
     assert event.bucket_name == "lambda-artifacts-deafc19498e3f2df"
     assert event.object_key == "b21b84d653bb07b05b1e6b33684dc11b"
 
@@ -559,7 +561,7 @@ def test_ses_trigger_event():
     assert headers[0].value == "<janedoe@example.com>"
     common_headers = mail.common_headers
     assert common_headers.return_path == "janedoe@example.com"
-    assert common_headers.get_from == common_headers._data["from"]
+    assert common_headers.get_from == common_headers.data["from"]
     assert common_headers.date == "Wed, 7 Oct 2015 12:34:56 -0700"
     assert common_headers.to == [expected_address]
     assert common_headers.message_id == "<0123456789example.com>"
@@ -573,12 +575,12 @@ def test_ses_trigger_event():
     assert receipt.spf_verdict.status == "PASS"
     assert receipt.dmarc_verdict.status == "PASS"
     action = receipt.action
-    assert action.get_type == action._data["type"]
-    assert action.function_arn == action._data["functionArn"]
-    assert action.invocation_type == action._data["invocationType"]
-    assert event.record._data == event["Records"][0]
-    assert event.mail._data == event["Records"][0]["ses"]["mail"]
-    assert event.receipt._data == event["Records"][0]["ses"]["receipt"]
+    assert action.get_type == action.data["type"]
+    assert action.function_arn == action.data["functionArn"]
+    assert action.invocation_type == action.data["invocationType"]
+    assert event.record.data == event["Records"][0]
+    assert event.mail.data == event["Records"][0]["ses"]["mail"]
+    assert event.receipt.data == event["Records"][0]["ses"]["receipt"]
 
 
 def test_sns_trigger_event():
@@ -604,7 +606,7 @@ def test_sns_trigger_event():
     assert sns.unsubscribe_url == "https://sns.us-east-2.amazonaws.com/?Action=Unsubscribe"
     assert sns.topic_arn == "arn:aws:sns:us-east-2:123456789012:sns-lambda"
     assert sns.subject == "TestInvoke"
-    assert event.record._data == event["Records"][0]
+    assert event.record.data == event["Records"][0]
     assert event.sns_message == "Hello from SNS!"
 
 


### PR DESCRIPTION
**Issue #, if available:**

## Description of changes:

Changes:
- Add property to access the `_data` dict
- Add more code examples for Cognito triggers showing how to set response values.

eg:
```python
from aws_lambda_powertools.utilities.data_classes.cognito_user_pool_event import (
   DefineAuthChallengeTriggerEvent
)

def handler(event: dict, context) -> dict:
   event: DefineAuthChallengeTriggerEvent = DefineAuthChallengeTriggerEvent(event)
   if (
       len(event.request.session) == 1
       and event.request.session[0].challenge_name == "SRP_A"
   ):
       event.response.issue_tokens = False
       event.response.fail_authentication = False
       event.response.challenge_name = "PASSWORD_VERIFIER"
   elif (
       len(event.request.session) == 2
       and event.request.session[1].challenge_name == "PASSWORD_VERIFIER"
       and event.request.session[1].challenge_result
   ):
       event.response.issue_tokens = False
       event.response.fail_authentication = False
       event.response.challenge_name = "CUSTOM_CHALLENGE"
   elif (
       len(event.request.session) == 3
       and event.request.session[2].challenge_name == "CUSTOM_CHALLENGE"
       and event.request.session[2].challenge_result
   ):
       event.response.issue_tokens = True
       event.response.fail_authentication = False
   else:
       event.response.issue_tokens = False
       event.response.fail_authentication = True

   return event.raw_event
 ```

**Checklist**

<!--- Leave unchecked if your change doesn't seem to apply --> 

* [X] [Meet tenets criteria](https://awslabs.github.io/aws-lambda-powertools-python/#tenets)
* [X] Update tests
* [X] Update docs
* [X] PR title follows [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-python/blob/376ec0a2ac0d2a40e0af5717bef42ff84ca0d1b9/.github/semantic.yml#L2)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
