### PR TITLE
docs: Fix layers example template config

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -49,7 +49,7 @@ If using SAM, you can include this SAR App as part of your shared Layers stack, 
 
 === "template.yml"
 
-```yaml hl_lines="5-6 12-14"
+```yaml hl_lines="5-6 12-13"
 AwsLambdaPowertoolsPythonLayer:
   Type: AWS::Serverless::Application
   Properties:
@@ -60,10 +60,9 @@ AwsLambdaPowertoolsPythonLayer:
 MyLambdaFunction:
   Type: AWS::Serverless::Function
   Properties:
-	Location:
-	  Layers:
-	     # fetch Layer ARN from SAR App stack output
-	     - !GetAtt AwsLambdaPowertoolsPythonLayer.Outputs.LayerVersionArn
+  	Layers:
+      	  # fetch Layer ARN from SAR App stack output
+	  - !GetAtt AwsLambdaPowertoolsPythonLayer.Outputs.LayerVersionArn
 ```
 
 ??? tip "Example of least-privileged IAM permissions to deploy Layer"


### PR DESCRIPTION
## Description of changes:

Remove `Location` key from the `MyLambdaFunction` resource in the example template.yml.
According to the [ref docs](https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/sam-resource-function.html), `Layers` shouldn't be nested under `Location` 

This tripped me up so I thought I would offer to fix it.

**Checklist**

<!--- Leave unchecked if your change doesn't seem to apply --> 

* [x] [Meet tenets criteria](https://awslabs.github.io/aws-lambda-powertools-python/#tenets)
* [ ] Update tests
* [x] Update docs
* [x] PR title follows [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-python/blob/376ec0a2ac0d2a40e0af5717bef42ff84ca0d1b9/.github/semantic.yml#L2)

## Breaking change checklist

<!--- Ignore if it's not a breaking change -->

**RFC issue #**:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
