### PR TITLE
docs: enable dark mode switch

### DIFF
--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -4,6 +4,10 @@
 
 .highlight .hll {
     background-color: lavender
+
+    [data-md-color-scheme="slate"] {
+        background-color: rgb(69, 48, 164)
+    }
 }
 
 .md-typeset table:not([class]) {
@@ -24,4 +28,8 @@
 
 .md-typeset .admonition, .md-typeset details {
     font-size: 0.70rem
+}
+
+[data-md-color-scheme="slate"] {
+    --md-typeset-a-color: rgb(28, 152, 152)
 }

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -29,7 +29,17 @@ nav:
 theme:
   name: material
   palette:
-    primary: deep purple
+    - scheme: default
+      primary: deep purple
+      toggle:
+        icon: material/toggle-switch-off-outline
+        name: Switch to dark mode
+    - scheme: slate
+      primary: indigo
+      accent: teal
+      toggle:
+        icon: material/toggle-switch
+        name: Switch to light mode
   features:
     - navigation.sections
     - navigation.expand


### PR DESCRIPTION
## Description of changes:

Something like this would be easier on the eyes when most of the time
you are coding in dark mode style themes

<img width="1622" alt="Screen Shot 2021-06-08 at 10 01 05 PM" src="https://user-images.githubusercontent.com/5442469/121296154-09880400-c8a5-11eb-8848-f7d3b023864c.png">

* [X] [Meet tenets criteria](https://awslabs.github.io/aws-lambda-powertools-python/#tenets)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
