### PR TITLE
feat: add support to persist default dimensions

### DIFF
--- a/aws_lambda_powertools/metrics/metrics.py
+++ b/aws_lambda_powertools/metrics/metrics.py
@@ -128,6 +128,7 @@ class Metrics(MetricManager):
         lambda_handler: Callable[[Any, Any], Any] = None,
         capture_cold_start_metric: bool = False,
         raise_on_empty_metrics: bool = False,
+        default_dimensions: Dict[str, str] = None,
     ):
         """Decorator to serialize and publish metrics at the end of a function execution.
 
@@ -150,11 +151,13 @@ class Metrics(MetricManager):
         Parameters
         ----------
         lambda_handler : Callable[[Any, Any], Any], optional
-            Lambda function handler, by default None
+            lambda function handler, by default None
         capture_cold_start_metric : bool, optional
-            Captures cold start metric, by default False
+            captures cold start metric, by default False
         raise_on_empty_metrics : bool, optional
-            Raise exception if no metrics are emitted, by default False
+            raise exception if no metrics are emitted, by default False
+        default_dimensions: Dict[str, str], optional
+            metric dimensions as key=value that will always be present
 
         Raises
         ------
@@ -170,11 +173,14 @@ class Metrics(MetricManager):
                 self.log_metrics,
                 capture_cold_start_metric=capture_cold_start_metric,
                 raise_on_empty_metrics=raise_on_empty_metrics,
+                default_dimensions=default_dimensions,
             )
 
         @functools.wraps(lambda_handler)
         def decorate(event, context):
             try:
+                if default_dimensions:
+                    self.set_default_dimensions(**default_dimensions)
                 response = lambda_handler(event, context)
                 if capture_cold_start_metric:
                     self.__add_cold_start_metric(context=context)

--- a/aws_lambda_powertools/metrics/metrics.py
+++ b/aws_lambda_powertools/metrics/metrics.py
@@ -108,9 +108,10 @@ class Metrics(MetricManager):
             def lambda_handler():
                    return True
         """
-        self.default_dimensions.update(**dimensions)
         for name, value in dimensions.items():
             self.add_dimension(name, value)
+
+        self.default_dimensions.update(**dimensions)
 
     def clear_default_dimensions(self):
         self.default_dimensions.clear()
@@ -120,8 +121,7 @@ class Metrics(MetricManager):
         self.metric_set.clear()
         self.dimension_set.clear()
         self.metadata_set.clear()
