### PR TITLE
docs(idempotency): add default table configuration for those not using IaC

### DIFF
--- a/docs/utilities/idempotency.md
+++ b/docs/utilities/idempotency.md
@@ -30,19 +30,26 @@ times with the same parameters**. This makes idempotent operations safe to retry
 
 ### Required resources
 
-Before getting started, you need to create a persistent storage layer where the idempotency utility can store its
-state - your lambda functions will need read and write access to it.
+Before getting started, you need to create a persistent storage layer where the idempotency utility can store its state - your lambda functions will need read and write access to it.
 
 As of now, Amazon DynamoDB is the only supported persistent storage layer, so you'll need to create a table first.
+
+**Default table configuration**
+
+If you're not [changing the default configuration for the DynamoDB persistence layer](#dynamodbpersistencelayer), this is the expected default configuration:
+
+Configuration | Value | Notes
+------------------------------------------------- | ------------------------------------------------- | -------------------------------------------------
+Partition key | `id` |
+TTL attribute name | `expiration` | This can only be configured after your table is created if you're using AWS Console
+
+
+!!! tip "You can share a single state table for all functions"
+    You can reuse the same DynamoDB table to store idempotency state. We add your `function_name` in addition to the idempotency key as a hash key.
 
 > Example using AWS Serverless Application Model (SAM)
 
 === "template.yml"
-
-	!!! tip "You can share a single state table for all functions"
-		> New in 1.12.0
-
-		You can reuse the same DynamoDB table to store idempotency state. We add your function_name in addition to the idempotency key as a hash key.
 
     ```yaml hl_lines="5-13 21-23"
     Resources:


### PR DESCRIPTION
**Issue #, if available:** #377

## Description of changes:

<!--- One or two sentences as a summary of what's being changed -->

**Checklist**

<!--- Leave unchecked if your change doesn't seem to apply --> 

* [ ] [Meet tenets criteria](https://awslabs.github.io/aws-lambda-powertools-python/#tenets)
* [ ] Update tests
* [x] Update docs
* [ ] PR title follows [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-python/blob/376ec0a2ac0d2a40e0af5717bef42ff84ca0d1b9/.github/semantic.yml#L2)

## Breaking change checklist

<!--- Ignore if it's not a breaking change -->

**RFC issue #**:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
