### PR TITLE
feat(parameters): Add force_fetch option

### DIFF
--- a/aws_lambda_powertools/utilities/parameters/appconfig.py
+++ b/aws_lambda_powertools/utilities/parameters/appconfig.py
@@ -107,7 +107,12 @@ class AppConfigProvider(BaseProvider):
 
 
 def get_app_config(
-    name: str, environment: str, application: Optional[str] = None, transform: Optional[str] = None, **sdk_options
+    name: str,
+    environment: str,
+    application: Optional[str] = None,
+    transform: Optional[str] = None,
+    force_update: bool = False,
+    **sdk_options
 ) -> Union[str, list, dict, bytes]:
     """
     Retrieve a configuration value from AWS App Config.
@@ -122,6 +127,8 @@ def get_app_config(
         Application of the configuration
     transform: str, optional
         Transforms the content from a JSON object ('json') or base64 binary string ('binary')
+    force_update: bool, optional
+        Force update even before a cached item has expired, defaults to False
     sdk_options: dict, optional
         Dictionary of options that will be passed to the Parameter Store get_parameter API call
 
@@ -160,4 +167,4 @@ def get_app_config(
 
     sdk_options["ClientId"] = CLIENT_ID
 
-    return DEFAULT_PROVIDERS["appconfig"].get(name, transform=transform, **sdk_options)
+    return DEFAULT_PROVIDERS["appconfig"].get(name, transform=transform, force_update=force_update, **sdk_options)

--- a/aws_lambda_powertools/utilities/parameters/appconfig.py
+++ b/aws_lambda_powertools/utilities/parameters/appconfig.py
@@ -111,7 +111,7 @@ def get_app_config(
     environment: str,
     application: Optional[str] = None,
     transform: Optional[str] = None,
-    force_update: bool = False,
+    force_fetch: bool = False,
     **sdk_options
 ) -> Union[str, list, dict, bytes]:
     """