-        # re-add default dimensions
-        self.dimension_set.update(**self._default_dimensions)
+        self.set_default_dimensions(**self.default_dimensions)  # re-add default dimensions
 
     def log_metrics(
         self,

--- a/docs/core/metrics.md
+++ b/docs/core/metrics.md
@@ -107,11 +107,11 @@ You can create metrics using `add_metric`, and you can create dimensions for all
 
 ### Adding default dimensions
 
-You can add default metric dimensions to ensure they are persisted across Lambda invocations using `set_default_dimenions`.
+You can use either `set_default_dimensions` method or `default_permissions` parameter in `log_metrics` decorator to persist dimensions across Lambda invocations.
 
 If you'd like to remove them at some point, you can use `clear_default_dimensions` method.
 
-=== "Default dimensions"
+=== "set_default_dimensions method"
 
     ```python hl_lines="5"
 	from aws_lambda_powertools import Metrics
@@ -121,6 +121,19 @@ If you'd like to remove them at some point, you can use `clear_default_dimension
 	metrics.set_default_dimensions(environment="prod", another="one")
 
 	@metrics.log_metrics
+	def lambda_handler(evt, ctx):
+		metrics.add_metric(name="SuccessfulBooking", unit=MetricUnit.Count, value=1)
+	```
+=== "with log_metrics decorator"
+
+    ```python hl_lines="5 7"
+	from aws_lambda_powertools import Metrics
+	from aws_lambda_powertools.metrics import MetricUnit
+
+	metrics = Metrics(namespace="ExampleApplication", service="booking")
+	DEFAULT_DIMENSIONS = {"environment": "prod", "another": "one"}
+
+	@metrics.log_metrics(default_dimensions=DEFAULT_DIMENSIONS)
 	def lambda_handler(evt, ctx):
 		metrics.add_metric(name="SuccessfulBooking", unit=MetricUnit.Count, value=1)
 	```

--- a/docs/core/metrics.md
+++ b/docs/core/metrics.md
@@ -109,8 +109,7 @@ You can create metrics using `add_metric`, and you can create dimensions for all
 
 You can add default metric dimensions to ensure they are persisted across Lambda invocations using `set_default_dimenions`.
 
-!!! info "If you'd like to remove them at some point, you can use `clear_default_dimensions` method"
-	Note that they continue to count against the maximum of 9 dimensions.
+If you'd like to remove them at some point, you can use `clear_default_dimensions` method.
 
 === "Default dimensions"
 

--- a/docs/core/metrics.md
+++ b/docs/core/metrics.md
@@ -104,6 +104,8 @@ You can create metrics using `add_metric`, and you can create dimensions for all
 !!! note "Metrics overflow"
 	CloudWatch EMF supports a max of 100 metrics per batch. Metrics utility will flush all metrics when adding the 100th metric. Subsequent metrics, e.g. 101th, will be aggregated into a new EMF object, for your convenience.
 
+!!! warning "Do not create metrics or dimensions outside the handler"
+	Metrics or dimensions added in the global scope will only be added during cold start. Disregard if you that's the intended behaviour.
 
 ### Adding default dimensions
 

--- a/docs/core/metrics.md
+++ b/docs/core/metrics.md
@@ -252,6 +252,8 @@ If it's a cold start invocation, this feature will:
 
 This has the advantage of keeping cold start metric separate from your application metrics, where you might have unrelated dimensions.
 
+!!! info "We do not emit 0 as a value for ColdStart metric for cost reasons. [Let us know](https://github.com/awslabs/aws-lambda-powertools-python/issues/new?assignees=&labels=feature-request%2C+triage&template=feature_request.md&title=) if you'd prefer a flag to override it"
+
 ## Advanced
 
 ### Adding metadata

--- a/docs/core/metrics.md
+++ b/docs/core/metrics.md
@@ -374,7 +374,7 @@ If you prefer setting environment variable for specific tests, and are using Pyt
         metrics = Metrics()
         metrics.clear_metrics()
         metrics_global.is_cold_start = True  # ensure each test has cold start
-		metrics.clear_default_dimensions()   # remove persisted default dimensions, if any
+        metrics.clear_default_dimensions()   # remove persisted default dimensions, if any
         yield
     ```
 

--- a/tests/functional/test_metrics.py
+++ b/tests/functional/test_metrics.py
@@ -15,6 +15,7 @@ from aws_lambda_powertools.metrics.base import MetricManager
 def reset_metric_set():
     metrics = Metrics()
     metrics.clear_metrics()
+    metrics.clear_default_dimensions()
     metrics_global.is_cold_start = True  # ensure each test has cold start
     yield
 

--- a/tests/functional/test_metrics.py
+++ b/tests/functional/test_metrics.py
@@ -749,3 +749,51 @@ def test_metric_manage_metadata_set():
         assert metric.metadata_set == expected_dict
     except AttributeError:
         pytest.fail("AttributeError should not be raised")
+
+
+def test_log_persist_default_dimensions(capsys, metrics, dimensions, namespace):
+    # GIVEN Metrics is initialized and we persist a set of default dimensions
+    my_metrics = Metrics(namespace=namespace)
+    my_metrics.set_default_dimensions(environment="test", log_group="/lambda/test")
+
+    # WHEN we utilize log_metrics to serialize
+    # and flush metrics and clear all metrics and dimensions from memory
+    # at the end of a function execution
+    @my_metrics.log_metrics
+    def lambda_handler(evt, ctx):
+        for metric in metrics:
+            my_metrics.add_metric(**metric)
+
+    lambda_handler({}, {})
+    first_invocation = capture_metrics_output(capsys)
+
+    lambda_handler({}, {})
+    second_invocation = capture_metrics_output(capsys)
+
+    # THEN we should have default dimensions in both outputs
+    assert "environment" in first_invocation
+    assert "environment" in second_invocation
+
+
+def test_clear_default_dimensions(namespace):
+    # GIVEN Metrics is initialized and we persist a set of default dimensions
+    my_metrics = Metrics(namespace=namespace)
+    my_metrics.set_default_dimensions(environment="test", log_group="/lambda/test")
+
+    # WHEN they are removed via clear_default_dimensions method
+    my_metrics.clear_default_dimensions()
+
+    # THEN there should be no default dimensions
+    assert not my_metrics.default_dimensions
+
+
+def test_default_dimensions_across_instances(namespace):
+    # GIVEN Metrics is initialized and we persist a set of default dimensions
+    my_metrics = Metrics(namespace=namespace)
+    my_metrics.set_default_dimensions(environment="test", log_group="/lambda/test")
+
+    # WHEN a new Metrics instance is created
+    same_metrics = Metrics()
+
+    # THEN default dimensions should also be present
+    assert "environment" in same_metrics.default_dimensions


### PR DESCRIPTION
**Issue #, if available:** #406

## Description of changes:

<!--- One or two sentences as a summary of what's being changed -->

**Checklist**

<!--- Leave unchecked if your change doesn't seem to apply --> 

* [x] [Meet tenets criteria](https://awslabs.github.io/aws-lambda-powertools-python/#tenets)
* [x] Update tests
* [x] Update docs
* [x] PR title follows [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-python/blob/376ec0a2ac0d2a40e0af5717bef42ff84ca0d1b9/.github/semantic.yml#L2)
* [x] Add new `set_default_dimensions` method
* [x] Add new `clear_default_dimensions` method
* [x] Docs: Update testing section to inspect Metrics created
* [x] Docs: Update testing section to reset Default Dimensions
* [x] Docs: Banner about adding metrics outside the handler
* [x] Docs: Banner about sparse cold start metrics for cost
* [x] Docs: Add Functional testing section

## UX

Persists two dimensions across all metrics, every Metrics instance throughout the codebase, and across all Lambda invocations.

```python
from aws_lambda_powertools import Metrics
from aws_lambda_powertools.metrics import MetricUnit

metrics = Metrics(namespace="ExampleApplication", service="booking")
metrics.set_default_dimensions(environment="prod", another="one")

@metrics.log_metrics
def lambda_handler(evt, ctx):
  metrics.add_metric(name="SuccessfulBooking", unit=MetricUnit.Count, value=1)
```



## Breaking change checklist

<!--- Ignore if it's not a breaking change -->

**RFC issue #**:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
