### PR TITLE
feat(data-classes): decode json_body if based64 encoded

### DIFF
--- a/aws_lambda_powertools/utilities/data_classes/common.py
+++ b/aws_lambda_powertools/utilities/data_classes/common.py
@@ -65,7 +65,7 @@ class BaseProxyEvent(DictWrapper):
     @property
     def json_body(self) -> Any:
         """Parses the submitted body as json"""
-        return json.loads(self["body"])
+        return json.loads(self.decoded_body)
 
     @property
     def decoded_body(self) -> str:

--- a/tests/functional/test_data_classes.py
+++ b/tests/functional/test_data_classes.py
@@ -1037,6 +1037,18 @@ def test_base_proxy_event_decode_body_encoded_true():
     assert event.decoded_body == data
 
 
+def test_base_proxy_event_json_body_with_base64_encoded_data():
+    # GIVEN a base64 encoded json body
+    data = {"message": "Foo"}
+    data_str = json.dumps(data)
+    encoded_data = base64.b64encode(data_str.encode()).decode()
+    event = BaseProxyEvent({"body": encoded_data, "isBase64Encoded": True})
+
+    # WHEN calling json_body
+    # THEN then base64 decode and json load
+    assert event.json_body == data
+
+
 def test_kinesis_stream_event():
     event = KinesisStreamEvent(load_event("kinesisStreamEvent.json"))
 


### PR DESCRIPTION
**Issue #, if available:**

- #544

## Description of changes:

Use `decoded_body` for the body in `json_body`. This will allow for a json string that is base64 encoded to be decoded and parsed in one go.

**Checklist**

<!--- Leave unchecked if your change doesn't seem to apply --> 

* [X] [Meet tenets criteria](https://awslabs.github.io/aws-lambda-powertools-python/#tenets)
* [X] Update tests
* [X] Update docs
* [X] PR title follows [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-python/blob/376ec0a2ac0d2a40e0af5717bef42ff84ca0d1b9/.github/semantic.yml#L2)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