@@ -127,7 +127,7 @@ def get_app_config(
         Application of the configuration
     transform: str, optional
         Transforms the content from a JSON object ('json') or base64 binary string ('binary')
-    force_update: bool, optional
+    force_fetch: bool, optional
         Force update even before a cached item has expired, defaults to False
     sdk_options: dict, optional
         Dictionary of options that will be passed to the Parameter Store get_parameter API call
@@ -167,4 +167,4 @@ def get_app_config(
 
     sdk_options["ClientId"] = CLIENT_ID
 
-    return DEFAULT_PROVIDERS["appconfig"].get(name, transform=transform, force_update=force_update, **sdk_options)
+    return DEFAULT_PROVIDERS["appconfig"].get(name, transform=transform, force_fetch=force_fetch, **sdk_options)

--- a/aws_lambda_powertools/utilities/parameters/base.py
+++ b/aws_lambda_powertools/utilities/parameters/base.py
@@ -42,7 +42,7 @@ class BaseProvider(ABC):
         name: str,
         max_age: int = DEFAULT_MAX_AGE_SECS,
         transform: Optional[str] = None,
-        force_update: bool = False,
+        force_fetch: bool = False,
         **sdk_options,
     ) -> Union[str, list, dict, bytes]:
         """
@@ -58,7 +58,7 @@ class BaseProvider(ABC):
             Optional transformation of the parameter value. Supported values
             are "json" for JSON strings and "binary" for base 64 encoded
             values.
-        force_update: bool, optional
+        force_fetch: bool, optional
             Force update even before a cached item has expired, defaults to False
         sdk_options: dict, optional
             Arguments that will be passed directly to the underlying API call
@@ -83,7 +83,7 @@ class BaseProvider(ABC):
         # an acceptable tradeoff.
         key = (name, transform)
 
-        if not force_update and self._has_not_expired(key):
+        if not force_fetch and self._has_not_expired(key):
             return self.store[key].value
 
         try:
@@ -112,7 +112,7 @@ class BaseProvider(ABC):
         max_age: int = DEFAULT_MAX_AGE_SECS,
         transform: Optional[str] = None,
         raise_on_transform_error: bool = False,
-        force_update: bool = False,
+        force_fetch: bool = False,
         **sdk_options,
     ) -> Union[Dict[str, str], Dict[str, dict], Dict[str, bytes]]:
         """
@@ -131,7 +131,7 @@ class BaseProvider(ABC):
         raise_on_transform_error: bool, optional
             Raises an exception if any transform fails, otherwise this will
             return a None value for each transform that failed
-        force_update: bool, optional
+        force_fetch: bool, optional
             Force update even before a cached item has expired, defaults to False
         sdk_options: dict, optional
             Arguments that will be passed directly to the underlying API call
@@ -147,7 +147,7 @@ class BaseProvider(ABC):
 
         key = (path, transform)
 
-        if not force_update and self._has_not_expired(key):
+        if not force_fetch and self._has_not_expired(key):
             return self.store[key].value
 
         try:

--- a/aws_lambda_powertools/utilities/parameters/base.py
+++ b/aws_lambda_powertools/utilities/parameters/base.py
@@ -59,7 +59,7 @@ class BaseProvider(ABC):
             are "json" for JSON strings and "binary" for base 64 encoded
             values.
         force_update: bool, optional
-            Force update even before a cached item has expired
+            Force update even before a cached item has expired, defaults to False
         sdk_options: dict, optional
             Arguments that will be passed directly to the underlying API call
 
@@ -132,7 +132,7 @@ class BaseProvider(ABC):
             Raises an exception if any transform fails, otherwise this will
             return a None value for each transform that failed
         force_update: bool, optional
-            Force update even before a cached item has expired
+            Force update even before a cached item has expired, defaults to False
         sdk_options: dict, optional
             Arguments that will be passed directly to the underlying API call
 

--- a/aws_lambda_powertools/utilities/parameters/base.py
+++ b/aws_lambda_powertools/utilities/parameters/base.py
@@ -38,7 +38,12 @@ class BaseProvider(ABC):
         return key in self.store and self.store[key].ttl >= datetime.now()
 
     def get(
-        self, name: str, max_age: int = DEFAULT_MAX_AGE_SECS, transform: Optional[str] = None, **sdk_options
+        self,
+        name: str,
+        max_age: int = DEFAULT_MAX_AGE_SECS,
+        transform: Optional[str] = None,
+        force_update: bool = False,
+        **sdk_options,
     ) -> Union[str, list, dict, bytes]:
         """
         Retrieve a parameter value or return the cached value
@@ -53,6 +58,8 @@ class BaseProvider(ABC):
             Optional transformation of the parameter value. Supported values
             are "json" for JSON strings and "binary" for base 64 encoded
             values.
+        force_update: bool, optional
+            Force update even before a cached item has expired
         sdk_options: dict, optional
             Arguments that will be passed directly to the underlying API call
 
@@ -76,7 +83,7 @@ class BaseProvider(ABC):
         # an acceptable tradeoff.
         key = (name, transform)
 
-        if self._has_not_expired(key):
+        if not force_update and self._has_not_expired(key):
             return self.store[key].value
 
         try:
@@ -105,6 +112,7 @@ class BaseProvider(ABC):
         max_age: int = DEFAULT_MAX_AGE_SECS,
         transform: Optional[str] = None,
         raise_on_transform_error: bool = False,
+        force_update: bool = False,
         **sdk_options,
     ) -> Union[Dict[str, str], Dict[str, dict], Dict[str, bytes]]:
         """
@@ -123,6 +131,8 @@ class BaseProvider(ABC):
         raise_on_transform_error: bool, optional
             Raises an exception if any transform fails, otherwise this will
             return a None value for each transform that failed
+        force_update: bool, optional
+            Force update even before a cached item has expired
         sdk_options: dict, optional
             Arguments that will be passed directly to the underlying API call
 
@@ -137,7 +147,7 @@ class BaseProvider(ABC):
 
         key = (path, transform)
 
-        if self._has_not_expired(key):
+        if not force_update and self._has_not_expired(key):
             return self.store[key].value
 
         try:

--- a/aws_lambda_powertools/utilities/parameters/secrets.py
+++ b/aws_lambda_powertools/utilities/parameters/secrets.py
@@ -94,7 +94,7 @@ class SecretsProvider(BaseProvider):
 
 
 def get_secret(
-    name: str, transform: Optional[str] = None, force_update: bool = False, **sdk_options
+    name: str, transform: Optional[str] = None, force_fetch: bool = False, **sdk_options
 ) -> Union[str, dict, bytes]:
     """
     Retrieve a parameter value from AWS Secrets Manager
@@ -105,7 +105,7 @@ def get_secret(
         Name of the parameter
     transform: str, optional
         Transforms the content from a JSON object ('json') or base64 binary string ('binary')
-    force_update: bool, optional
+    force_fetch: bool, optional
         Force update even before a cached item has expired, defaults to False
     sdk_options: dict, optional
         Dictionary of options that will be passed to the get_secret_value call
@@ -143,4 +143,4 @@ def get_secret(
     if "secrets" not in DEFAULT_PROVIDERS:
         DEFAULT_PROVIDERS["secrets"] = SecretsProvider()
 
-    return DEFAULT_PROVIDERS["secrets"].get(name, transform=transform, force_update=force_update, **sdk_options)
+    return DEFAULT_PROVIDERS["secrets"].get(name, transform=transform, force_fetch=force_fetch, **sdk_options)

--- a/aws_lambda_powertools/utilities/parameters/secrets.py
+++ b/aws_lambda_powertools/utilities/parameters/secrets.py
@@ -93,7 +93,9 @@ class SecretsProvider(BaseProvider):
         raise NotImplementedError()
 
 
-def get_secret(name: str, transform: Optional[str] = None, **sdk_options) -> Union[str, dict, bytes]:
+def get_secret(
+    name: str, transform: Optional[str] = None, force_update: bool = False, **sdk_options
+) -> Union[str, dict, bytes]:
     """
     Retrieve a parameter value from AWS Secrets Manager
 
@@ -103,6 +105,8 @@ def get_secret(name: str, transform: Optional[str] = None, **sdk_options) -> Uni
         Name of the parameter
     transform: str, optional
         Transforms the content from a JSON object ('json') or base64 binary string ('binary')
+    force_update: bool, optional
+        Force update even before a cached item has expired, defaults to False
     sdk_options: dict, optional
         Dictionary of options that will be passed to the get_secret_value call
 
@@ -139,4 +143,4 @@ def get_secret(name: str, transform: Optional[str] = None, **sdk_options) -> Uni
     if "secrets" not in DEFAULT_PROVIDERS:
         DEFAULT_PROVIDERS["secrets"] = SecretsProvider()
 
-    return DEFAULT_PROVIDERS["secrets"].get(name, transform=transform, **sdk_options)
+    return DEFAULT_PROVIDERS["secrets"].get(name, transform=transform, force_update=force_update, **sdk_options)

--- a/aws_lambda_powertools/utilities/parameters/ssm.py
+++ b/aws_lambda_powertools/utilities/parameters/ssm.py
@@ -188,7 +188,7 @@ class SSMProvider(BaseProvider):
 
 
 def get_parameter(
-    name: str, transform: Optional[str] = None, decrypt: bool = False, **sdk_options
+    name: str, transform: Optional[str] = None, decrypt: bool = False, force_update: bool = False, **sdk_options
 ) -> Union[str, list, dict, bytes]:
     """
     Retrieve a parameter value from AWS Systems Manager (SSM) Parameter Store
@@ -201,6 +201,8 @@ def get_parameter(
         Transforms the content from a JSON object ('json') or base64 binary string ('binary')
     decrypt: bool, optional
         If the parameter values should be decrypted
+    force_update: bool, optional
+        Force update even before a cached item has expired
     sdk_options: dict, optional
         Dictionary of options that will be passed to the Parameter Store get_parameter API call
 
@@ -240,7 +242,7 @@ def get_parameter(
     # Add to `decrypt` sdk_options to we can have an explicit option for this
     sdk_options["decrypt"] = decrypt
 
-    return DEFAULT_PROVIDERS["ssm"].get(name, transform=transform, **sdk_options)
+    return DEFAULT_PROVIDERS["ssm"].get(name, transform=transform, force_update=force_update, **sdk_options)
 
 
 def get_parameters(

--- a/aws_lambda_powertools/utilities/parameters/ssm.py
+++ b/aws_lambda_powertools/utilities/parameters/ssm.py
@@ -111,7 +111,7 @@ class SSMProvider(BaseProvider):
         decrypt: bool, optional
             If the parameter value should be decrypted
         force_update: bool, optional
-            Force update even before a cached item has expired
+            Force update even before a cached item has expired, defaults to False
         sdk_options: dict, optional
             Arguments that will be passed directly to the underlying API call
 
@@ -202,7 +202,7 @@ def get_parameter(
     decrypt: bool, optional
         If the parameter values should be decrypted
     force_update: bool, optional
-        Force update even before a cached item has expired
+        Force update even before a cached item has expired, defaults to False
     sdk_options: dict, optional
         Dictionary of options that will be passed to the Parameter Store get_parameter API call
 
@@ -246,7 +246,12 @@ def get_parameter(
 
 
 def get_parameters(
-    path: str, transform: Optional[str] = None, recursive: bool = True, decrypt: bool = False, **sdk_options
+    path: str,
+    transform: Optional[str] = None,
+    recursive: bool = True,
+    decrypt: bool = False,
+    force_update: bool = False,
+    **sdk_options
 ) -> Union[Dict[str, str], Dict[str, dict], Dict[str, bytes]]:
     """
     Retrieve multiple parameter values from AWS Systems Manager (SSM) Parameter Store
@@ -261,6 +266,8 @@ def get_parameters(
         If this should retrieve the parameter values recursively or not, defaults to True
     decrypt: bool, optional
         If the parameter values should be decrypted
+    force_update: bool, optional
+        Force update even before a cached item has expired, defaults to False
     sdk_options: dict, optional
         Dictionary of options that will be passed to the Parameter Store get_parameters_by_path API call
 
@@ -300,4 +307,4 @@ def get_parameters(
     sdk_options["recursive"] = recursive
     sdk_options["decrypt"] = decrypt
 
-    return DEFAULT_PROVIDERS["ssm"].get_multiple(path, transform=transform, **sdk_options)
+    return DEFAULT_PROVIDERS["ssm"].get_multiple(path, transform=transform, force_update=force_update, **sdk_options)

--- a/aws_lambda_powertools/utilities/parameters/ssm.py
+++ b/aws_lambda_powertools/utilities/parameters/ssm.py
@@ -92,7 +92,7 @@ class SSMProvider(BaseProvider):
         max_age: int = DEFAULT_MAX_AGE_SECS,
         transform: Optional[str] = None,
         decrypt: bool = False,
-        force_update: bool = False,
+        force_fetch: bool = False,
         **sdk_options
     ) -> Union[str, list, dict, bytes]:
         """
@@ -110,7 +110,7 @@ class SSMProvider(BaseProvider):
             values.
         decrypt: bool, optional
             If the parameter value should be decrypted
-        force_update: bool, optional
+        force_fetch: bool, optional
             Force update even before a cached item has expired, defaults to False
         sdk_options: dict, optional
             Arguments that will be passed directly to the underlying API call
@@ -127,7 +127,7 @@ class SSMProvider(BaseProvider):
         # Add to `decrypt` sdk_options to we can have an explicit option for this
         sdk_options["decrypt"] = decrypt
 
-        return super().get(name, max_age, transform, force_update, **sdk_options)
+        return super().get(name, max_age, transform, force_fetch, **sdk_options)
 
     def _get(self, name: str, decrypt: bool = False, **sdk_options) -> str:
         """
@@ -188,7 +188,7 @@ class SSMProvider(BaseProvider):
 
 
 def get_parameter(
-    name: str, transform: Optional[str] = None, decrypt: bool = False, force_update: bool = False, **sdk_options
+    name: str, transform: Optional[str] = None, decrypt: bool = False, force_fetch: bool = False, **sdk_options
 ) -> Union[str, list, dict, bytes]:
     """
     Retrieve a parameter value from AWS Systems Manager (SSM) Parameter Store
@@ -201,7 +201,7 @@ def get_parameter(
         Transforms the content from a JSON object ('json') or base64 binary string ('binary')
     decrypt: bool, optional
         If the parameter values should be decrypted
-    force_update: bool, optional
+    force_fetch: bool, optional
         Force update even before a cached item has expired, defaults to False
     sdk_options: dict, optional
         Dictionary of options that will be passed to the Parameter Store get_parameter API call
@@ -242,7 +242,7 @@ def get_parameter(
     # Add to `decrypt` sdk_options to we can have an explicit option for this
     sdk_options["decrypt"] = decrypt
 
-    return DEFAULT_PROVIDERS["ssm"].get(name, transform=transform, force_update=force_update, **sdk_options)
+    return DEFAULT_PROVIDERS["ssm"].get(name, transform=transform, force_fetch=force_fetch, **sdk_options)
 
 
 def get_parameters(
@@ -250,7 +250,7 @@ def get_parameters(
     transform: Optional[str] = None,
     recursive: bool = True,
     decrypt: bool = False,
-    force_update: bool = False,
+    force_fetch: bool = False,
     **sdk_options
 ) -> Union[Dict[str, str], Dict[str, dict], Dict[str, bytes]]:
     """
@@ -266,7 +266,7 @@ def get_parameters(
         If this should retrieve the parameter values recursively or not, defaults to True
     decrypt: bool, optional
         If the parameter values should be decrypted
-    force_update: bool, optional
+    force_fetch: bool, optional
         Force update even before a cached item has expired, defaults to False
     sdk_options: dict, optional
         Dictionary of options that will be passed to the Parameter Store get_parameters_by_path API call
@@ -307,4 +307,4 @@ def get_parameters(
     sdk_options["recursive"] = recursive
     sdk_options["decrypt"] = decrypt
 
-    return DEFAULT_PROVIDERS["ssm"].get_multiple(path, transform=transform, force_update=force_update, **sdk_options)
+    return DEFAULT_PROVIDERS["ssm"].get_multiple(path, transform=transform, force_fetch=force_fetch, **sdk_options)

--- a/aws_lambda_powertools/utilities/parameters/ssm.py
+++ b/aws_lambda_powertools/utilities/parameters/ssm.py
@@ -92,6 +92,7 @@ class SSMProvider(BaseProvider):
         max_age: int = DEFAULT_MAX_AGE_SECS,
         transform: Optional[str] = None,
         decrypt: bool = False,
+        force_update: bool = False,
         **sdk_options
     ) -> Union[str, list, dict, bytes]:
         """
@@ -109,6 +110,8 @@ class SSMProvider(BaseProvider):
             values.
         decrypt: bool, optional
             If the parameter value should be decrypted
+        force_update: bool, optional
+            Force update even before a cached item has expired
         sdk_options: dict, optional
             Arguments that will be passed directly to the underlying API call
 
@@ -124,7 +127,7 @@ class SSMProvider(BaseProvider):
         # Add to `decrypt` sdk_options to we can have an explicit option for this
         sdk_options["decrypt"] = decrypt
 
-        return super().get(name, max_age, transform, **sdk_options)
+        return super().get(name, max_age, transform, force_update, **sdk_options)
 
     def _get(self, name: str, decrypt: bool = False, **sdk_options) -> str:
         """

--- a/tests/functional/test_utilities_parameters.py
+++ b/tests/functional/test_utilities_parameters.py
@@ -1667,7 +1667,7 @@ def test_get_transform_method_preserve_auto_unhandled(key):
 
 def test_base_provider_get_multiple_force_update(mock_name, mock_value):
     """
-    Test BaseProvider.get_multiple()  with cached values and force_update is True
+    Test BaseProvider.get_multiple()  with cached values and force_fetch is True
     """
 
     class TestProvider(BaseProvider):
@@ -1682,7 +1682,7 @@ def test_base_provider_get_multiple_force_update(mock_name, mock_value):
 
     provider.store[(mock_name, None)] = ExpirableValue({"B": mock_value}, datetime.now() + timedelta(seconds=60))
 
-    value = provider.get_multiple(mock_name, force_update=True)
+    value = provider.get_multiple(mock_name, force_fetch=True)
 
     assert isinstance(value, dict)
     assert value["A"] == mock_value
@@ -1690,7 +1690,7 @@ def test_base_provider_get_multiple_force_update(mock_name, mock_value):
 
 def test_base_provider_get_force_update(mock_name, mock_value):
     """
-    Test BaseProvider.get()  with cached values and force_update is True
+    Test BaseProvider.get()  with cached values and force_fetch is True
     """
 
     class TestProvider(BaseProvider):
@@ -1704,7 +1704,7 @@ def test_base_provider_get_force_update(mock_name, mock_value):
 
     provider.store[(mock_name, None)] = ExpirableValue("not-value", datetime.now() + timedelta(seconds=60))
 
-    value = provider.get(mock_name, force_update=True)
+    value = provider.get(mock_name, force_fetch=True)
 
     assert isinstance(value, str)
     assert value == mock_value

--- a/tests/functional/test_utilities_parameters.py
+++ b/tests/functional/test_utilities_parameters.py
@@ -1663,3 +1663,48 @@ def test_get_transform_method_preserve_auto_unhandled(key):
     transform = parameters.base.get_transform_method(key, "auto")
 
     assert transform is None
+
+
+def test_base_provider_get_multiple_force_update(mock_name, mock_value):
+    """
+    Test BaseProvider.get_multiple()  with cached values and force_update is True
+    """
+
+    class TestProvider(BaseProvider):
+        def _get(self, name: str, **kwargs) -> str:
+            raise NotImplementedError()
+
+        def _get_multiple(self, path: str, **kwargs) -> Dict[str, str]:
+            assert path == mock_name
+            return {"A": mock_value}
+
+    provider = TestProvider()
+
+    provider.store[(mock_name, None)] = ExpirableValue({"B": mock_value}, datetime.now() + timedelta(seconds=60))
+
+    value = provider.get_multiple(mock_name, force_update=True)
+
+    assert isinstance(value, dict)
+    assert value["A"] == mock_value
+
+
+def test_base_provider_get_force_update(mock_name, mock_value):
+    """
+    Test BaseProvider.get()  with cached values and force_update is True
+    """
+
+    class TestProvider(BaseProvider):
+        def _get(self, name: str, **kwargs) -> str:
+            return mock_value
+
+        def _get_multiple(self, path: str, **kwargs) -> Dict[str, str]:
+            raise NotImplementedError()
+
+    provider = TestProvider()
+
+    provider.store[(mock_name, None)] = ExpirableValue("not-value", datetime.now() + timedelta(seconds=60))
+
+    value = provider.get(mock_name, force_update=True)
+
+    assert isinstance(value, str)
+    assert value == mock_value


### PR DESCRIPTION
**Issue #, if available:**

https://github.com/awslabs/aws-lambda-powertools-python/issues/131

## Description of changes:

Changes:
- Add new `force_fetch` to always fetch the latest value, even if there is a cached value

Example based on https://github.com/alexcasalboni/ssm-cache-python#complex-invalidation-based-on-signals
```python3
import os
from aws_lambda_powertools.utilities import parameters


class InvalidCredentials(Exception):
    """Raised when client get an invalid credentials error"""


class Client:
    password = None

    def configure(self, password):
        self.password = password

    def read_record(self):
        """Might raise an InvalidCredentials exception """


DB_PASS_PARAM = os.environ["DB_PASS_PARAM"]
db_client = Client()
db_client.configure(parameters.get_parameter(DB_PASS_PARAM))


def refresh_db_password():
    db_client.configure(parameters.get_parameter(DB_PASS_PARAM, force_fetch=True))


def read_record(is_retry=False):
    try:
        return db_client.read_record()
    except InvalidCredentials:
        if not is_retry:  # avoid infinite recursion
            refresh_db_password()  # force parameter refresh
            return read_record(is_retry=True)


def handler(event, context):
    return {"record": read_record()}
```


**Checklist**

<!--- Leave unchecked if your change doesn't seem to apply --> 

* [x] [Meet tenets criteria](https://awslabs.github.io/aws-lambda-powertools-python/#tenets)
* [x] Update tests
* [ ] Update docs
* [x] PR title follows [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-python/blob/376ec0a2ac0d2a40e0af5717bef42ff84ca0d1b9/.github/semantic.yml#L2)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
