### PR TITLE
fix(idempotent): Correctly raise IdempotencyKeyError

### DIFF
--- a/aws_lambda_powertools/utilities/idempotency/idempotency.py
+++ b/aws_lambda_powertools/utilities/idempotency/idempotency.py
@@ -11,6 +11,7 @@ from aws_lambda_powertools.utilities.idempotency.exceptions import (
     IdempotencyInconsistentStateError,
     IdempotencyItemAlreadyExistsError,
     IdempotencyItemNotFoundError,
+    IdempotencyKeyError,
     IdempotencyPersistenceLayerError,
     IdempotencyValidationError,
 )
@@ -132,6 +133,8 @@ class IdempotencyHandler:
             # We call save_inprogress first as an optimization for the most common case where no idempotent record
             # already exists. If it succeeds, there's no need to call get_record.
             self.persistence_store.save_inprogress(event=self.event, context=self.context)
+        except IdempotencyKeyError as e:
+            raise e
         except IdempotencyItemAlreadyExistsError:
             # Now we know the item already exists, we can retrieve it
             record = self._get_idempotency_record()

--- a/aws_lambda_powertools/utilities/idempotency/idempotency.py
+++ b/aws_lambda_powertools/utilities/idempotency/idempotency.py
@@ -133,8 +133,8 @@ class IdempotencyHandler:
             # We call save_inprogress first as an optimization for the most common case where no idempotent record
             # already exists. If it succeeds, there's no need to call get_record.
             self.persistence_store.save_inprogress(event=self.event, context=self.context)
-        except IdempotencyKeyError as e:
-            raise e
+        except IdempotencyKeyError:
+            raise
         except IdempotencyItemAlreadyExistsError:
             # Now we know the item already exists, we can retrieve it
             record = self._get_idempotency_record()


### PR DESCRIPTION
**Issue #, if available:**

## Description of changes:

Idempotent handler is currently returning `IdempotencyPersistenceLayerError` instead of the `IdempotencyKeyError`

**Checklist**

<!--- Leave unchecked if your change doesn't seem to apply --> 

* [x] [Meet tenets criteria](https://awslabs.github.io/aws-lambda-powertools-python/#tenets)
* [x] Update tests
* [x] Update docs
* [x] PR title follows [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-python/blob/376ec0a2ac0d2a40e0af5717bef42ff84ca0d1b9/.github/semantic.yml#L2)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
