### PR TITLE
fix(parser): Make ApiGateway version, authorizer fields optional

### DIFF
--- a/aws_lambda_powertools/utilities/parser/models/apigw.py
+++ b/aws_lambda_powertools/utilities/parser/models/apigw.py
@@ -46,7 +46,7 @@ class APIGatewayEventAuthorizer(BaseModel):
 class APIGatewayEventRequestContext(BaseModel):
     accountId: str
     apiId: str
-    authorizer: APIGatewayEventAuthorizer
+    authorizer: Optional[APIGatewayEventAuthorizer]
     stage: str
     protocol: str
     identity: APIGatewayEventIdentity
@@ -70,7 +70,7 @@ class APIGatewayEventRequestContext(BaseModel):
 
 
 class APIGatewayProxyEventModel(BaseModel):
-    version: str
+    version: Optional[str]
     resource: str
     path: str
     httpMethod: Literal["DELETE", "GET", "HEAD", "OPTIONS", "PATCH", "POST", "PUT"]

--- a/tests/events/apiGatewayProxyEvent_noVersionAuth.json
+++ b/tests/events/apiGatewayProxyEvent_noVersionAuth.json
@@ -1,0 +1,75 @@
+{
+  "resource": "/my/path",
+  "path": "/my/path",
+  "httpMethod": "GET",
+  "headers": {
+    "Header1": "value1",
+    "Header2": "value2"
+  },
+  "multiValueHeaders": {
+    "Header1": [
+      "value1"
+    ],
+    "Header2": [
+      "value1",
+      "value2"
+    ]
+  },
+  "queryStringParameters": {
+    "parameter1": "value1",
+    "parameter2": "value"
+  },
+  "multiValueQueryStringParameters": {
+    "parameter1": [
+      "value1",
+      "value2"
+    ],
+    "parameter2": [
+      "value"
+    ]
+  },
+  "requestContext": {
+    "accountId": "123456789012",
+    "apiId": "id",
+    "domainName": "id.execute-api.us-east-1.amazonaws.com",
+    "domainPrefix": "id",
+    "extendedRequestId": "request-id",
+    "httpMethod": "GET",
+    "identity": {
+      "accessKey": null,
+      "accountId": null,
+      "caller": null,
+      "cognitoAuthenticationProvider": null,
+      "cognitoAuthenticationType": null,
+      "cognitoIdentityId": null,
+      "cognitoIdentityPoolId": null,
+      "principalOrgId": null,
+      "sourceIp": "192.168.0.1/32",
+      "user": null,
+      "userAgent": "user-agent",
+      "userArn": null,
+      "clientCert": {
+        "clientCertPem": "CERT_CONTENT",
+        "subjectDN": "www.example.com",
+        "issuerDN": "Example issuer",
+        "serialNumber": "a1:a1:a1:a1:a1:a1:a1:a1:a1:a1:a1:a1:a1:a1:a1:a1",
+        "validity": {
+          "notBefore": "May 28 12:30:02 2019 GMT",
+          "notAfter": "Aug  5 09:36:04 2021 GMT"
+        }
+      }
+    },
+    "path": "/my/path",
+    "protocol": "HTTP/1.1",
+    "requestId": "id=",
+    "requestTime": "04/Mar/2020:19:15:17 +0000",
+    "requestTimeEpoch": 1583349317135,
+    "resourceId": null,
+    "resourcePath": "/my/path",
+    "stage": "$default"
+  },
+  "pathParameters": null,
+  "stageVariables": null,
+  "body": "Hello from Lambda!",
+  "isBase64Encoded": true
+}

--- a/tests/functional/test_data_classes.py
+++ b/tests/functional/test_data_classes.py
@@ -743,6 +743,70 @@ def test_seq_trigger_event():
     assert record.aws_region == "us-east-2"
 
 
