### PR TITLE
feat(logger): add option to clear state per invocation

### DIFF
--- a/aws_lambda_powertools/logging/logger.py
+++ b/aws_lambda_powertools/logging/logger.py
@@ -264,13 +264,13 @@ class Logger(logging.Logger):  # lgtm [py/missing-call-to-init]
         lambda_handler: Callable[[Dict, Any], Any] = None,
         log_event: bool = None,
         correlation_id_path: str = None,
-        clear_custom_keys: bool = False,
+        remove_custom_keys: bool = False,
     ):
         """Decorator to capture Lambda contextual info and inject into logger
 
         Parameters
         ----------
-        clear_custom_keys : bool, optional
+        remove_custom_keys : bool, optional
             Instructs logger to remove any custom keys previously added
         lambda_handler : Callable
             Method to inject the lambda context
@@ -320,7 +320,7 @@ class Logger(logging.Logger):  # lgtm [py/missing-call-to-init]
                 self.inject_lambda_context,
                 log_event=log_event,
                 correlation_id_path=correlation_id_path,
-                clear_custom_keys=clear_custom_keys,
+                remove_custom_keys=remove_custom_keys,
             )
 
         log_event = resolve_truthy_env_var_choice(
@@ -332,7 +332,7 @@ class Logger(logging.Logger):  # lgtm [py/missing-call-to-init]
             lambda_context = build_lambda_context_model(context)
             cold_start = _is_cold_start()
 
-            if clear_custom_keys:
+            if remove_custom_keys:
                 self.structure_logs(cold_start=cold_start, **lambda_context.__dict__)
             else:
                 self.append_keys(cold_start=cold_start, **lambda_context.__dict__)

--- a/aws_lambda_powertools/logging/logger.py
+++ b/aws_lambda_powertools/logging/logger.py
@@ -264,13 +264,13 @@ class Logger(logging.Logger):  # lgtm [py/missing-call-to-init]
         lambda_handler: Callable[[Dict, Any], Any] = None,
         log_event: bool = None,
         correlation_id_path: str = None,
-        remove_custom_keys: bool = False,
+        clear_state: bool = False,
     ):
         """Decorator to capture Lambda contextual info and inject into logger
 
         Parameters
         ----------
-        remove_custom_keys : bool, optional
+        clear_state : bool, optional
             Instructs logger to remove any custom keys previously added
         lambda_handler : Callable
             Method to inject the lambda context
@@ -320,7 +320,7 @@ class Logger(logging.Logger):  # lgtm [py/missing-call-to-init]
                 self.inject_lambda_context,
                 log_event=log_event,
                 correlation_id_path=correlation_id_path,
