### PR TITLE
fix(api-gateway): non-greedy route pattern regex

### DIFF
--- a/tests/functional/event_handler/test_api_gateway.py
+++ b/tests/functional/event_handler/test_api_gateway.py
@@ -672,31 +672,30 @@ def test_similar_dynamic_routes():
     app = ApiGatewayResolver()
     event = deepcopy(LOAD_GW_EVENT)
 
+    # WHEN
     # r'^/accounts/(?P<account_id>\\w+\\b)$' # noqa: E800
     @app.get("/accounts/<account_id>")
     def get_account(account_id: str):
         assert account_id == "single_account"
-        return {"message": f"{account_id}"}
 
     # r'^/accounts/(?P<account_id>\\w+\\b)/source_networks$' # noqa: E800
     @app.get("/accounts/<account_id>/source_networks")
     def get_account_networks(account_id: str):
         assert account_id == "nested_account"
-        return {"message": f"{account_id}"}
 
     # r'^/accounts/(?P<account_id>\\w+\\b)/source_networks/(?P<network_id>\\w+\\b)$' # noqa: E800
     @app.get("/accounts/<account_id>/source_networks/<network_id>")
     def get_network_account(account_id: str, network_id: str):
         assert account_id == "nested_account"
         assert network_id == "network"
-        return {"message": f"{account_id}"}
+
+    # THEN
+    event["resource"] = "/accounts/{account_id}"
+    event["path"] = "/accounts/single_account"
+    app.resolve(event, None)
 
     event["resource"] = "/accounts/{account_id}/source_networks"
     event["path"] = "/accounts/nested_account/source_networks"
-    app.resolve(event, None)
-
-    event["resource"] = "/accounts/{account_id}"
-    event["path"] = "/accounts/single_account"
     app.resolve(event, None)
 
     event["resource"] = "/accounts/{account_id}/source_networks/{network_id}"


### PR DESCRIPTION
**Issue #, if available:** #520

## Description of changes:

<!--- One or two sentences as a summary of what's being changed -->

This fixes a regex bug that used a greedy pattern ending with incorrect path resolution, as any path after a pattern would be included in the argument.

Excerpt:

```python
@app.get("/accounts/<account_id>")
def get_account(account_id: str):
    print(f"Account ID ({account_id}) would be 123")

# Greedy regex would inject the incorrect function parameter
@app.get("/accounts/<account_id>/source_networks")
def get_account_networks(account_id: str):
    # re.compile()
    print(f"Account ID ({account_id}) would be 123/source_networks")
```

In this example, say we have a GET request as `/accounts/123` and another as `/accounts/123/source_networks`, we'd have the following effect prior to this fix:

Function | Regex | Effective account_id value
------------------------------------------------- | --------------------------------------------------------------------------------- | -------------------------------------------------
get_account | `r'^/accounts/(?P<account_id>.+)$'` | `123`
get_account_networks | `r'^/accounts/(?P<account_id>.+)/source_networks$'` |  `123/source_networks`

With this fix, `account_id` parameter would be 123 in both occasions due to [word boundary](https://www.regular-expressions.info/wordboundaries.html) not being non-greedy. This also allows an arbitrary number of dynamic route paths and static route paths.

Function | Regex | Effective account_id value
------------------------------------------------- | --------------------------------------------------------------------------------- | -------------------------------------------------
get_account | `r'^/accounts/(?P<account_id>\\w+\\b)$'` | `123`
get_account_networks | `r'^/accounts/(?P<account_id>\\w+\\b)/source_networks$'` |  `123`

**Checklist**

<!--- Leave unchecked if your change doesn't seem to apply --> 

* [x] [Meet tenets criteria](https://awslabs.github.io/aws-lambda-powertools-python/#tenets)
* [x] Update tests
* [x] PR title follows [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-python/blob/376ec0a2ac0d2a40e0af5717bef42ff84ca0d1b9/.github/semantic.yml#L2)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
