### PR TITLE
feat(api-gateway): add common service errors

### DIFF
--- a/aws_lambda_powertools/event_handler/__init__.py
+++ b/aws_lambda_powertools/event_handler/__init__.py
@@ -2,6 +2,7 @@
 Event handler decorators for common Lambda events
 """
 
+from .api_gateway import ApiGatewayResolver
 from .appsync import AppSyncResolver
 
-__all__ = ["AppSyncResolver"]
+__all__ = ["AppSyncResolver", "ApiGatewayResolver"]

--- a/aws_lambda_powertools/event_handler/api_gateway.py
+++ b/aws_lambda_powertools/event_handler/api_gateway.py
@@ -4,6 +4,7 @@ import logging
 import re
 import zlib
 from enum import Enum
+from http import HTTPStatus
 from typing import Any, Callable, Dict, List, Optional, Set, Union
 
 from aws_lambda_powertools.shared.json_encoder import Encoder
@@ -35,28 +36,28 @@ class BadRequestError(ServiceError):
     """Bad Request Error"""
 
     def __init__(self, msg: str):
-        super().__init__(400, msg)
+        super().__init__(HTTPStatus.BAD_REQUEST.value, msg)
 
 
 class UnauthorizedError(ServiceError):
     """Unauthorized Error"""
 
     def __init__(self, msg: str):
-        super().__init__(401, msg)
+        super().__init__(HTTPStatus.UNAUTHORIZED.value, msg)
 
 
 class NotFoundError(ServiceError):
     """Not Found Error"""
 
     def __init__(self, msg: str = "Not found"):
-        super().__init__(404, msg)
+        super().__init__(HTTPStatus.NOT_FOUND.value, msg)
 
 
 class InternalServerError(ServiceError):
     """Internal Server Error"""
 
     def __init__(self, message: str):
-        super().__init__(500, message)
+        super().__init__(HTTPStatus.INTERNAL_SERVER_ERROR.value, message)
 
 
 class ProxyEventType(Enum):
@@ -511,10 +512,10 @@ class ApiGatewayResolver:
 
         return ResponseBuilder(
             Response(
-                status_code=404,
+                status_code=HTTPStatus.NOT_FOUND.value,
                 content_type=APPLICATION_JSON,
                 headers=headers,
-                body=self._json_dump({"code": 404, "message": "Not found"}),
+                body=self._json_dump({"statusCode": HTTPStatus.NOT_FOUND.value, "message": "Not found"}),
             )
         )
 
@@ -527,7 +528,7 @@ class ApiGatewayResolver:
                 Response(
                     status_code=e.status_code,
                     content_type=APPLICATION_JSON,
-                    body=self._json_dump({"code": e.status_code, "message": e.msg}),
+                    body=self._json_dump({"statusCode": e.status_code, "message": e.msg}),
                 ),
                 route,
             )

--- a/aws_lambda_powertools/event_handler/api_gateway.py
+++ b/aws_lambda_powertools/event_handler/api_gateway.py
@@ -7,57 +7,14 @@ from enum import Enum
 from http import HTTPStatus
 from typing import Any, Callable, Dict, List, Optional, Set, Union
 
+from aws_lambda_powertools.event_handler import content_types
+from aws_lambda_powertools.event_handler.exceptions import ServiceError
 from aws_lambda_powertools.shared.json_encoder import Encoder
 from aws_lambda_powertools.utilities.data_classes import ALBEvent, APIGatewayProxyEvent, APIGatewayProxyEventV2
 from aws_lambda_powertools.utilities.data_classes.common import BaseProxyEvent
 from aws_lambda_powertools.utilities.typing import LambdaContext
 
 logger = logging.getLogger(__name__)
-APPLICATION_JSON = "application/json"
-
-
-class ServiceError(Exception):
-    """Service Error"""
-
-    def __init__(self, status_code: int, msg: str):
-        """
-        Parameters
-        ----------
-        status_code: int
-            Http status code
-        msg: str
-            Error message
-        """
-        self.status_code = status_code
-        self.msg = msg
-
-
-class BadRequestError(ServiceError):
-    """Bad Request Error"""
-
-    def __init__(self, msg: str):
-        super().__init__(HTTPStatus.BAD_REQUEST.value, msg)
-
-
-class UnauthorizedError(ServiceError):
-    """Unauthorized Error"""
-
-    def __init__(self, msg: str):
-        super().__init__(HTTPStatus.UNAUTHORIZED.value, msg)
-
-
-class NotFoundError(ServiceError):
-    """Not Found Error"""
-
-    def __init__(self, msg: str = "Not found"):
-        super().__init__(HTTPStatus.NOT_FOUND.value, msg)
-
-
-class InternalServerError(ServiceError):
-    """Internal Server Error"""
-
-    def __init__(self, message: str):
-        super().__init__(HTTPStatus.INTERNAL_SERVER_ERROR.value, message)
 
 
 class ProxyEventType(Enum):
@@ -513,7 +470,7 @@ class ApiGatewayResolver:
         return ResponseBuilder(
             Response(
                 status_code=HTTPStatus.NOT_FOUND.value,
-                content_type=APPLICATION_JSON,
+                content_type=content_types.APPLICATION_JSON,
                 headers=headers,
                 body=self._json_dump({"statusCode": HTTPStatus.NOT_FOUND.value, "message": "Not found"}),
             )
@@ -527,7 +484,7 @@ class ApiGatewayResolver:
             return ResponseBuilder(
                 Response(
                     status_code=e.status_code,
-                    content_type=APPLICATION_JSON,
+                    content_type=content_types.APPLICATION_JSON,
                     body=self._json_dump({"statusCode": e.status_code, "message": e.msg}),
                 ),
                 route,
@@ -548,7 +505,7 @@ class ApiGatewayResolver:
         logger.debug("Simple response detected, serializing return before constructing final response")
         return Response(
             status_code=200,
-            content_type=APPLICATION_JSON,
+            content_type=content_types.APPLICATION_JSON,
             body=self._json_dump(result),
         )
 

--- a/aws_lambda_powertools/event_handler/api_gateway.py
+++ b/aws_lambda_powertools/event_handler/api_gateway.py
@@ -18,72 +18,44 @@ APPLICATION_JSON = "application/json"
 class ServiceError(Exception):
     """Service Error"""
 
-    def __init__(self, status_code: int, message: str):
+    def __init__(self, status_code: int, msg: str):
         """
         Parameters
         ----------