-                remove_custom_keys=remove_custom_keys,
+                clear_state=clear_state,
             )
 
         log_event = resolve_truthy_env_var_choice(
@@ -332,7 +332,7 @@ class Logger(logging.Logger):  # lgtm [py/missing-call-to-init]
             lambda_context = build_lambda_context_model(context)
             cold_start = _is_cold_start()
 
-            if remove_custom_keys:
+            if clear_state:
                 self.structure_logs(cold_start=cold_start, **lambda_context.__dict__)
             else:
                 self.append_keys(cold_start=cold_start, **lambda_context.__dict__)

--- a/docs/core/logger.md
+++ b/docs/core/logger.md
@@ -232,7 +232,7 @@ We provide [built-in JMESPath expressions](#built-in-correlation-id-expressions)
 ### Appending additional keys
 
 !!! info "Custom keys are persisted across warm invocations"
-	Always set additional keys as part of your handler to ensure they have the latest value, or explicitly clear them with `clear_custom_keys=True`as explained above.
+	Always set additional keys as part of your handler to ensure they have the latest value, or explicitly clear them with `remove_custom_keys=True`as explained above.
 
 
 You can append additional keys using either mechanism:
@@ -429,7 +429,7 @@ You can remove any additional key from Logger state using `remove_keys`.
 
 #### Removing all custom keys
 
-Logger is commonly initialized in the global scope. Due to [Lambda Execution Context reuse](https://docs.aws.amazon.com/lambda/latest/dg/runtimes-context.html), this means that custom keys can be persisted across invocations. If you want all custom keys to be deleted, you can use `clear_custom_keys=True` param in `inject_lambda_context` decorator.
+Logger is commonly initialized in the global scope. Due to [Lambda Execution Context reuse](https://docs.aws.amazon.com/lambda/latest/dg/runtimes-context.html), this means that custom keys can be persisted across invocations. If you want all custom keys to be deleted, you can use `remove_custom_keys=True` param in `inject_lambda_context` decorator.
 
 !!! info
 	This is useful when you add multiple custom keys conditionally, instead of setting a default `None` value if not present. Any key with `None` value is automatically removed by Logger.
@@ -437,7 +437,7 @@ Logger is commonly initialized in the global scope. Due to [Lambda Execution Con
 !!! danger "This can have unintended side effects if you use Layers"
 	Lambda Layers code is imported before the Lambda handler.
 
-	This means that `clear_custom_keys=True` will instruct Logger to remove any keys previously added before Lambda handler execution proceeds.
+	This means that `remove_custom_keys=True` will instruct Logger to remove any keys previously added before Lambda handler execution proceeds.
 
 	You can either avoid running any code as part of Lambda Layers global scope, or override keys with their latest value as part of handler's execution.
 
@@ -448,7 +448,7 @@ Logger is commonly initialized in the global scope. Due to [Lambda Execution Con
 
     logger = Logger(service="payment")
 
-    @logger.inject_lambda_context(clear_custom_keys=True)
+    @logger.inject_lambda_context(remove_custom_keys=True)
     def handler(event, context):
 		if event.get("special_key"):
 			# Should only be available in the first request log

--- a/docs/core/logger.md
+++ b/docs/core/logger.md
@@ -232,7 +232,7 @@ We provide [built-in JMESPath expressions](#built-in-correlation-id-expressions)
 ### Appending additional keys
 
 !!! info "Custom keys are persisted across warm invocations"
-	Always set additional keys as part of your handler to ensure they have the latest value, or explicitly clear them with `clear_state=True`as explained above.
+	Always set additional keys as part of your handler to ensure they have the latest value, or explicitly clear them with [`clear_state=True`](#clearing-all-state).
 
 
 You can append additional keys using either mechanism:

--- a/docs/core/logger.md
+++ b/docs/core/logger.md
@@ -232,7 +232,7 @@ We provide [built-in JMESPath expressions](#built-in-correlation-id-expressions)
 ### Appending additional keys
 
 !!! info "Custom keys are persisted across warm invocations"
-	Always set additional keys as part of your handler to ensure they have the latest value, or explicitly clear them with `remove_custom_keys=True`as explained above.
+	Always set additional keys as part of your handler to ensure they have the latest value, or explicitly clear them with `clear_state=True`as explained above.
 
 
 You can append additional keys using either mechanism:
@@ -427,9 +427,9 @@ You can remove any additional key from Logger state using `remove_keys`.
 	}
     ```
 
-#### Removing all custom keys
+#### Clearing all state
 
-Logger is commonly initialized in the global scope. Due to [Lambda Execution Context reuse](https://docs.aws.amazon.com/lambda/latest/dg/runtimes-context.html), this means that custom keys can be persisted across invocations. If you want all custom keys to be deleted, you can use `remove_custom_keys=True` param in `inject_lambda_context` decorator.
+Logger is commonly initialized in the global scope. Due to [Lambda Execution Context reuse](https://docs.aws.amazon.com/lambda/latest/dg/runtimes-context.html), this means that custom keys can be persisted across invocations. If you want all custom keys to be deleted, you can use `clear_state=True` param in `inject_lambda_context` decorator.
 
 !!! info
 	This is useful when you add multiple custom keys conditionally, instead of setting a default `None` value if not present. Any key with `None` value is automatically removed by Logger.
@@ -437,7 +437,7 @@ Logger is commonly initialized in the global scope. Due to [Lambda Execution Con
 !!! danger "This can have unintended side effects if you use Layers"
 	Lambda Layers code is imported before the Lambda handler.
 
-	This means that `remove_custom_keys=True` will instruct Logger to remove any keys previously added before Lambda handler execution proceeds.
+	This means that `clear_state=True` will instruct Logger to remove any keys previously added before Lambda handler execution proceeds.
 
 	You can either avoid running any code as part of Lambda Layers global scope, or override keys with their latest value as part of handler's execution.
 
@@ -448,7 +448,7 @@ Logger is commonly initialized in the global scope. Due to [Lambda Execution Con
 
     logger = Logger(service="payment")
 
-    @logger.inject_lambda_context(remove_custom_keys=True)
+    @logger.inject_lambda_context(clear_state=True)
     def handler(event, context):
 		if event.get("special_key"):
 			# Should only be available in the first request log

--- a/docs/core/logger.md
+++ b/docs/core/logger.md
@@ -231,8 +231,9 @@ We provide [built-in JMESPath expressions](#built-in-correlation-id-expressions)
 
 ### Appending additional keys
 
-!!! info "Keys might be persisted across invocations"
-	Always set additional keys as part of your handler to ensure they have the latest value. Additional keys are kept in memory as part of a Logger instance and might be reused in non-cold start scenarios.
+!!! info "Custom keys are persisted across warm invocations"
+	Always set additional keys as part of your handler to ensure they have the latest value, or explicitly clear them with `clear_custom_keys=True`as explained above.
+
 
 You can append additional keys using either mechanism:
 
@@ -425,6 +426,73 @@ You can remove any additional key from Logger state using `remove_keys`.
 	  	"service": "payment"
 	}
     ```
+
+#### Removing all custom keys
+
+Logger is commonly initialized in the global scope. Due to [Lambda Execution Context reuse](https://docs.aws.amazon.com/lambda/latest/dg/runtimes-context.html), this means that custom keys can be persisted across invocations. If you want all custom keys to be deleted, you can use `clear_custom_keys=True` param in `inject_lambda_context` decorator.
+
+!!! info
+	This is useful when you add multiple custom keys conditionally, instead of setting a default `None` value if not present. Any key with `None` value is automatically removed by Logger.
+
+!!! danger "This can have unintended side effects if you use Layers"
+	Lambda Layers code is imported before the Lambda handler.
+
+	This means that `clear_custom_keys=True` will instruct Logger to remove any keys previously added before Lambda handler execution proceeds.
+
+	You can either avoid running any code as part of Lambda Layers global scope, or override keys with their latest value as part of handler's execution.
+
+=== "collect.py"
+
+    ```python hl_lines="5 8"
+    from aws_lambda_powertools import Logger
+
+    logger = Logger(service="payment")
+
+    @logger.inject_lambda_context(clear_custom_keys=True)
+    def handler(event, context):
+		if event.get("special_key"):
+			# Should only be available in the first request log
+			# as the second request doesn't contain `special_key`
+			logger.append_keys(debugging_key="value")
+
+		logger.info("Collecting payment")
+    ```
+
+=== "#1 request"
+
+    ```json hl_lines="7"
+	{
+		"level": "INFO",
+	  	"location": "collect.handler:10",
+	  	"message": "Collecting payment",
+		"timestamp": "2021-05-03 11:47:12,494+0200",
+	  	"service": "payment",
+		"special_key": "debug_key",
+	  	"cold_start": true,
+	  	"lambda_function_name": "test",
+	  	"lambda_function_memory_size": 128,
+	  	"lambda_function_arn": "arn:aws:lambda:eu-west-1:12345678910:function:test",
+	  	"lambda_request_id": "52fdfc07-2182-154f-163f-5f0f9a621d72"
+	}
+    ```
+
+=== "#2 request"
+
+	```json hl_lines="7"
+	{
+		"level": "INFO",
+	  	"location": "collect.handler:10",
+	  	"message": "Collecting payment",
+		"timestamp": "2021-05-03 11:47:12,494+0200",
+	  	"service": "payment",
+	  	"cold_start": false,
+	  	"lambda_function_name": "test",
+	  	"lambda_function_memory_size": 128,
+	  	"lambda_function_arn": "arn:aws:lambda:eu-west-1:12345678910:function:test",
+	  	"lambda_request_id": "52fdfc07-2182-154f-163f-5f0f9a621d72"
+	}
+    ```
+
 
 ### Logging exceptions
 

--- a/tests/functional/test_logger.py
+++ b/tests/functional/test_logger.py
@@ -564,12 +564,12 @@ def test_logger_custom_handler(lambda_context, service_name, tmp_path):
     assert "custom handler" in log
 
 
-def test_clear_keys_on_inject_lambda_context(lambda_context, stdout, service_name):
+def test_clear_state_on_inject_lambda_context(lambda_context, stdout, service_name):
     # GIVEN
     logger = Logger(service=service_name, stream=stdout)
 
-    # WHEN remove_custom_keys is set and a key was conditionally added in the first invocation
-    @logger.inject_lambda_context(remove_custom_keys=True)
+    # WHEN clear_state is set and a key was conditionally added in the first invocation
+    @logger.inject_lambda_context(clear_state=True)
     def handler(event, context):
         if event.get("add_key"):
             logger.append_keys(my_key="value")

--- a/tests/functional/test_logger.py
+++ b/tests/functional/test_logger.py
@@ -568,8 +568,8 @@ def test_clear_keys_on_inject_lambda_context(lambda_context, stdout, service_nam
     # GIVEN
     logger = Logger(service=service_name, stream=stdout)
 
-    # WHEN clear_custom_key is set and a key was conditionally added in the first invocation
-    @logger.inject_lambda_context(clear_custom_keys=True)
+    # WHEN remove_custom_keys is set and a key was conditionally added in the first invocation
+    @logger.inject_lambda_context(remove_custom_keys=True)
     def handler(event, context):
         if event.get("add_key"):
             logger.append_keys(my_key="value")


### PR DESCRIPTION
**Issue #, if available:**

## Description of changes:

<!--- One or two sentences as a summary of what's being changed -->

**Checklist**

<!--- Leave unchecked if your change doesn't seem to apply --> 

* [x] [Meet tenets criteria](https://awslabs.github.io/aws-lambda-powertools-python/#tenets)
* [x] Update tests
* [x] Update docs
* [x] PR title follows [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-python/blob/376ec0a2ac0d2a40e0af5717bef42ff84ca0d1b9/.github/semantic.yml#L2)

## UX

```python
from aws_lambda_powertools import Logger

logger = Logger(service="payment")

@logger.inject_lambda_context(clear_state=True)
def handler(event, context):
    if event.get("special_key"):
        # Should only be available in the first request log
        # as the second request doesn't contain `special_key`
        logger.append_keys(debugging_key="value")

    logger.info("Collecting payment")

```

## Breaking change checklist

<!--- Ignore if it's not a breaking change -->

**RFC issue #**:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
