### PR TITLE
fix(logger): Support .info("foo %s", "bar") formatting

### DIFF
--- a/aws_lambda_powertools/logging/formatter.py
+++ b/aws_lambda_powertools/logging/formatter.py
@@ -176,6 +176,9 @@ class LambdaPowertoolsFormatter(BasePowertoolsFormatter):
         if isinstance(message, dict):
             return message
 
+        if log_record.args:  # logger.info("foo %s", "bar") requires formatting
+            return log_record.getMessage()
+
         if isinstance(message, str):  # could be a JSON string
             try:
                 message = self.json_deserializer(message)

--- a/tests/functional/test_logger_powertools_formatter.py
+++ b/tests/functional/test_logger_powertools_formatter.py
@@ -275,3 +275,16 @@ def test_logging_various_primitives(stdout, service_name, message):
     # THEN it should raise no serialization/deserialization error
     logger.info(message)
     json.loads(stdout.getvalue())
+
+
+def test_log_formatting(stdout, service_name):
+    # GIVEN a logger with default settings
+    logger = Logger(service=service_name, stream=stdout)
+
+    # WHEN logging a message with formatting
+    logger.info('["foo %s %d %s", null]', "bar", 123, [1, None])
+
+    log_dict: dict = json.loads(stdout.getvalue())
+
+    # THEN the formatting should be applied (NB. this is valid json, but hasn't be parsed)
+    assert log_dict["message"] == '["foo bar 123 [1, None]", null]'


### PR DESCRIPTION
**Issue #, if available:** N/A

## Description of changes:

This adjusts the default logging formatter (`LambdaPowertoolsFormatter`)
to handle non-structured logs with formatting, like:

```python
logger.info("foo %s", "bar")
```

This allows the formatter to be used in more situations, such as the
universal formatter for all log messages coming out of a system, even
libraries using the normal logging functionality, without explicit
support for aws-lambda-powertools.

If formatting is performed, this is taken as a hint that the value
probably isn't semantically JSON, even if it's syntactically valid as
JSON.

(I've called this a bug fix in the title but could be a 'feat' too, I guess?)

**Checklist**

<!--- Leave unchecked if your change doesn't seem to apply --> 

* [x] [Meet tenets criteria](https://awslabs.github.io/aws-lambda-powertools-python/#tenets)
* [x] Update tests
* [ ] Update docs
* [x] PR title follows [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-python/blob/376ec0a2ac0d2a40e0af5717bef42ff84ca0d1b9/.github/semantic.yml#L2)

## Breaking change checklist

<!--- Ignore if it's not a breaking change -->

**RFC issue #**: N/A

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