-        code: int
+        status_code: int
             Http status code
-        message: str
+        msg: str
             Error message
         """
         self.status_code = status_code
-        self.message = message
-
-    def __str__(self) -> str:
-        """To string of the message only"""
-        return self.message
+        self.msg = msg
 
 
 class BadRequestError(ServiceError):
     """Bad Request Error"""
 
-    def __init__(self, message: str):
-        """
-        Parameters
-        ----------
-        message: str
-            Error message
-        """
-        super().__init__(400, message)
+    def __init__(self, msg: str):
+        super().__init__(400, msg)
 
 
 class UnauthorizedError(ServiceError):
     """Unauthorized Error"""
 
-    def __init__(self, message: str):
-        """
-        Parameters
-        ----------
-        message: str
-            Error message
-        """
-        super().__init__(401, message)
+    def __init__(self, msg: str):
+        super().__init__(401, msg)
 
 
 class NotFoundError(ServiceError):
     """Not Found Error"""
 
-    def __init__(self, message: str = "Not found"):
-        """
-        Parameters
-        ----------
-        message: str
-            Error message
-        """
-        super().__init__(404, message)
+    def __init__(self, msg: str = "Not found"):
+        super().__init__(404, msg)
 
 
 class InternalServerError(ServiceError):
-    """Internal Serve Error"""
+    """Internal Server Error"""
 
     def __init__(self, message: str):
-        """
-        Parameters
-        ----------
-        message: str
-            Error message
-        """
         super().__init__(500, message)
 
 
@@ -542,7 +514,7 @@ class ApiGatewayResolver:
                 status_code=404,
                 content_type=APPLICATION_JSON,
                 headers=headers,
-                body=json.dumps({"message": "Not found"}),
+                body=self._json_dump({"code": 404, "message": "Not found"}),
             )
         )
 
@@ -555,13 +527,12 @@ class ApiGatewayResolver:
                 Response(
                     status_code=e.status_code,
                     content_type=APPLICATION_JSON,
-                    body=json.dumps({"message": str(e)}),
+                    body=self._json_dump({"code": e.status_code, "message": e.msg}),
                 ),
                 route,
             )
 
-    @staticmethod
-    def _to_response(result: Union[Dict, Response]) -> Response:
+    def _to_response(self, result: Union[Dict, Response]) -> Response:
         """Convert the route's result to a Response
 
          2 main result types are supported:
