### PR TITLE
fix(docs): Use updated names for ProxyEventType

### DIFF
--- a/docs/core/event_handler/api_gateway.md
+++ b/docs/core/event_handler/api_gateway.md
@@ -208,7 +208,7 @@ When using API Gateway HTTP API to front your Lambda functions, you can instruct
 
 	tracer = Tracer()
 	logger = Logger()
-	app = ApiGatewayResolver(proxy_type=ProxyEventType.http_api_v2)
+	app = ApiGatewayResolver(proxy_type=ProxyEventType.APIGatewayProxyEventV2)
 
 	@app.get("/hello")
 	@tracer.capture_method
@@ -235,7 +235,7 @@ When using ALB to front your Lambda functions, you can instruct `ApiGatewayResol
 
 	tracer = Tracer()
 	logger = Logger()
-	app = ApiGatewayResolver(proxy_type=ProxyEventType.alb_event)
+	app = ApiGatewayResolver(proxy_type=ProxyEventType.ALBEvent)
 
 	@app.get("/hello")
 	@tracer.capture_method


### PR DESCRIPTION
**Issue #, if available:**

## Description of changes:

Use the updated names for ProxyEventType which are now CamelCased.

<!--- One or two sentences as a summary of what's being changed -->

**Checklist**

<!--- Leave unchecked if your change doesn't seem to apply --> 

* [x] [Meet tenets criteria](https://awslabs.github.io/aws-lambda-powertools-python/#tenets)
* [x] Update tests
* [x] Update docs
* [x] PR title follows [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-python/blob/376ec0a2ac0d2a40e0af5717bef42ff84ca0d1b9/.github/semantic.yml#L2)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
