### PR TITLE
docs: Fix doc links and line highlights

### DIFF
--- a/docs/core/event_handler.md
+++ b/docs/core/event_handler.md
@@ -6,7 +6,7 @@ description: Utility
 Event handler decorators for common Lambda events
 
 
-### AppSync Resolver Decorator
+## AppSync Resolver Decorator
 
 > New in 1.14.0
 
@@ -15,7 +15,7 @@ AppSync resolver decorator is a concise way to create lambda functions to handle
 [AppSync Resolver ](/utilities/data_classes#appsync-resolver) data class and therefore works with [Amplify GraphQL Transform Library](https://docs.amplify.aws/cli/graphql-transformer/function){target="_blank"} (`@function`),
 and [AppSync Direct Lambda Resolvers](https://aws.amazon.com/blogs/mobile/appsync-direct-lambda/){target="_blank"}
 
-#### Key Features
+### Key Features
 
 * Works with any of the existing Powertools utilities by allow you to create your own `lambda_handler` function
 * Supports an implicit handler where in `app = AppSyncResolver()` can be invoked directly as `app(event, context)`
@@ -24,7 +24,7 @@ and [AppSync Direct Lambda Resolvers](https://aws.amazon.com/blogs/mobile/appsyn
 * AppSyncResolver includes `current_event` and `lambda_cotext` fields can be used to pass in the original `AppSyncResolver` or `LambdaContext`
  objects
 
-####  Amplify GraphQL Example
+###  Amplify GraphQL Example
 
 Create a new GraphQL api via `amplify add api` and add the following to the new `schema.graphql`
 

--- a/docs/core/logger.md
+++ b/docs/core/logger.md
@@ -3,7 +3,6 @@ title: Logger
 description: Core utility
 ---
 
-
 Logger provides an opinionated logger with output structured as JSON.
 
 ## Key features

--- a/docs/core/tracer.md
+++ b/docs/core/tracer.md
@@ -41,7 +41,7 @@ Before your use this utility, your AWS Lambda function [must have permissions](h
 You can quickly start by importing the `Tracer` class, initialize it outside the Lambda handler, and use `capture_lambda_handler` decorator.
 
 === "app.py"
-	```python hl_lines="1 3 7"
+	```python hl_lines="1 3 6"
 	from aws_lambda_powertools import Tracer
 
 	tracer = Tracer() # Sets service via env var

--- a/docs/utilities/batch.md
+++ b/docs/utilities/batch.md
@@ -54,7 +54,7 @@ Before your use this utility, your AWS Lambda function must have `sqs:DeleteMess
 
 ### Processing messages from SQS
 
-You can use either **[sqs_batch_processor](#sqs_batch_processor-decorator)** decorator, or **[PartialSQSProcessor](#partialsqsprocessor-context-manager)** as a context manager if you'd like access to the processed results.
+You can use either `sqs_batch_processor` decorator, or `PartialSQSProcessor` as a context manager if you'd like access to the processed results.
 
 You need to create a function to handle each record from the batch - We call it `record_handler` from here on.
 

--- a/docs/utilities/idempotency.md
+++ b/docs/utilities/idempotency.md
@@ -124,7 +124,7 @@ You can quickly start by initializing the `DynamoDBPersistenceLayer` class and u
 !!! tip "Dealing with always changing payloads"
     When dealing with a more elaborate payload, where parts of the payload always change, you should use **`event_key_jmespath`** parameter.
 
-Use [`IdempotencyConfig`](#customizing-the-default-behaviour) to instruct the idempotent decorator to only use a portion of your payload to verify whether a request is idempotent, and therefore it should not be retried.
+Use [`IdempotencyConfig`](#customizing-the-default-behavior) to instruct the idempotent decorator to only use a portion of your payload to verify whether a request is idempotent, and therefore it should not be retried.
 
 > **Payment scenario**
 

--- a/docs/utilities/middleware_factory.md
+++ b/docs/utilities/middleware_factory.md
@@ -3,11 +3,9 @@ title: Middleware factory
 description: Utility
 ---
 
-
-
 Middleware factory provides a decorator factory to create your own middleware to run logic before, and after each Lambda invocation synchronously.
 
-**Key features**
+## Key features
 
 * Run logic before, after, and handle exceptions
 * Trace each middleware when requested

--- a/docs/utilities/parameters.md
+++ b/docs/utilities/parameters.md
@@ -4,7 +4,7 @@ description: Utility
 ---
 
 
-The parameters utility provides high-level functions to retrieve one or multiple parameter values from [AWS Systems Manager Parameter Store](https://docs.aws.amazon.com/systems-manager/latest/userguide/systems-manager-parameter-store.html){target="_blank"}, [AWS Secrets Manager](https://aws.amazon.com/secrets-manager/), [AWS AppConfig](https://aws.amazon.com/appconfig/){target="_blank"}, [Amazon DynamoDB](https://aws.amazon.com/dynamodb/){target="_blank"}, or bring your own.
+The parameters utility provides high-level functions to retrieve one or multiple parameter values from [AWS Systems Manager Parameter Store](https://docs.aws.amazon.com/systems-manager/latest/userguide/systems-manager-parameter-store.html){target="_blank"}, [AWS Secrets Manager](https://aws.amazon.com/secrets-manager/){target="_blank"}, [AWS AppConfig](https://docs.aws.amazon.com/appconfig/latest/userguide/what-is-appconfig.html){target="_blank"}, [Amazon DynamoDB](https://aws.amazon.com/dynamodb/){target="_blank"}, or bring your own.
 
 ## Key features
 

--- a/docs/utilities/parser.md
+++ b/docs/utilities/parser.md
@@ -5,7 +5,7 @@ description: Utility
 
 This utility provides data parsing and deep validation using [Pydantic](https://pydantic-docs.helpmanual.io/).
 
-**Key features**
+## Key features
 
 * Defines data in pure Python classes, then parse, validate and extract only what you want
 * Built-in envelopes to unwrap, extend, and validate popular event sources payloads

--- a/docs/utilities/validation.md
+++ b/docs/utilities/validation.md
@@ -3,10 +3,9 @@ title: Validation
 description: Utility
 ---
 
-
 This utility provides JSON Schema validation for events and responses, including JMESPath support to unwrap events before validation.
 
-**Key features**
+## Key features
 
 * Validate incoming event and response
 * JMESPath support to unwrap events before validation applies


### PR DESCRIPTION
**Issue #, if available:**

## Description of changes:

Changes:
- docs(batch): Remove archors for `sqs_batch_processor` and `PartialSQSProcessor`
- docs(idempotency): Fix link for `IdempotencyConfig`
- docs(paramters): Fix link for `AWS AppConfig`
- docs(tracer): Fix link highlight for `capture_lambda_handler`
- docs: Consitently format Key Features

**Checklist**

<!--- Leave unchecked if your change doesn't seem to apply --> 

* [x] [Meet tenets criteria](https://awslabs.github.io/aws-lambda-powertools-python/#tenets)
* [x] Update tests
* [x] Update docs
* [x] PR title follows [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-python/blob/376ec0a2ac0d2a40e0af5717bef42ff84ca0d1b9/.github/semantic.yml#L2)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