@@ -577,5 +548,10 @@ class ApiGatewayResolver:
         return Response(
             status_code=200,
             content_type=APPLICATION_JSON,
-            body=json.dumps(result, separators=(",", ":"), cls=Encoder),
+            body=self._json_dump(result),
         )
+
+    @staticmethod
+    def _json_dump(obj: Any) -> str:
+        """Does a concise json serialization"""
+        return json.dumps(obj, separators=(",", ":"), cls=Encoder)

--- a/aws_lambda_powertools/event_handler/content_types.py
+++ b/aws_lambda_powertools/event_handler/content_types.py
@@ -1,0 +1,2 @@
+APPLICATION_JSON = "application/json"
+PLAIN_TEXT = "plain/text"

--- a/aws_lambda_powertools/event_handler/exceptions.py
+++ b/aws_lambda_powertools/event_handler/exceptions.py
@@ -21,25 +21,25 @@ class BadRequestError(ServiceError):
     """Bad Request Error"""
 
     def __init__(self, msg: str):
-        super().__init__(HTTPStatus.BAD_REQUEST.value, msg)
+        super().__init__(HTTPStatus.BAD_REQUEST, msg)
 
 
 class UnauthorizedError(ServiceError):
     """Unauthorized Error"""
 
     def __init__(self, msg: str):
-        super().__init__(HTTPStatus.UNAUTHORIZED.value, msg)
+        super().__init__(HTTPStatus.UNAUTHORIZED, msg)
 
 
 class NotFoundError(ServiceError):
     """Not Found Error"""
 
     def __init__(self, msg: str = "Not found"):
-        super().__init__(HTTPStatus.NOT_FOUND.value, msg)
+        super().__init__(HTTPStatus.NOT_FOUND, msg)
 
 
 class InternalServerError(ServiceError):
     """Internal Server Error"""
 
     def __init__(self, message: str):
-        super().__init__(HTTPStatus.INTERNAL_SERVER_ERROR.value, message)
+        super().__init__(HTTPStatus.INTERNAL_SERVER_ERROR, message)

--- a/aws_lambda_powertools/event_handler/exceptions.py
+++ b/aws_lambda_powertools/event_handler/exceptions.py
@@ -1,0 +1,45 @@
+from http import HTTPStatus
+
+
+class ServiceError(Exception):
+    """Service Error"""
+
+    def __init__(self, status_code: int, msg: str):
+        """
+        Parameters
+        ----------
+        status_code: int
+            Http status code
+        msg: str
+            Error message
+        """
+        self.status_code = status_code
+        self.msg = msg
+
+
+class BadRequestError(ServiceError):
+    """Bad Request Error"""
+
+    def __init__(self, msg: str):
+        super().__init__(HTTPStatus.BAD_REQUEST.value, msg)
+
+
+class UnauthorizedError(ServiceError):
+    """Unauthorized Error"""
+
+    def __init__(self, msg: str):
+        super().__init__(HTTPStatus.UNAUTHORIZED.value, msg)
+
+
+class NotFoundError(ServiceError):
+    """Not Found Error"""
+
+    def __init__(self, msg: str = "Not found"):
+        super().__init__(HTTPStatus.NOT_FOUND.value, msg)
+
+
+class InternalServerError(ServiceError):
+    """Internal Server Error"""
+
+    def __init__(self, message: str):
+        super().__init__(HTTPStatus.INTERNAL_SERVER_ERROR.value, message)

--- a/tests/functional/event_handler/test_api_gateway.py
+++ b/tests/functional/event_handler/test_api_gateway.py
@@ -517,7 +517,7 @@ def test_service_error_responses():
     # AND status code equals 400
     assert result["statusCode"] == 400
     assert result["headers"]["Content-Type"] == APPLICATION_JSON
-    expected = {"code": 400, "message": "Missing required parameter"}
+    expected = {"statusCode": 400, "message": "Missing required parameter"}
     assert result["body"] == json_dump(expected)
 
     # GIVEN an UnauthorizedError
@@ -532,7 +532,7 @@ def test_service_error_responses():
     # AND status code equals 401
     assert result["statusCode"] == 401
     assert result["headers"]["Content-Type"] == APPLICATION_JSON
-    expected = {"code": 401, "message": "Unauthorized"}
+    expected = {"statusCode": 401, "message": "Unauthorized"}
     assert result["body"] == json_dump(expected)
 
     # GIVEN an NotFoundError
@@ -547,7 +547,7 @@ def test_service_error_responses():
     # AND status code equals 404
     assert result["statusCode"] == 404
     assert result["headers"]["Content-Type"] == APPLICATION_JSON
