### PR TITLE
docs(tracer): additional scenario when to disable auto-capture

### DIFF
--- a/docs/core/tracer.md
+++ b/docs/core/tracer.md
@@ -201,10 +201,11 @@ tracer = Tracer(patch_modules=modules_to_be_patched)
 
 Use **`capture_response=False`** parameter in both `capture_lambda_handler` and `capture_method` decorators to instruct Tracer **not** to serialize function responses as metadata.
 
-!!! info "This is commonly useful in two scenarios"
+!!! info "This is commonly useful in three scenarios"
 
 	1. You might **return sensitive** information you don't want it to be added to your traces
 	2. You might manipulate **streaming objects that can be read only once**; this prevents subsequent calls from being empty
+	3. You might return **more than 64K** of data _e.g., `message too long` error_
 
 === "sensitive_data_scenario.py"
 	```python hl_lines="3 7"


### PR DESCRIPTION
**Issue #, if available:** #476

## Description of changes:

This PR adds an additional scenario on when to disable auto-capture response - >64K responses

<!--- One or two sentences as a summary of what's being changed -->

**Checklist**

<!--- Leave unchecked if your change doesn't seem to apply --> 

* [x] [Meet tenets criteria](https://awslabs.github.io/aws-lambda-powertools-python/#tenets)
* [ ] Update tests
* [x] Update docs
* [x] PR title follows [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-python/blob/376ec0a2ac0d2a40e0af5717bef42ff84ca0d1b9/.github/semantic.yml#L2)

## Breaking change checklist

<!--- Ignore if it's not a breaking change -->

**RFC issue #**:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
