### PR TITLE
fix(validator): handle built-in custom formats correctly

### DIFF
--- a/aws_lambda_powertools/utilities/validation/base.py
+++ b/aws_lambda_powertools/utilities/validation/base.py
@@ -32,6 +32,7 @@ def validate_data_against_schema(data: Dict, schema: Dict, formats: Optional[Dic
         When JSON schema provided is invalid
     """
     try:
+        formats = formats or {}
         fastjsonschema.validate(definition=schema, data=data, formats=formats)
     except (TypeError, AttributeError, fastjsonschema.JsonSchemaDefinitionException) as e:
         raise InvalidSchemaFormatError(f"Schema received: {schema}, Formats: {formats}. Error: {e}")

--- a/tests/functional/validator/conftest.py
+++ b/tests/functional/validator/conftest.py
@@ -565,3 +565,24 @@ def eventbridge_schema_registry_cloudtrail_v2_s3():
         "x-amazon-events-detail-type": "AWS API Call via CloudTrail",
         "x-amazon-events-source": "aws.s3",
     }
+
+
+@pytest.fixture
+def schema_datetime_format():
+    return {
+        "$schema": "http://json-schema.org/draft-07/schema",
+        "$id": "http://example.com/example.json",
+        "type": "object",
+        "title": "Sample schema with string date-time format",
+        "description": "The root schema comprises the entire JSON document.",
+        "required": ["message"],
+        "properties": {
+            "message": {
+                "$id": "#/properties/message",
+                "type": "string",
+                "format": "date-time",
+                "title": "The message",
+                "examples": ["hello world"],
+            },
+        },
+    }

--- a/tests/functional/validator/test_validator.py
+++ b/tests/functional/validator/test_validator.py
@@ -151,3 +151,12 @@ def test_custom_jmespath_function_overrides_builtin_functions(schema, wrapped_ev
             envelope="powertools_json(data).payload",
             jmespath_options=jmespath_opts,
         )
+
+
+def test_validate_date_time_format(schema_datetime_format):
+    raw_event = {"message": "2021-06-29T14:46:06.804Z"}
+    validate(event=raw_event, schema=schema_datetime_format)
+
+    invalid_datetime = {"message": "2021-06-29T14"}
+    with pytest.raises(exceptions.SchemaValidationError, match="data.message must be date-time"):
+        validate(event=invalid_datetime, schema=schema_datetime_format)


### PR DESCRIPTION
**Issue #, if available:** #496

## Description of changes:

<!--- One or two sentences as a summary of what's being changed -->

JSONSchema Draft 7 has support for custom built-in formats like `date-time`. This PR fixes a malformed input to the upstream JSON validator (`fastjsonschema`) which cannot differentiate between custom format and custom built-in formats.

If no custom formats are explicitly passed we default to a Dict when passing that as input to `fastjsonschema`. This leads to the right fallback mechanism in the upstream validator to search for built-in custom formats.

Example JSON schema field that triggered it:

```json
"message": {
    "$id": "#/properties/message",
    "type": "string",
    "format": "date-time",
    "title": "The message",
    "examples": ["hello world"],
},
```


**Checklist**

<!--- Leave unchecked if your change doesn't seem to apply --> 

* [x] [Meet tenets criteria](https://awslabs.github.io/aws-lambda-powertools-python/#tenets)
* [x] Update tests
* [x] Update docs
* [x] PR title follows [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-python/blob/376ec0a2ac0d2a40e0af5717bef42ff84ca0d1b9/.github/semantic.yml#L2)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
