### PR TITLE
chore: update mergify to require approval on dependabot

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -4,6 +4,7 @@ pull_request_rules:
       - author~=^dependabot(|-preview)\[bot\]$
       - check-success=Build
       - -label~="do-not-merge"
+      - "#approved-reviews-by>=1"  # until we exclude major versions in dependabot
     actions:
       merge:
         strict: false


### PR DESCRIPTION
This change has been made by @heitorlessa from https://mergify.io config editor.