### PR TITLE
feat(data-classes): add AttributeValueType to DynamoDBStreamEvent

### DIFF
--- a/aws_lambda_powertools/utilities/data_classes/dynamo_db_stream_event.py
+++ b/aws_lambda_powertools/utilities/data_classes/dynamo_db_stream_event.py
@@ -4,11 +4,29 @@ from typing import Dict, Iterator, List, Optional
 from aws_lambda_powertools.utilities.data_classes.common import DictWrapper
 
 
+class AttributeValueType(Enum):
+    Binary = "B"
+    BinarySet = "BS"
+    Boolean = "BOOL"
+    List = "L"
+    Map = "M"
+    Number = "N"
+    NumberSet = "NS"
+    Null = "NULL"
+    String = "S"
+    StringSet = "SS"
+
+
 class AttributeValue(DictWrapper):
     """Represents the data for an attribute
 
     Documentation: https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_streams_AttributeValue.html
     """
+
+    @property
+    def get_type(self) -> AttributeValueType:
+        """Get the attribute value type based on the contained data"""
+        return AttributeValueType(list(self.raw_event.keys())[0])
 
     @property
     def b_value(self) -> Optional[str]:

--- a/aws_lambda_powertools/utilities/data_classes/dynamo_db_stream_event.py
+++ b/aws_lambda_powertools/utilities/data_classes/dynamo_db_stream_event.py
@@ -297,8 +297,6 @@ class DynamoDBStreamEvent(DictWrapper):
                 elif key == AttributeValueType.Map:
                     assert key.get_value == key.map_value
                     print(key.get_value)
