### PR TITLE
fix(data-classes): Add missing operationName

### DIFF
--- a/aws_lambda_powertools/utilities/data_classes/api_gateway_proxy_event.py
+++ b/aws_lambda_powertools/utilities/data_classes/api_gateway_proxy_event.py
@@ -195,6 +195,11 @@ class APIGatewayEventRequestContext(DictWrapper):
         """The selected route key."""
         return self["requestContext"].get("routeKey")
 
+    @property
+    def operation_name(self) -> Optional[str]:
+        """The name of the operation being performed"""
+        return self["requestContext"].get("operationName")
+
 
 class APIGatewayProxyEvent(BaseProxyEvent):
     """AWS Lambda proxy V1

--- a/tests/functional/test_lambda_trigger_events.py
+++ b/tests/functional/test_lambda_trigger_events.py
@@ -704,6 +704,7 @@ def test_api_gateway_proxy_event():
     assert request_context.message_direction is None
     assert request_context.message_id is None
     assert request_context.route_key is None
+    assert request_context.operation_name is None
     assert identity.api_key is None
     assert identity.api_key_id is None
 


### PR DESCRIPTION
**Issue #, if available:**

https://github.com/awslabs/aws-lambda-powertools-python/issues/371

## Description of changes:

Add missing field `operationName` 

**Checklist**

<!--- Leave unchecked if your change doesn't seem to apply --> 

* [x] [Meet tenets criteria](https://awslabs.github.io/aws-lambda-powertools-python/#tenets)
* [x] Update tests
* [x] Update docs
* [x] PR title follows [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-python/blob/376ec0a2ac0d2a40e0af5717bef42ff84ca0d1b9/.github/semantic.yml#L2)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
