### PR TITLE
refactor: simplify custom formatter for minor changes

### DIFF
--- a/aws_lambda_powertools/logging/formatter.py
+++ b/aws_lambda_powertools/logging/formatter.py
@@ -69,7 +69,7 @@ class LambdaPowertoolsFormatter(BasePowertoolsFormatter):
 
         The `log_record_order` kwarg is used to specify the order of the keys used in
         the structured json logs. By default the order is: "level", "location", "message", "timestamp",
-        "service" and "sampling_rate".
+        "service".
 
         Other kwargs are used to specify log field format strings.
 
@@ -113,6 +113,10 @@ class LambdaPowertoolsFormatter(BasePowertoolsFormatter):
         keys_combined = {**self._build_default_keys(), **kwargs}
         self.log_format.update(**keys_combined)
 
+    def serialize(self, log: Dict) -> str:
+        """Serialize structured log dict to JSON str"""
+        return self.json_serializer(log)
+
     def format(self, record: logging.LogRecord) -> str:  # noqa: A003
         """Format logging record as structured JSON str"""
         formatted_log = self._extract_log_keys(log_record=record)
@@ -121,7 +125,7 @@ class LambdaPowertoolsFormatter(BasePowertoolsFormatter):
         formatted_log["xray_trace_id"] = self._get_latest_trace_id()
         formatted_log = self._strip_none_records(records=formatted_log)
 
-        return self.json_serializer(formatted_log)
+        return self.serialize(log=formatted_log)
 
     def formatTime(self, record: logging.LogRecord, datefmt: Optional[str] = None) -> str:
         record_ts = self.converter(record.created)

--- a/aws_lambda_powertools/tracing/tracer.py
+++ b/aws_lambda_powertools/tracing/tracer.py
@@ -720,7 +720,7 @@ class Tracer:
         patch_modules: Union[List, Tuple] = None,
         provider: BaseProvider = None,
     ):
-        """ Populates Tracer config for new and existing initializations """
+        """Populates Tracer config for new and existing initializations"""
         is_disabled = disabled if disabled is not None else self._is_tracer_disabled()
         is_service = resolve_env_var_choice(choice=service, env=os.getenv(constants.SERVICE_NAME_ENV))
 

--- a/aws_lambda_powertools/utilities/data_classes/api_gateway_proxy_event.py
+++ b/aws_lambda_powertools/utilities/data_classes/api_gateway_proxy_event.py
@@ -164,7 +164,7 @@ class APIGatewayEventRequestContext(DictWrapper):
 
     @property
     def stage(self) -> str:
-        """The deployment stage of the API request """
+        """The deployment stage of the API request"""
         return self["requestContext"]["stage"]
 
     @property
@@ -352,7 +352,7 @@ class RequestContextV2(DictWrapper):
 
     @property
     def domain_name(self) -> str:
-        """A domain name """
+        """A domain name"""
         return self["requestContext"]["domainName"]
 
     @property
@@ -375,7 +375,7 @@ class RequestContextV2(DictWrapper):
 
     @property
     def stage(self) -> str:
-        """The deployment stage of the API request """
+        """The deployment stage of the API request"""
         return self["requestContext"]["stage"]
 
     @property

--- a/aws_lambda_powertools/utilities/data_classes/appsync_resolver_event.py
+++ b/aws_lambda_powertools/utilities/data_classes/appsync_resolver_event.py
@@ -22,7 +22,7 @@ class AppSyncIdentityIAM(DictWrapper):
 
     @property
     def source_ip(self) -> List[str]:
-        """The source IP address of the caller received by AWS AppSync. """
+        """The source IP address of the caller received by AWS AppSync."""
         return self["sourceIp"]
 
     @property
@@ -67,7 +67,7 @@ class AppSyncIdentityCognito(DictWrapper):
 
     @property
     def source_ip(self) -> List[str]:
-        """The source IP address of the caller received by AWS AppSync. """
+        """The source IP address of the caller received by AWS AppSync."""
         return self["sourceIp"]
 
     @property

--- a/aws_lambda_powertools/utilities/data_classes/event_bridge_event.py
+++ b/aws_lambda_powertools/utilities/data_classes/event_bridge_event.py
@@ -60,7 +60,7 @@ class EventBridgeEvent(DictWrapper):
 
     @property
     def detail(self) -> Dict[str, Any]:
-        """A JSON object, whose content is at the discretion of the service originating the event. """
+        """A JSON object, whose content is at the discretion of the service originating the event."""
         return self["detail"]
 
     @property

--- a/aws_lambda_powertools/utilities/data_classes/s3_object_event.py
+++ b/aws_lambda_powertools/utilities/data_classes/s3_object_event.py
@@ -53,7 +53,7 @@ class S3ObjectConfiguration(DictWrapper):
 
 
 class S3ObjectUserRequest(DictWrapper):
-    """ Information about the original call to S3 Object Lambda."""
+    """Information about the original call to S3 Object Lambda."""
 
     @property
     def url(self) -> str:

