### PR TITLE
feat(params): expose high level max_age, raise_on_transform_error

### DIFF
--- a/aws_lambda_powertools/utilities/parameters/appconfig.py
+++ b/aws_lambda_powertools/utilities/parameters/appconfig.py
@@ -12,7 +12,7 @@ from botocore.config import Config
 
 from ...shared import constants
 from ...shared.functions import resolve_env_var_choice
-from .base import DEFAULT_PROVIDERS, BaseProvider
+from .base import DEFAULT_MAX_AGE_SECS, DEFAULT_PROVIDERS, BaseProvider
 
 CLIENT_ID = str(uuid4())
 
@@ -110,6 +110,7 @@ def get_app_config(
     application: Optional[str] = None,
     transform: Optional[str] = None,
     force_fetch: bool = False,
+    max_age: int = DEFAULT_MAX_AGE_SECS,
     **sdk_options
 ) -> Union[str, list, dict, bytes]:
     """
@@ -127,6 +128,8 @@ def get_app_config(
         Transforms the content from a JSON object ('json') or base64 binary string ('binary')
     force_fetch: bool, optional
         Force update even before a cached item has expired, defaults to False
+    max_age: int
+        Maximum age of the cached value
     sdk_options: dict, optional
         Dictionary of options that will be passed to the Parameter Store get_parameter API call
 
@@ -165,4 +168,6 @@ def get_app_config(
 
     sdk_options["ClientId"] = CLIENT_ID
 
-    return DEFAULT_PROVIDERS["appconfig"].get(name, transform=transform, force_fetch=force_fetch, **sdk_options)
+    return DEFAULT_PROVIDERS["appconfig"].get(
+        name, max_age=max_age, transform=transform, force_fetch=force_fetch, **sdk_options
+    )

--- a/aws_lambda_powertools/utilities/parameters/secrets.py
+++ b/aws_lambda_powertools/utilities/parameters/secrets.py
@@ -8,7 +8,7 @@ from typing import Any, Dict, Optional, Union
 import boto3
 from botocore.config import Config
 
-from .base import DEFAULT_PROVIDERS, BaseProvider
+from .base import DEFAULT_MAX_AGE_SECS, DEFAULT_PROVIDERS, BaseProvider
 
 
 class SecretsProvider(BaseProvider):
@@ -94,7 +94,11 @@ class SecretsProvider(BaseProvider):
 
 
 def get_secret(
-    name: str, transform: Optional[str] = None, force_fetch: bool = False, **sdk_options
+    name: str,
+    transform: Optional[str] = None,
+    force_fetch: bool = False,
+    max_age: int = DEFAULT_MAX_AGE_SECS,
+    **sdk_options
 ) -> Union[str, dict, bytes]:
     """
     Retrieve a parameter value from AWS Secrets Manager
@@ -107,6 +111,8 @@ def get_secret(
         Transforms the content from a JSON object ('json') or base64 binary string ('binary')
     force_fetch: bool, optional
         Force update even before a cached item has expired, defaults to False
+    max_age: int
+        Maximum age of the cached value
     sdk_options: dict, optional
         Dictionary of options that will be passed to the get_secret_value call
 
@@ -143,4 +149,6 @@ def get_secret(
     if "secrets" not in DEFAULT_PROVIDERS:
         DEFAULT_PROVIDERS["secrets"] = SecretsProvider()
 
-    return DEFAULT_PROVIDERS["secrets"].get(name, transform=transform, force_fetch=force_fetch, **sdk_options)
+    return DEFAULT_PROVIDERS["secrets"].get(
+        name, max_age=max_age, transform=transform, force_fetch=force_fetch, **sdk_options
+    )

--- a/aws_lambda_powertools/utilities/parameters/ssm.py
+++ b/aws_lambda_powertools/utilities/parameters/ssm.py
@@ -186,7 +186,12 @@ class SSMProvider(BaseProvider):
 
 
 def get_parameter(
-    name: str, transform: Optional[str] = None, decrypt: bool = False, force_fetch: bool = False, **sdk_options
+    name: str,
+    transform: Optional[str] = None,
+    decrypt: bool = False,
+    force_fetch: bool = False,
+    max_age: int = DEFAULT_MAX_AGE_SECS,
+    **sdk_options
 ) -> Union[str, list, dict, bytes]:
     """
     Retrieve a parameter value from AWS Systems Manager (SSM) Parameter Store
@@ -201,6 +206,8 @@ def get_parameter(
         If the parameter values should be decrypted
     force_fetch: bool, optional
         Force update even before a cached item has expired, defaults to False
+    max_age: int
+        Maximum age of the cached value
     sdk_options: dict, optional
         Dictionary of options that will be passed to the Parameter Store get_parameter API call
 
@@ -240,7 +247,9 @@ def get_parameter(
     # Add to `decrypt` sdk_options to we can have an explicit option for this
     sdk_options["decrypt"] = decrypt
 
-    return DEFAULT_PROVIDERS["ssm"].get(name, transform=transform, force_fetch=force_fetch, **sdk_options)
+    return DEFAULT_PROVIDERS["ssm"].get(
+        name, max_age=max_age, transform=transform, force_fetch=force_fetch, **sdk_options
+    )
 
 
 def get_parameters(
@@ -249,6 +258,8 @@ def get_parameters(
     recursive: bool = True,
     decrypt: bool = False,
     force_fetch: bool = False,
+    max_age: int = DEFAULT_MAX_AGE_SECS,
+    raise_on_transform_error: bool = False,
     **sdk_options
 ) -> Union[Dict[str, str], Dict[str, dict], Dict[str, bytes]]:
     """
@@ -266,6 +277,11 @@ def get_parameters(
         If the parameter values should be decrypted
     force_fetch: bool, optional
         Force update even before a cached item has expired, defaults to False
+    max_age: int
+        Maximum age of the cached value
+    raise_on_transform_error: bool, optional
+        Raises an exception if any transform fails, otherwise this will
+        return a None value for each transform that failed
     sdk_options: dict, optional
         Dictionary of options that will be passed to the Parameter Store get_parameters_by_path API call
 
@@ -305,4 +321,11 @@ def get_parameters(
     sdk_options["recursive"] = recursive
     sdk_options["decrypt"] = decrypt
 
-    return DEFAULT_PROVIDERS["ssm"].get_multiple(path, transform=transform, force_fetch=force_fetch, **sdk_options)
+    return DEFAULT_PROVIDERS["ssm"].get_multiple(
+        path,
+        max_age=max_age,
+        transform=transform,
+        raise_on_transform_error=raise_on_transform_error,
+        force_fetch=force_fetch,
+        **sdk_options
+    )


### PR DESCRIPTION
**Issue #, if available:**
- https://github.com/awslabs/aws-lambda-powertools-python/issues/561

## Description of changes:

Expose the following parameters at the top level interface:

- max_age
- raise_on_transform_error

**Checklist**

<!--- Leave unchecked if your change doesn't seem to apply --> 

* [X] [Meet tenets criteria](https://awslabs.github.io/aws-lambda-powertools-python/#tenets)
* [X] Update tests
* [X] Update docs
* [X] PR title follows [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-python/blob/376ec0a2ac0d2a40e0af5717bef42ff84ca0d1b9/.github/semantic.yml#L2)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