-
-
     """
 
     @property

--- a/tests/functional/test_data_classes.py
+++ b/tests/functional/test_data_classes.py
@@ -450,6 +450,7 @@ def test_dynamo_attribute_value_b_value():
     attribute_value = AttributeValue(example_attribute_value)
 
     assert attribute_value.get_type == AttributeValueType.Binary
+    assert attribute_value.b_value == attribute_value.value
 
 
 def test_dynamo_attribute_value_bs_value():
@@ -458,6 +459,7 @@ def test_dynamo_attribute_value_bs_value():
     attribute_value = AttributeValue(example_attribute_value)
 
     assert attribute_value.get_type == AttributeValueType.BinarySet
+    assert attribute_value.bs_value == attribute_value.value
 
 
 def test_dynamo_attribute_value_bool_value():
@@ -466,6 +468,7 @@ def test_dynamo_attribute_value_bool_value():
     attribute_value = AttributeValue(example_attribute_value)
 
     assert attribute_value.get_type == AttributeValueType.Boolean
+    assert attribute_value.bool_value == attribute_value.value
 
 
 def test_dynamo_attribute_value_list_value():
@@ -476,6 +479,8 @@ def test_dynamo_attribute_value_list_value():
     item = list_value[0]
     assert item.s_value == "Cookies"
     assert attribute_value.get_type == AttributeValueType.List
+    assert attribute_value.l_value == attribute_value.list_value
+    assert attribute_value.list_value == attribute_value.value
 
 
 def test_dynamo_attribute_value_map_value():
@@ -488,6 +493,8 @@ def test_dynamo_attribute_value_map_value():
     item = map_value["Name"]
     assert item.s_value == "Joe"
     assert attribute_value.get_type == AttributeValueType.Map
+    assert attribute_value.m_value == attribute_value.map_value
+    assert attribute_value.map_value == attribute_value.value
 
 
 def test_dynamo_attribute_value_n_value():
@@ -496,6 +503,7 @@ def test_dynamo_attribute_value_n_value():
     attribute_value = AttributeValue(example_attribute_value)
 
     assert attribute_value.get_type == AttributeValueType.Number
+    assert attribute_value.n_value == attribute_value.value
 
 
 def test_dynamo_attribute_value_ns_value():
@@ -504,6 +512,7 @@ def test_dynamo_attribute_value_ns_value():
     attribute_value = AttributeValue(example_attribute_value)
 
     assert attribute_value.get_type == AttributeValueType.NumberSet
+    assert attribute_value.ns_value == attribute_value.value
 
 
 def test_dynamo_attribute_value_null_value():
@@ -512,6 +521,7 @@ def test_dynamo_attribute_value_null_value():
     attribute_value = AttributeValue(example_attribute_value)
 
     assert attribute_value.get_type == AttributeValueType.Null
+    assert attribute_value.null_value == attribute_value.value
 
 
 def test_dynamo_attribute_value_s_value():
@@ -520,6 +530,7 @@ def test_dynamo_attribute_value_s_value():
     attribute_value = AttributeValue(example_attribute_value)
 
     assert attribute_value.get_type == AttributeValueType.String
+    assert attribute_value.s_value == attribute_value.value
 
 
 def test_dynamo_attribute_value_ss_value():
@@ -528,6 +539,7 @@ def test_dynamo_attribute_value_ss_value():
     attribute_value = AttributeValue(example_attribute_value)
 
     assert attribute_value.get_type == AttributeValueType.StringSet
+    assert attribute_value.ss_value == attribute_value.value
 
 
 def test_event_bridge_event():

--- a/tests/functional/test_data_classes.py
+++ b/tests/functional/test_data_classes.py
@@ -58,6 +58,7 @@ from aws_lambda_powertools.utilities.data_classes.connect_contact_flow_event imp
 )
 from aws_lambda_powertools.utilities.data_classes.dynamo_db_stream_event import (
     AttributeValue,
+    AttributeValueType,
     DynamoDBRecordEventName,
     DynamoDBStreamEvent,
     StreamViewType,
@@ -443,6 +444,30 @@ def test_dynamo_db_stream_trigger_event():
     assert record.user_identity is None
 
 
+def test_dynamo_attribute_value_b_value():
+    example_attribute_value = {"B": "dGhpcyB0ZXh0IGlzIGJhc2U2NC1lbmNvZGVk"}
+
+    attribute_value = AttributeValue(example_attribute_value)
+
+    assert attribute_value.get_type == AttributeValueType.Binary
+
+
+def test_dynamo_attribute_value_bs_value():
+    example_attribute_value = {"BS": ["U3Vubnk=", "UmFpbnk=", "U25vd3k="]}
+
+    attribute_value = AttributeValue(example_attribute_value)
+
+    assert attribute_value.get_type == AttributeValueType.BinarySet
+
+
+def test_dynamo_attribute_value_bool_value():
+    example_attribute_value = {"BOOL": True}
+
+    attribute_value = AttributeValue(example_attribute_value)
+
+    assert attribute_value.get_type == AttributeValueType.Boolean
+
+
 def test_dynamo_attribute_value_list_value():
     example_attribute_value = {"L": [{"S": "Cookies"}, {"S": "Coffee"}, {"N": "3.14159"}]}
     attribute_value = AttributeValue(example_attribute_value)
@@ -450,6 +475,7 @@ def test_dynamo_attribute_value_list_value():
     assert list_value is not None
     item = list_value[0]
     assert item.s_value == "Cookies"
+    assert attribute_value.get_type == AttributeValueType.List
 
 
 def test_dynamo_attribute_value_map_value():
@@ -461,6 +487,47 @@ def test_dynamo_attribute_value_map_value():
     assert map_value is not None
     item = map_value["Name"]
     assert item.s_value == "Joe"
+    assert attribute_value.get_type == AttributeValueType.Map
+
+
+def test_dynamo_attribute_value_n_value():
+    example_attribute_value = {"N": "123.45"}
+
+    attribute_value = AttributeValue(example_attribute_value)
+
+    assert attribute_value.get_type == AttributeValueType.Number
+
+
+def test_dynamo_attribute_value_ns_value():
+    example_attribute_value = {"NS": ["42.2", "-19", "7.5", "3.14"]}
+
+    attribute_value = AttributeValue(example_attribute_value)
+
+    assert attribute_value.get_type == AttributeValueType.NumberSet
+
+
+def test_dynamo_attribute_value_null_value():
+    example_attribute_value = {"NULL": True}
+
+    attribute_value = AttributeValue(example_attribute_value)
+
+    assert attribute_value.get_type == AttributeValueType.Null
+
+
+def test_dynamo_attribute_value_s_value():
+    example_attribute_value = {"S": "Hello"}
+
+    attribute_value = AttributeValue(example_attribute_value)
+
+    assert attribute_value.get_type == AttributeValueType.String
+
+
+def test_dynamo_attribute_value_ss_value():
+    example_attribute_value = {"SS": ["Giraffe", "Hippo", "Zebra"]}
+
+    attribute_value = AttributeValue(example_attribute_value)
+
+    assert attribute_value.get_type == AttributeValueType.StringSet
 
 
 def test_event_bridge_event():

--- a/tests/functional/test_data_classes.py
+++ b/tests/functional/test_data_classes.py
@@ -450,7 +450,7 @@ def test_dynamo_attribute_value_b_value():
     attribute_value = AttributeValue(example_attribute_value)
 
     assert attribute_value.get_type == AttributeValueType.Binary
-    assert attribute_value.b_value == attribute_value.value
+    assert attribute_value.b_value == attribute_value.get_value
 
 
 def test_dynamo_attribute_value_bs_value():
@@ -459,7 +459,7 @@ def test_dynamo_attribute_value_bs_value():
     attribute_value = AttributeValue(example_attribute_value)
 
     assert attribute_value.get_type == AttributeValueType.BinarySet
-    assert attribute_value.bs_value == attribute_value.value
+    assert attribute_value.bs_value == attribute_value.get_value
 
 
 def test_dynamo_attribute_value_bool_value():
@@ -468,7 +468,7 @@ def test_dynamo_attribute_value_bool_value():
     attribute_value = AttributeValue(example_attribute_value)
 
     assert attribute_value.get_type == AttributeValueType.Boolean
-    assert attribute_value.bool_value == attribute_value.value
+    assert attribute_value.bool_value == attribute_value.get_value
 
 
 def test_dynamo_attribute_value_list_value():
@@ -480,7 +480,7 @@ def test_dynamo_attribute_value_list_value():
     assert item.s_value == "Cookies"
     assert attribute_value.get_type == AttributeValueType.List
     assert attribute_value.l_value == attribute_value.list_value
-    assert attribute_value.list_value == attribute_value.value
+    assert attribute_value.list_value == attribute_value.get_value
 
 
 def test_dynamo_attribute_value_map_value():
@@ -494,7 +494,7 @@ def test_dynamo_attribute_value_map_value():
     assert item.s_value == "Joe"
     assert attribute_value.get_type == AttributeValueType.Map
     assert attribute_value.m_value == attribute_value.map_value
-    assert attribute_value.map_value == attribute_value.value
+    assert attribute_value.map_value == attribute_value.get_value
 
 
 def test_dynamo_attribute_value_n_value():
@@ -503,7 +503,7 @@ def test_dynamo_attribute_value_n_value():
     attribute_value = AttributeValue(example_attribute_value)
 
     assert attribute_value.get_type == AttributeValueType.Number
-    assert attribute_value.n_value == attribute_value.value
+    assert attribute_value.n_value == attribute_value.get_value
 
 
 def test_dynamo_attribute_value_ns_value():
@@ -512,7 +512,7 @@ def test_dynamo_attribute_value_ns_value():
     attribute_value = AttributeValue(example_attribute_value)
 
     assert attribute_value.get_type == AttributeValueType.NumberSet
-    assert attribute_value.ns_value == attribute_value.value
+    assert attribute_value.ns_value == attribute_value.get_value
 
 
 def test_dynamo_attribute_value_null_value():
@@ -521,7 +521,7 @@ def test_dynamo_attribute_value_null_value():
     attribute_value = AttributeValue(example_attribute_value)
 
     assert attribute_value.get_type == AttributeValueType.Null
-    assert attribute_value.null_value == attribute_value.value
+    assert attribute_value.null_value == attribute_value.get_value
 
 
 def test_dynamo_attribute_value_s_value():
@@ -530,7 +530,7 @@ def test_dynamo_attribute_value_s_value():
     attribute_value = AttributeValue(example_attribute_value)
 
     assert attribute_value.get_type == AttributeValueType.String
-    assert attribute_value.s_value == attribute_value.value
+    assert attribute_value.s_value == attribute_value.get_value
 
 
 def test_dynamo_attribute_value_ss_value():
@@ -539,7 +539,7 @@ def test_dynamo_attribute_value_ss_value():
     attribute_value = AttributeValue(example_attribute_value)
 
     assert attribute_value.get_type == AttributeValueType.StringSet
-    assert attribute_value.ss_value == attribute_value.value
+    assert attribute_value.ss_value == attribute_value.get_value
 
 
 def test_dynamo_attribute_value_type_error():
@@ -548,7 +548,7 @@ def test_dynamo_attribute_value_type_error():
     attribute_value = AttributeValue(example_attribute_value)
 
     with pytest.raises(TypeError):
-        print(attribute_value.value)
+        print(attribute_value.get_value)
     with pytest.raises(ValueError):
         print(attribute_value.get_type)
 

--- a/tests/functional/test_data_classes.py
+++ b/tests/functional/test_data_classes.py
@@ -542,6 +542,17 @@ def test_dynamo_attribute_value_ss_value():
     assert attribute_value.ss_value == attribute_value.value
 
 
+def test_dynamo_attribute_value_type_error():
+    example_attribute_value = {"UNSUPPORTED": "'value' should raise a type error"}
+
+    attribute_value = AttributeValue(example_attribute_value)
+
+    with pytest.raises(TypeError):
+        print(attribute_value.value)
+    with pytest.raises(ValueError):
+        print(attribute_value.get_type)
+
+
 def test_event_bridge_event():
     event = EventBridgeEvent(load_event("eventBridgeEvent.json"))
 


### PR DESCRIPTION
**Issue #, if available:**

https://github.com/awslabs/aws-lambda-powertools-python/issues/461

## Description of changes:

Changes:
- [x] Add new enum AttributeValueType for the type of AttributeValue
- [x] Add new property `get_type` to return said enum
- [x] Add new property `get_value` which returns converted value
- [x] Update docs with any revisited changes in the type conversion process


Example usage:

```python3
from aws_lambda_powertools.utilities.data_classes import event_source, DynamoDBStreamEvent
from aws_lambda_powertools.utilities.data_classes.dynamo_db_stream_event import AttributeValueType, AttributeValue
from aws_lambda_powertools.utilities.typing import LambdaContext


@event_source(data_class=DynamoDBStreamEvent)
def lambda_handler(event: DynamoDBStreamEvent, context: LambdaContext):
    for record in event.records:
        key: AttributeValue = record.dynamodb.keys["id"]
        if key == AttributeValueType.Number:
            assert key.get_value == key.n_value
            print(key.get_value)
        elif key == AttributeValueType.Map:
            assert key.get_value == key.map_value
            print(key.get_value)
```


Where `AttributeValueType` is:

```python3
class AttributeValueType(Enum):
    Binary = "B"
    BinarySet = "BS"
    Boolean = "BOOL"
    List = "L"
    Map = "M"
    Number = "N"
    NumberSet = "NS"
    Null = "NULL"
    String = "S"
    StringSet = "SS"
```


## How AttributeValue does the raw values


Example Values:

* b_value:
```{"B": "dGhpcyB0ZXh0IGlzIGJhc2U2NC1lbmNvZGVk"}```
* bs_value
```{"BS": ["U3Vubnk=", "UmFpbnk=", "U25vd3k="]}```
* bool_value
```{"BOOL": True}```
* list_value/l_value
```{"L": [ {"S": "Cookies"} , {"S": "Coffee"}, {"N": "3.14159"}]}```
* map_value/m_value
```{"M": {"Name": {"S": "Joe"}, "Age": {"N": "35"}}}```
* n_value
```{"N": "123.45"}```
* ns_value
```{"NS": ["42.2", "-19", "7.5", "3.14"]}```
* null_value
```{"NULL": True}```
* s_value
```{"S": "Hello"}```
* ss_value
```{"SS": ["Giraffe", "Hippo" ,"Zebra"]}```

> NOTE: All return types are `Optional`

Return types

| Property           | Description                                                      | Raw Return Type             |
|--------------------|------------------------------------------------------------------|-----------------------------|
| b_value            | An attribute of type Base64-encoded binary data object           | str                         |
| bs_value           | An attribute of type Array of Base64-encoded binary data objects | List[str]                   |
| bool_value         | An attribute of type Boolean                                     | bool                        |
| list_value l_value | An attribute of type Array of AttributeValue objects             | List["AttributeValue"]      |
| map_value m_value  | An attribute of type String to AttributeValue object map         | Dict[str, "AttributeValue"] |
| n_value            | An attribute of type Number                                      | str                         |
| ns_value           | An attribute of type Number Set                                  | List[str]                   |
| null_value         | An attribute of type Null                                        | bool                  |
| s_value            | An attribute of type String                                      | str                         |
| ss_value           | An attribute of type Array of strings                            | List[str]                   |


## How Dynamodb Type does deserialization


| DynamoDB	|	Python |
|-----------|----------|
| {'NULL': True}	|	None |
| {'BOOL': True/False}	|	True/False |
| {'N': str(value)}	|	Decimal(str(value)) |
| {'S': string}	|	string |
| {'B': bytes}	|	Binary(bytes) |
| {'NS': [str(value)]}	|	set([Decimal(str(value))]) |
| {'SS': [string]}	|	set([string]) |
| {'BS': [bytes]}	|	set([bytes]) |
| {'L': list}	|	list |
| {'M': dict}	|	dict |

**Checklist**

<!--- Leave unchecked if your change doesn't seem to apply --> 

* [X] [Meet tenets criteria](https://awslabs.github.io/aws-lambda-powertools-python/#tenets)
* [X] Update tests
* [X] Update docs
* [X] PR title follows [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-python/blob/376ec0a2ac0d2a40e0af5717bef42ff84ca0d1b9/.github/semantic.yml#L2)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