--- a/aws_lambda_powertools/utilities/data_classes/sns_event.py
+++ b/aws_lambda_powertools/utilities/data_classes/sns_event.py
@@ -46,7 +46,7 @@ class SNSMessage(DictWrapper):
 
     @property
     def message(self) -> str:
-        """A string that describes the message. """
+        """A string that describes the message."""
         return self["Sns"]["Message"]
 
     @property

--- a/aws_lambda_powertools/utilities/data_classes/sqs_event.py
+++ b/aws_lambda_powertools/utilities/data_classes/sqs_event.py
@@ -70,7 +70,7 @@ class SQSMessageAttribute(DictWrapper):
 
     @property
     def data_type(self) -> str:
-        """ The message attribute data type. Supported types include `String`, `Number`, and `Binary`."""
+        """The message attribute data type. Supported types include `String`, `Number`, and `Binary`."""
         return self["dataType"]
 
 
@@ -120,7 +120,7 @@ class SQSRecord(DictWrapper):
 
     @property
     def event_source(self) -> str:
-        """The AWS service from which the SQS record originated. For SQS, this is `aws:sqs` """
+        """The AWS service from which the SQS record originated. For SQS, this is `aws:sqs`"""
         return self["eventSource"]
 
     @property

--- a/aws_lambda_powertools/utilities/idempotency/persistence/base.py
+++ b/aws_lambda_powertools/utilities/idempotency/persistence/base.py
@@ -110,7 +110,7 @@ class BasePersistenceLayer(ABC):
     """
 
     def __init__(self):
-        """Initialize the defaults """
+        """Initialize the defaults"""
         self.configured = False
         self.event_key_jmespath: Optional[str] = None
         self.event_key_compiled_jmespath = None

--- a/tests/functional/test_metrics.py
+++ b/tests/functional/test_metrics.py
@@ -85,7 +85,7 @@ def a_hundred_metrics() -> List[Dict[str, str]]:
 def serialize_metrics(
     metrics: List[Dict], dimensions: List[Dict], namespace: str, metadatas: List[Dict] = None
 ) -> Dict:
-    """ Helper function to build EMF object from a list of metrics, dimensions """
+    """Helper function to build EMF object from a list of metrics, dimensions"""
     my_metrics = MetricManager(namespace=namespace)
     for dimension in dimensions:
         my_metrics.add_dimension(**dimension)
@@ -102,7 +102,7 @@ def serialize_metrics(
 
 
 def serialize_single_metric(metric: Dict, dimension: Dict, namespace: str, metadata: Dict = None) -> Dict:
-    """ Helper function to build EMF object from a given metric, dimension and namespace """
+    """Helper function to build EMF object from a given metric, dimension and namespace"""
     my_metrics = MetricManager(namespace=namespace)
     my_metrics.add_metric(**metric)
     my_metrics.add_dimension(**dimension)
@@ -114,7 +114,7 @@ def serialize_single_metric(metric: Dict, dimension: Dict, namespace: str, metad
 
 
 def remove_timestamp(metrics: List):
-    """ Helper function to remove Timestamp key from EMF objects as they're built at serialization """
+    """Helper function to remove Timestamp key from EMF objects as they're built at serialization"""
     for metric in metrics:
         del metric["_aws"]["Timestamp"]
 


### PR DESCRIPTION
**Issue #, if available:**

## Description of changes:

For minor changes such as remapping keys, removing certain keys, etc., you will no longer have to implement a whole custom formatter from `BasePowertoolsFormatter`.

This PR introduces a public method `serialize` that is called after log record processing takes place, so customers don't have to reimplement extra keys, UTC support, X-Ray (if used), etc:

### UX

```python
from aws_lambda_powertools import Logger
from aws_lambda_powertools.logging.formatter import LambdaPowertoolsFormatter

from typing import Dict

class CustomFormatter(LambdaPowertoolsFormatter):
    def serialize(self, log: Dict) -> str:
        log["event"] = log.pop("message")
        return self.json_serializer(log)

logger = Logger(service="example", logger_formatter=CustomFormatter())
logger.info("hello")
```

This PR also documents the use of `LambdaPowertoolsFormatter` as a standalone formatter:

```python
from aws_lambda_powertools import Logger
from aws_lambda_powertools.logging.formatter import LambdaPowertoolsFormatter

formatter = LambdaPowertoolsFormatter(utc=True, log_record_order=["message"])
logger = Logger(service="example", logger_formatter=formatter)
```

**Checklist**

<!--- Leave unchecked if your change doesn't seem to apply --> 

* [x] [Meet tenets criteria](https://awslabs.github.io/aws-lambda-powertools-python/#tenets)
* [x] Update tests
* [x] Update docs
* [x] PR title follows [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-python/blob/376ec0a2ac0d2a40e0af5717bef42ff84ca0d1b9/.github/semantic.yml#L2)

## Breaking change checklist

<!--- Ignore if it's not a breaking change -->

**RFC issue #**:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
