### PR TITLE
docs(logger): add example on how to set UTC timestamp

### DIFF
--- a/docs/core/logger.md
+++ b/docs/core/logger.md
@@ -531,6 +531,7 @@ Service is what defines the Logger name, including what the Lambda function is r
 For Logger, the `service` is the logging key customers can use to search log operations for one or more functions - For example, **search for all errors, or messages like X, where service is payment**.
 
 ??? tip "Logging output example"
+
     ```json hl_lines="5"
     {
        "timestamp": "2020-05-24 18:17:33,774",
@@ -571,6 +572,7 @@ A common issue when migrating from other Loggers is that `service` might be defi
 
     logger = Logger(child=True)
     ```
+
 === "correct_logger_inheritance.py"
 
     ```python hl_lines="4 10"
@@ -651,6 +653,26 @@ You can also change the order of the following log record keys via the `log_reco
 		"sampling_rate": 0.0
 	}
 	```
+
+#### Setting timestamp to UTC
+
+By default, this Logger and standard logging library emits records using local time timestamp. You can override this behaviour by updating the current converter set in our formatter:
+
+=== "app.py"
+
+    ```python hl_lines="1 3 9"
+    from aws_lambda_powertools import Logger
+
+    import time
+
+    logger = Logger(service="sample_service")
+
+    logger.info("Local time")
+
+    logger._logger.handlers[0].formatter.converter = time.gmtime
+
+    logger.info("GMT time")
+    ```
 
 ## Testing your code
 


### PR DESCRIPTION
**Issue #, if available:**

## Description of changes:

<!--- One or two sentences as a summary of what's being changed -->

**Checklist**

<!--- Leave unchecked if your change doesn't seem to apply --> 

* [ ] [Meet tenets criteria](https://awslabs.github.io/aws-lambda-powertools-python/#tenets)
* [ ] Update tests
* [ ] Update docs
* [ ] PR title follows [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-python/blob/376ec0a2ac0d2a40e0af5717bef42ff84ca0d1b9/.github/semantic.yml#L2)

## Breaking change checklist

<!--- Ignore if it's not a breaking change -->

**RFC issue #**:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