+def test_default_api_gateway_proxy_event():
+    event = APIGatewayProxyEvent(load_event("apiGatewayProxyEvent_noVersionAuth.json"))
+
+    assert event.get("version") is None
+    assert event.resource == event["resource"]
+    assert event.path == event["path"]
+    assert event.http_method == event["httpMethod"]
+    assert event.headers == event["headers"]
+    assert event.multi_value_headers == event["multiValueHeaders"]
+    assert event.query_string_parameters == event["queryStringParameters"]
+    assert event.multi_value_query_string_parameters == event["multiValueQueryStringParameters"]
+
+    request_context = event.request_context
+    assert request_context.account_id == event["requestContext"]["accountId"]
+    assert request_context.api_id == event["requestContext"]["apiId"]
+
+    assert request_context.get("authorizer") is None
+
+    assert request_context.domain_name == event["requestContext"]["domainName"]
+    assert request_context.domain_prefix == event["requestContext"]["domainPrefix"]
+    assert request_context.extended_request_id == event["requestContext"]["extendedRequestId"]
+    assert request_context.http_method == event["requestContext"]["httpMethod"]
+
+    identity = request_context.identity
+    assert identity.access_key == event["requestContext"]["identity"]["accessKey"]
+    assert identity.account_id == event["requestContext"]["identity"]["accountId"]
+    assert identity.caller == event["requestContext"]["identity"]["caller"]
+    assert (
+        identity.cognito_authentication_provider == event["requestContext"]["identity"]["cognitoAuthenticationProvider"]
+    )
+    assert identity.cognito_authentication_type == event["requestContext"]["identity"]["cognitoAuthenticationType"]
+    assert identity.cognito_identity_id == event["requestContext"]["identity"]["cognitoIdentityId"]
+    assert identity.cognito_identity_pool_id == event["requestContext"]["identity"]["cognitoIdentityPoolId"]
+    assert identity.principal_org_id == event["requestContext"]["identity"]["principalOrgId"]
+    assert identity.source_ip == event["requestContext"]["identity"]["sourceIp"]
+    assert identity.user == event["requestContext"]["identity"]["user"]
+    assert identity.user_agent == event["requestContext"]["identity"]["userAgent"]
+    assert identity.user_arn == event["requestContext"]["identity"]["userArn"]
+
+    assert request_context.path == event["requestContext"]["path"]
+    assert request_context.protocol == event["requestContext"]["protocol"]
+    assert request_context.request_id == event["requestContext"]["requestId"]
+    assert request_context.request_time == event["requestContext"]["requestTime"]
+    assert request_context.request_time_epoch == event["requestContext"]["requestTimeEpoch"]
+    assert request_context.resource_id == event["requestContext"]["resourceId"]
+    assert request_context.resource_path == event["requestContext"]["resourcePath"]
+    assert request_context.stage == event["requestContext"]["stage"]
+
+    assert event.path_parameters == event["pathParameters"]
+    assert event.stage_variables == event["stageVariables"]
+    assert event.body == event["body"]
+    assert event.is_base64_encoded == event["isBase64Encoded"]
+
+    assert request_context.connected_at is None
+    assert request_context.connection_id is None
+    assert request_context.event_type is None
+    assert request_context.message_direction is None
+    assert request_context.message_id is None
+    assert request_context.route_key is None
+    assert request_context.operation_name is None
+    assert identity.api_key is None
+    assert identity.api_key_id is None
+
+
 def test_api_gateway_proxy_event():
     event = APIGatewayProxyEvent(load_event("apiGatewayProxyEvent.json"))
 


### PR DESCRIPTION
**Issue #531 **

## Description of changes:

Change to APIGatewayProxyEventModel to make "version" Optional
Change to APIGatewayEventRequestContext to make "authorizer" Optional

**Checklist**

<!--- Leave unchecked if your change doesn't seem to apply --> 

* [x] [Meet tenets criteria](https://awslabs.github.io/aws-lambda-powertools-python/#tenets)
* [x] Update tests
* [ ] Update docs
* [x] PR title follows [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-python/blob/376ec0a2ac0d2a40e0af5717bef42ff84ca0d1b9/.github/semantic.yml#L2)

## Breaking change checklist

**RFC issue #**:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
