### PR TITLE
feat(event-handler): allow for `cors=None` setting

### DIFF
--- a/tests/functional/event_handler/test_api_gateway.py
+++ b/tests/functional/event_handler/test_api_gateway.py
@@ -182,6 +182,10 @@ def test_cors():
     def with_cors() -> Response:
         return Response(200, TEXT_HTML, "test")
 
+    @app.get("/without-cors")
+    def without_cors() -> Response:
+        return Response(200, TEXT_HTML, "test")
+
     def handler(event, context):
         return app.resolve(event, context)
 
@@ -195,6 +199,11 @@ def test_cors():
     assert headers["Access-Control-Allow-Origin"] == "*"
     assert "Access-Control-Allow-Credentials" not in headers
     assert headers["Access-Control-Allow-Headers"] == ",".join(sorted(CORSConfig._REQUIRED_HEADERS))
+
+    # THEN for routes without cors flag return no cors headers
+    mock_event = {"path": "/my/request", "httpMethod": "GET"}
+    result = handler(mock_event, None)
+    assert "Access-Control-Allow-Origin" not in result["headers"]
 
 
 def test_compress():
@@ -359,7 +368,7 @@ def test_custom_cors_config():
     app = ApiGatewayResolver(cors=cors_config)
     event = {"path": "/cors", "httpMethod": "GET"}
 
-    @app.get("/cors", cors=True)
+    @app.get("/cors")
     def get_with_cors():
         return {}
 
@@ -370,7 +379,7 @@ def test_custom_cors_config():
     # WHEN calling the event handler
     result = app(event, None)
 
-    # THEN return the custom cors headers
+    # THEN routes by default return the custom cors headers
     assert "headers" in result
     headers = result["headers"]
     assert headers["Content-Type"] == APPLICATION_JSON
@@ -385,6 +394,7 @@ def test_custom_cors_config():
     # AND custom cors was set on the app
     assert isinstance(app._cors, CORSConfig)
     assert app._cors is cors_config
+
     # AND routes without cors don't include "Access-Control" headers
     event = {"path": "/another-one", "httpMethod": "GET"}
     result = app(event, None)
@@ -426,11 +436,11 @@ def test_cors_preflight():
     # AND cors is enabled
     app = ApiGatewayResolver(cors=CORSConfig())
 
-    @app.get("/foo", cors=True)
+    @app.get("/foo")
     def foo_cors():
         ...
 
-    @app.route(method="delete", rule="/foo", cors=True)
+    @app.route(method="delete", rule="/foo")
     def foo_delete_cors():
         ...
 


### PR DESCRIPTION
**Issue #, if available:**

## Description of changes:

At the route level we should allow for `cors=None` which means that cors are enabled for this route when configured globally




Global Setting | Route Setting | Includes cors headers?
-- | -- | --
`app=ApiGatewayResolver()` | `@app.get("/cors", cors=True)` | Yes
`app=ApiGatewayResolver(cors=CORSConfig())` | `@app.get("/cors", cors=True)` | Yes
`app=ApiGatewayResolver()` | `@app.get("/no-cors", cors=False)` | No
`app=ApiGatewayResolver(cors=CORSConfig())` | `@app.get("/no-cors", cors=False)` | No
`app=ApiGatewayResolver()` | `@app.get("/no-cors")` | No
`app=ApiGatewayResolver(cors=CORSConfig())` | `@app.get("/cors")` | Yes

---

**Checklist**

<!--- Leave unchecked if your change doesn't seem to apply --> 

* [X] [Meet tenets criteria](https://awslabs.github.io/aws-lambda-powertools-python/#tenets)
* [X] Update tests
* [X] Update docs
* [X] PR title follows [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-python/blob/376ec0a2ac0d2a40e0af5717bef42ff84ca0d1b9/.github/semantic.yml#L2)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
