### PR TITLE
docs(tracer): Fix Tracer typing hinting for Pycharm

### DIFF
--- a/aws_lambda_powertools/tracing/tracer.py
+++ b/aws_lambda_powertools/tracing/tracer.py
@@ -155,7 +155,7 @@ class Tracer:
         self.__build_config(
             service=service, disabled=disabled, auto_patch=auto_patch, patch_modules=patch_modules, provider=provider
         )
-        self.provider = self._config["provider"]
+        self.provider: BaseProvider = self._config["provider"]
         self.disabled = self._config["disabled"]
         self.service = self._config["service"]
         self.auto_patch = self._config["auto_patch"]

--- a/aws_lambda_powertools/tracing/tracer.py
+++ b/aws_lambda_powertools/tracing/tracer.py
@@ -155,7 +155,7 @@ class Tracer:
         self.__build_config(
             service=service, disabled=disabled, auto_patch=auto_patch, patch_modules=patch_modules, provider=provider
         )
-        self.provider: BaseProvider = self._config["provider"]
+        self.provider = self._config["provider"]
         self.disabled = self._config["disabled"]
         self.service = self._config["service"]
         self.auto_patch = self._config["auto_patch"]

--- a/aws_lambda_powertools/tracing/tracer.py
+++ b/aws_lambda_powertools/tracing/tracer.py
@@ -55,6 +55,13 @@ class Tracer:
         `Env POWERTOOLS_TRACE_DISABLED="true"`
     patch_modules: Tuple[str]
         Tuple of modules supported by tracing provider to patch, by default all modules are patched
+    provider: BaseProvider
+        Tracing provider, by default it is aws_xray_sdk.core.xray_recorder
+
+    Returns
+    -------
+    Tracer
+        Tracer instance with imported modules patched
 
     Example
     -------
@@ -123,17 +130,12 @@ class Tracer:
         tracer = Tracer()
         ...
 
-    Returns
-    -------
-    Tracer
-        Tracer instance with imported modules patched
-
     Limitations
     -----------
     * Async handler not supported
     """
 
-    _default_config = {
+    _default_config: Dict[str, Any] = {
         "service": "service_undefined",
         "disabled": False,
         "auto_patch": True,
@@ -153,7 +155,7 @@ class Tracer:
         self.__build_config(
             service=service, disabled=disabled, auto_patch=auto_patch, patch_modules=patch_modules, provider=provider
         )
-        self.provider = self._config["provider"]
+        self.provider: BaseProvider = self._config["provider"]
         self.disabled = self._config["disabled"]
         self.service = self._config["service"]
         self.auto_patch = self._config["auto_patch"]


### PR DESCRIPTION
**Issue #, if available:**

Typing for Tracer seems to be broken on PyCharm, see screenshot below:

<img width="342" alt="Screen Shot 2021-03-17 at 6 39 54 AM" src="https://user-images.githubusercontent.com/5442469/111476994-e86fa700-86eb-11eb-85c9-c81680def1f2.png">

The location of the `Returns` doc string is causing the PyCharm linter to thing that `Tracer` is  a tuple (possibly also due to the `_default_config` and `_config` before the `__init__` ? 


## Description of changes:

Changes:
* Move up `Returns` to just below the `Parameters`
* Add type hinting for `provider` 
* Add docstring for `provider`

**Checklist**

<!--- Leave unchecked if your change doesn't seem to apply --> 

* [x] [Meet tenets criteria](https://awslabs.github.io/aws-lambda-powertools-python/#tenets)
* [x] Update tests
* [x] Update docs
* [x] PR title follows [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-python/blob/376ec0a2ac0d2a40e0af5717bef42ff84ca0d1b9/.github/semantic.yml#L2)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
