### PR TITLE
docs(parameters): auto-transforming values based on suffix

### DIFF
--- a/docs/utilities/parameters.md
+++ b/docs/utilities/parameters.md
@@ -443,22 +443,23 @@ If you use `transform` with `get_multiple()`, you might want to retrieve and tra
 
 !!! info "The `transform="auto"` feature is available across all providers, including the high level functions"
 
-=== "partial_failures.py"
+=== "transform_auto.py"
 
-````python hl_lines="6"
+    ```python hl_lines="6"
     from aws_lambda_powertools.utilities import parameters
 
     ssm_provider = parameters.SSMProvider()
 
     def handler(event, context):
         values = ssm_provider.get_multiple("/param", transform="auto")
+    ```
 
 For example, if you have two parameters with the following suffixes `.json` and `.binary`:
 
-| Parameter name  | Parameter value         |
-| --------------- | ----------------------- |
-| /param/a.json   | [some encoded value]    |
-| /param/a.binary | [some encoded value]    |
+| Parameter name  | Parameter value      |
+| --------------- | -------------------- |
+| /param/a.json   | [some encoded value] |
+| /param/a.binary | [some encoded value] |
 
 The return of `ssm_provider.get_multiple("/param", transform="auto")` call will be a dictionary like:
 
@@ -468,7 +469,6 @@ The return of `ssm_provider.get_multiple("/param", transform="auto")` call will 
     "b.binary": [some value]
 }
 ```
-````
 
 ### Passing additional SDK arguments
 

--- a/docs/utilities/parameters.md
+++ b/docs/utilities/parameters.md
@@ -437,11 +437,13 @@ For example, if you have three parameters, */param/a*, */param/b* and */param/c*
         values = ssm_provider.get_multiple("/param", transform="json", raise_on_transform_error=True)
     ```
 
-#### Infer transform from parameter suffix with `get_multiple()`
+#### Auto-transform values on suffix
 
-If you use `transform` with `get_multiple()`, you might want to retrieve and transform parameters encoded in different formats. You can do this with a single request by using `transform="auto"` and let the infer the transform type to use based on the parameter suffix.
+If you use `transform` with `get_multiple()`, you might want to retrieve and transform parameters encoded in different formats.
 
-!!! info "The `transform="auto"` feature is available across all providers, including the high level functions"
+You can do this with a single request by using `transform="auto"`. This will instruct any Parameter to to infer its type based on the suffix and transform it accordingly.
+
+!!! info "`transform="auto"` feature is available across all providers, including the high level functions"
 
 === "transform_auto.py"
 

--- a/docs/utilities/parameters.md
+++ b/docs/utilities/parameters.md
@@ -437,6 +437,39 @@ For example, if you have three parameters, */param/a*, */param/b* and */param/c*
         values = ssm_provider.get_multiple("/param", transform="json", raise_on_transform_error=True)
     ```
 
+#### Infer transform from parameter suffix with `get_multiple()`
+
+If you use `transform` with `get_multiple()`, you might want to retrieve and transform parameters encoded in different formats. You can do this with a single request by using `transform="auto"` and let the infer the transform type to use based on the parameter suffix.
+
+!!! info "The `transform="auto"` feature is available across all providers, including the high level functions"
+
+=== "partial_failures.py"
+
+````python hl_lines="6"
+    from aws_lambda_powertools.utilities import parameters
+
+    ssm_provider = parameters.SSMProvider()
+
+    def handler(event, context):
+        values = ssm_provider.get_multiple("/param", transform="auto")
+
+For example, if you have two parameters with the following suffixes `.json` and `.binary`:
+
+| Parameter name  | Parameter value         |
+| --------------- | ----------------------- |
+| /param/a.json   | [some encoded value]    |
+| /param/a.binary | [some encoded value]    |
+
+The return of `ssm_provider.get_multiple("/param", transform="auto")` call will be a dictionary like:
+
+```json
+{
+    "a.json": [some value],
+    "b.binary": [some value]
+}
+```
+````
+
 ### Passing additional SDK arguments
 
 You can use arbitrary keyword arguments to pass it directly to the underlying SDK method.


### PR DESCRIPTION
**Issue #, if available:**
#562 

## Description of changes:

<!--- One or two sentences as a summary of what's being changed -->
Added subsection under "Utilities > Parameters > Advanced > Deserializing values with transform parameter" titled "Infer transform from parameter suffix with `get_multiple()`" to document auto transform behaviour.

**Checklist**

<!--- Leave unchecked if your change doesn't seem to apply --> 

* [x] [Meet tenets criteria](https://awslabs.github.io/aws-lambda-powertools-python/#tenets)
* [ ] Update tests
* [x] Update docs
* [x] PR title follows [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-python/blob/376ec0a2ac0d2a40e0af5717bef42ff84ca0d1b9/.github/semantic.yml#L2)

## Breaking change checklist

<!--- Ignore if it's not a breaking change -->

**RFC issue #**:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
