### PR TITLE
feat(data-classes): decode base64 encoded body

### DIFF
--- a/aws_lambda_powertools/utilities/data_classes/common.py
+++ b/aws_lambda_powertools/utilities/data_classes/common.py
@@ -68,7 +68,7 @@ class BaseProxyEvent(DictWrapper):
         return json.loads(self["body"])
 
     @property
-    def decode_body(self) -> str:
+    def decoded_body(self) -> str:
         """Dynamically base64 decode body as a str"""
         body: str = self["body"]
         if self.is_base64_encoded:

--- a/aws_lambda_powertools/utilities/data_classes/common.py
+++ b/aws_lambda_powertools/utilities/data_classes/common.py
@@ -1,3 +1,4 @@
+import base64
 import json
 from typing import Any, Dict, Optional
 
@@ -65,6 +66,14 @@ class BaseProxyEvent(DictWrapper):
     def json_body(self) -> Any:
         """Parses the submitted body as json"""
         return json.loads(self["body"])
+
+    @property
+    def decode_body(self) -> str:
+        """Dynamically base64 decode body as a str"""
+        body: str = self["body"]
+        if self.is_base64_encoded:
+            return base64.b64decode(body.encode()).decode()
+        return body
 
     @property
     def path(self) -> str:

--- a/tests/functional/test_data_classes.py
+++ b/tests/functional/test_data_classes.py
@@ -4,6 +4,8 @@ import json
 from secrets import compare_digest
 from urllib.parse import quote_plus
 
+import pytest
+
 from aws_lambda_powertools.utilities.data_classes import (
     ALBEvent,
     APIGatewayProxyEvent,
@@ -841,6 +843,39 @@ def test_base_proxy_event_get_header_value_case_insensitive():
 
     value = event.get_header_value("unknown", case_sensitive=True)
     assert value is None
+
+
+def test_base_proxy_event_json_body_key_error():
+    event = BaseProxyEvent({})
+    with pytest.raises(KeyError) as ke:
+        assert not event.json_body
+    assert str(ke.value) == "'body'"
+
+
+def test_base_proxy_event_json_body():
+    data = {"message": "Foo"}
+    event = BaseProxyEvent({"body": json.dumps(data)})
+    assert event.json_body == data
+
+
+def test_base_proxy_event_decode_body_key_error():
+    event = BaseProxyEvent({})
+    with pytest.raises(KeyError) as ke:
+        assert not event.decode_body
+    assert str(ke.value) == "'body'"
+
+
+def test_base_proxy_event_decode_body_encoded_false():
+    data = "Foo"
+    event = BaseProxyEvent({"body": data, "isBase64Encoded": False})
+    assert event.decode_body == data
+
+
+def test_base_proxy_event_decode_body_encoded_true():
+    data = "Foo"
+    encoded_data = base64.b64encode(data.encode()).decode()
+    event = BaseProxyEvent({"body": encoded_data, "isBase64Encoded": True})
+    assert event.decode_body == data
 
 
 def test_kinesis_stream_event():


### PR DESCRIPTION
**Issue #, if available:**

## Description of changes:

Code example:
```python3
def lambda_handler(event: dict, context):
    event = APIGatewayProxyEvent(event)
    # Dynamically base64 decode body as a str
    body: str = event.decoded_body
    print(body)
```

Where the event is:

```json
{
  "body": "W3siaWQiOjEsIm5hbWUiOiJDb21wYW55IE9uZSJ9LHsiaWQiOjIsIm5hbWUiOiJDb21wYW55IFR3byJ9XQo=",
   "isBase64Encoded": true
}
```

Print statement:

```json5
[{"id":1,"name":"Company One"},{"id":2,"name":"Company Two"}]
```

- Based on a tweet: https://twitter.com/donkersgood/status/1390292767662825473

**Checklist**

<!--- Leave unchecked if your change doesn't seem to apply --> 

* [X] [Meet tenets criteria](https://awslabs.github.io/aws-lambda-powertools-python/#tenets)
* [X] Update tests
* [X] Update docs
* [X] PR title follows [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-python/blob/376ec0a2ac0d2a40e0af5717bef42ff84ca0d1b9/.github/semantic.yml#L2)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
