### PR TITLE
feat(parameter): add dynamodb_endpoint_url for local_testing

### DIFF
--- a/aws_lambda_powertools/utilities/parameters/dynamodb.py
+++ b/aws_lambda_powertools/utilities/parameters/dynamodb.py
@@ -27,7 +27,7 @@ class DynamoDBProvider(BaseProvider):
     value_attr: str, optional
         Attribute that contains the values in the DynamoDB table (defaults to 'value')
     endpoint_url: str, optional
-        Complete url to reference local DynamoDB instance
+        Complete url to reference local DynamoDB instance, e.g. http://localhost:8080
     config: botocore.config.Config, optional
         Botocore configuration to pass during client initialization
 

--- a/aws_lambda_powertools/utilities/parameters/dynamodb.py
+++ b/aws_lambda_powertools/utilities/parameters/dynamodb.py
@@ -26,6 +26,8 @@ class DynamoDBProvider(BaseProvider):
         Name of the DynamoDB table sort key (defaults to 'sk'), used only for get_multiple
     value_attr: str, optional
         Attribute that contains the values in the DynamoDB table (defaults to 'value')
+    endpoint_url: str, optional
+        Complete url to reference local DynamoDB instance
     config: botocore.config.Config, optional
         Botocore configuration to pass during client initialization
 

--- a/aws_lambda_powertools/utilities/parameters/dynamodb.py
+++ b/aws_lambda_powertools/utilities/parameters/dynamodb.py
@@ -150,6 +150,7 @@ class DynamoDBProvider(BaseProvider):
         key_attr: str = "id",
         sort_attr: str = "sk",
         value_attr: str = "value",
+        endpoint_url: Optional[str] = None,
         config: Optional[Config] = None,
     ):
         """
@@ -157,7 +158,7 @@ class DynamoDBProvider(BaseProvider):
         """
 
         config = config or Config()
-        self.table = boto3.resource("dynamodb", config=config).Table(table_name)
+        self.table = boto3.resource("dynamodb", endpoint_url=endpoint_url, config=config).Table(table_name)
 
         self.key_attr = key_attr
         self.sort_attr = sort_attr

--- a/docs/utilities/parameters.md
+++ b/docs/utilities/parameters.md
@@ -196,10 +196,11 @@ The AWS Systems Manager Parameter Store provider supports two additional argumen
 
 The DynamoDB Provider does not have any high-level functions, as it needs to know the name of the DynamoDB table containing the parameters.
 
-**Local testing with DynamoDB**
+##### Local testing with DynamoDB Local
 
-You can initiliazare DynamoDB provider for [local dynamodb](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/DynamoDBLocal.html) with this configuration:
-```python hl_lines="3 7"
+You can initialize the DynamoDB provider pointing to [DynamoDB Local](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/DynamoDBLocal.html) using **`endpoint_url`** parameter:
+
+```python hl_lines="3"
 from aws_lambda_powertools.utilities import parameters
 
 dynamodb_provider = parameters.DynamoDBProvider(table_name="my-table", endpoint_url: "http://localhost:8000")

--- a/docs/utilities/parameters.md
+++ b/docs/utilities/parameters.md
@@ -196,15 +196,16 @@ The AWS Systems Manager Parameter Store provider supports two additional argumen
 
 The DynamoDB Provider does not have any high-level functions, as it needs to know the name of the DynamoDB table containing the parameters.
 
-##### Local testing with DynamoDB Local
+**Local testing with DynamoDB Local**
 
 You can initialize the DynamoDB provider pointing to [DynamoDB Local](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/DynamoDBLocal.html) using **`endpoint_url`** parameter:
 
-```python hl_lines="3"
-from aws_lambda_powertools.utilities import parameters
+=== "dynamodb_local.py"
+	```python hl_lines="3"
+	from aws_lambda_powertools.utilities import parameters
 
-dynamodb_provider = parameters.DynamoDBProvider(table_name="my-table", endpoint_url: "http://localhost:8000")
-```
+	dynamodb_provider = parameters.DynamoDBProvider(table_name="my-table", endpoint_url: "http://localhost:8000")
+	```
 
 **DynamoDB table structure for single parameters**
 

--- a/docs/utilities/parameters.md
+++ b/docs/utilities/parameters.md
@@ -204,7 +204,7 @@ You can initialize the DynamoDB provider pointing to [DynamoDB Local](https://do
 	```python hl_lines="3"
 	from aws_lambda_powertools.utilities import parameters
 
-	dynamodb_provider = parameters.DynamoDBProvider(table_name="my-table", endpoint_url: "http://localhost:8000")
+	dynamodb_provider = parameters.DynamoDBProvider(table_name="my-table", endpoint_url="http://localhost:8000")
 	```
 
 **DynamoDB table structure for single parameters**

--- a/docs/utilities/parameters.md
+++ b/docs/utilities/parameters.md
@@ -196,6 +196,15 @@ The AWS Systems Manager Parameter Store provider supports two additional argumen
 
 The DynamoDB Provider does not have any high-level functions, as it needs to know the name of the DynamoDB table containing the parameters.
 
+**Local testing with DynamoDB**
+
+You can initiliazare DynamoDB provider for [local dynamodb](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/DynamoDBLocal.html) with this configuration:
+```python hl_lines="3 7"
+from aws_lambda_powertools.utilities import parameters
+
+dynamodb_provider = parameters.DynamoDBProvider(table_name="my-table", endpoint_url: "http://localhost:8000")
+```
+
 **DynamoDB table structure for single parameters**
 
 For single parameters, you must use `id` as the [partition key](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/HowItWorks.CoreComponents.html#HowItWorks.CoreComponents.PrimaryKey) for that table.


### PR DESCRIPTION
**Issue #, if available:**

## Description of changes:

This feature allows capturing to use this library also with dynamodb running locally with docker

**Checklist**

<!--- Leave unchecked if your change doesn't seem to apply --> 

* [x] [Meet tenets criteria](https://awslabs.github.io/aws-lambda-powertools-python/#tenets)
* [ ] Update tests
* [x] Update docs
* [x] PR title follows [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-python/blob/376ec0a2ac0d2a40e0af5717bef42ff84ca0d1b9/.github/semantic.yml#L2)

## Breaking change checklist

<!--- Ignore if it's not a breaking change -->

**RFC issue #**:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