-    expected = {"code": 404, "message": "Not found"}
+    expected = {"statusCode": 404, "message": "Not found"}
     assert result["body"] == json_dump(expected)
 
     # GIVEN an InternalServerError
@@ -562,7 +562,7 @@ def test_service_error_responses():
     # AND status code equals 500
     assert result["statusCode"] == 500
     assert result["headers"]["Content-Type"] == APPLICATION_JSON
-    expected = {"code": 500, "message": "Internal server error"}
+    expected = {"statusCode": 500, "message": "Internal server error"}
     assert result["body"] == json_dump(expected)
 
     # GIVEN an ServiceError with a custom status code
@@ -578,5 +578,5 @@ def test_service_error_responses():
     assert result["statusCode"] == 502
     assert result["headers"]["Content-Type"] == APPLICATION_JSON
     assert "Access-Control-Allow-Origin" in result["headers"]
-    expected = {"code": 502, "message": "Something went wrong!"}
+    expected = {"statusCode": 502, "message": "Something went wrong!"}
     assert result["body"] == json_dump(expected)

--- a/tests/functional/event_handler/test_api_gateway.py
+++ b/tests/functional/event_handler/test_api_gateway.py
@@ -5,16 +5,18 @@ from decimal import Decimal
 from pathlib import Path
 from typing import Dict
 
+from aws_lambda_powertools.event_handler import content_types
 from aws_lambda_powertools.event_handler.api_gateway import (
-    APPLICATION_JSON,
     ApiGatewayResolver,
-    BadRequestError,
     CORSConfig,
-    InternalServerError,
-    NotFoundError,
     ProxyEventType,
     Response,
     ResponseBuilder,
+)
+from aws_lambda_powertools.event_handler.exceptions import (
+    BadRequestError,
+    InternalServerError,
+    NotFoundError,
     ServiceError,
     UnauthorizedError,
 )
@@ -60,7 +62,7 @@ def test_api_gateway_v1():
     def get_lambda() -> Response:
         assert isinstance(app.current_event, APIGatewayProxyEvent)
         assert app.lambda_context == {}
-        return Response(200, APPLICATION_JSON, json.dumps({"foo": "value"}))
+        return Response(200, content_types.APPLICATION_JSON, json.dumps({"foo": "value"}))
 
     # WHEN calling the event handler
     result = app(LOAD_GW_EVENT, {})
@@ -68,7 +70,7 @@ def test_api_gateway_v1():
     # THEN process event correctly
     # AND set the current_event type as APIGatewayProxyEvent
     assert result["statusCode"] == 200
-    assert result["headers"]["Content-Type"] == APPLICATION_JSON
+    assert result["headers"]["Content-Type"] == content_types.APPLICATION_JSON
 
 
 def test_api_gateway():
@@ -98,7 +100,7 @@ def test_api_gateway_v2():
     def my_path() -> Response:
         assert isinstance(app.current_event, APIGatewayProxyEventV2)
         post_data = app.current_event.json_body
-        return Response(200, "plain/text", post_data["username"])
+        return Response(200, content_types.PLAIN_TEXT, post_data["username"])
 
     # WHEN calling the event handler
     result = app(load_event("apiGatewayProxyV2Event.json"), {})
@@ -106,7 +108,7 @@ def test_api_gateway_v2():
     # THEN process event correctly
     # AND set the current_event type as APIGatewayProxyEventV2
     assert result["statusCode"] == 200
-    assert result["headers"]["Content-Type"] == "plain/text"
+    assert result["headers"]["Content-Type"] == content_types.PLAIN_TEXT
     assert result["body"] == "tom"
 
 
@@ -220,7 +222,7 @@ def test_compress():
 
     @app.get("/my/request", compress=True)
     def with_compression() -> Response:
-        return Response(200, APPLICATION_JSON, expected_value)
+        return Response(200, content_types.APPLICATION_JSON, expected_value)
 
     def handler(event, context):
         return app.resolve(event, context)
@@ -266,7 +268,7 @@ def test_compress_no_accept_encoding():
 
     @app.get("/my/path", compress=True)
     def return_text() -> Response:
-        return Response(200, "text/plain", expected_value)
+        return Response(200, content_types.PLAIN_TEXT, expected_value)
 
     # WHEN calling the event handler
     result = app({"path": "/my/path", "httpMethod": "GET", "headers": {}}, None)
@@ -332,7 +334,7 @@ def test_rest_api():
 
     # THEN automatically process this as a json rest api response
     assert result["statusCode"] == 200
