### PR TITLE
fix(deps): bump poetry to latest

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ target:
 	@$(MAKE) pr
 
 dev:
-	pip install --upgrade pip pre-commit poetry==1.1.4
+	pip install --upgrade pip pre-commit poetry
 	poetry install --extras "pydantic"
 	pre-commit install
 


### PR DESCRIPTION
**Issue #, if available:**

## Description of changes:

Seems like poetry 1.1.7 has resolved a bug which forced us to use 1.1.4

**Checklist**

<!--- Leave unchecked if your change doesn't seem to apply --> 

* [X] [Meet tenets criteria](https://awslabs.github.io/aws-lambda-powertools-python/#tenets)
* [X] Update tests
* [X] Update docs
* [X] PR title follows [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-python/blob/376ec0a2ac0d2a40e0af5717bef42ff84ca0d1b9/.github/semantic.yml#L2)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