-    assert result["headers"]["Content-Type"] == APPLICATION_JSON
+    assert result["headers"]["Content-Type"] == content_types.APPLICATION_JSON
     expected_str = json.dumps(expected_dict, separators=(",", ":"), indent=None, cls=Encoder)
     assert result["body"] == expected_str
 
@@ -387,7 +389,7 @@ def test_custom_cors_config():
     # THEN routes by default return the custom cors headers
     assert "headers" in result
     headers = result["headers"]
-    assert headers["Content-Type"] == APPLICATION_JSON
+    assert headers["Content-Type"] == content_types.APPLICATION_JSON
     assert headers["Access-Control-Allow-Origin"] == cors_config.allow_origin
     expected_allows_headers = ",".join(sorted(set(allow_header + cors_config._REQUIRED_HEADERS)))
     assert headers["Access-Control-Allow-Headers"] == expected_allows_headers
@@ -516,7 +518,7 @@ def test_service_error_responses():
     # THEN return the bad request error response
     # AND status code equals 400
     assert result["statusCode"] == 400
-    assert result["headers"]["Content-Type"] == APPLICATION_JSON
+    assert result["headers"]["Content-Type"] == content_types.APPLICATION_JSON
     expected = {"statusCode": 400, "message": "Missing required parameter"}
     assert result["body"] == json_dump(expected)
 
@@ -531,7 +533,7 @@ def test_service_error_responses():
     # THEN return the unauthorized error response
     # AND status code equals 401
     assert result["statusCode"] == 401
-    assert result["headers"]["Content-Type"] == APPLICATION_JSON
+    assert result["headers"]["Content-Type"] == content_types.APPLICATION_JSON
     expected = {"statusCode": 401, "message": "Unauthorized"}
     assert result["body"] == json_dump(expected)
 
@@ -546,7 +548,7 @@ def test_service_error_responses():
     # THEN return the not found error response
     # AND status code equals 404
     assert result["statusCode"] == 404
-    assert result["headers"]["Content-Type"] == APPLICATION_JSON
+    assert result["headers"]["Content-Type"] == content_types.APPLICATION_JSON
     expected = {"statusCode": 404, "message": "Not found"}
     assert result["body"] == json_dump(expected)
 
@@ -561,7 +563,7 @@ def test_service_error_responses():
     # THEN return the internal server error response
     # AND status code equals 500
     assert result["statusCode"] == 500
-    assert result["headers"]["Content-Type"] == APPLICATION_JSON
+    assert result["headers"]["Content-Type"] == content_types.APPLICATION_JSON
     expected = {"statusCode": 500, "message": "Internal server error"}
     assert result["body"] == json_dump(expected)
 
@@ -576,7 +578,7 @@ def test_service_error_responses():
     # THEN return the service error response
     # AND status code equals 502
     assert result["statusCode"] == 502
-    assert result["headers"]["Content-Type"] == APPLICATION_JSON
+    assert result["headers"]["Content-Type"] == content_types.APPLICATION_JSON
     assert "Access-Control-Allow-Origin" in result["headers"]
     expected = {"statusCode": 502, "message": "Something went wrong!"}
     assert result["body"] == json_dump(expected)


### PR DESCRIPTION
**Issue #, if available:**

- https://github.com/awslabs/aws-lambda-powertools-roadmap/issues/8

Pairs with https://github.com/awslabs/aws-lambda-powertools-python/pull/507

## Description of changes:

Changes:
- Add base ServiceError exception for rest api service errors
- BaseRequestError for 400s
- UnauthorizedError for 401s
- NotFoundError for 404s
- InternalServerError for 500s


Example usage for a unauthorized error

```python3
@app.route(method="GET", rule="/unauthorized-error")
def unauthorized_error():
    raise UnauthorizedError("Unauthorized")
```

will return:

```json5
{
	"statusCode": 401,
	"headers": {
		"Content-Type": "application/json"
	},
	"body: "{'statusCode':401,''message':'Unauthorized'}"
}
```

> NOTE: This is related to https://github.com/awslabs/aws-lambda-powertools-python/pull/507

**Checklist**

<!--- Leave unchecked if your change doesn't seem to apply --> 

* [X] [Meet tenets criteria](https://awslabs.github.io/aws-lambda-powertools-python/#tenets)
* [X] Update tests
* [ ] Update docs
* [X] PR title follows [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-python/blob/376ec0a2ac0d2a40e0af5717bef42ff84ca0d1b9/.github/semantic.yml#L2)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
