### PR TITLE
chore(api-docs): enable allow_reuse to fix the docs

### DIFF
--- a/aws_lambda_powertools/utilities/parser/models/apigw.py
+++ b/aws_lambda_powertools/utilities/parser/models/apigw.py
@@ -68,7 +68,7 @@ class APIGatewayEventRequestContext(BaseModel):
     routeKey: Optional[str]
     operationName: Optional[str]
 
-    @root_validator
+    @root_validator(allow_reuse=True)
     def check_message_id(cls, values):
         message_id, event_type = values.get("messageId"), values.get("eventType")
         if message_id is not None and event_type != "MESSAGE":

--- a/aws_lambda_powertools/utilities/parser/models/cloudwatch.py
+++ b/aws_lambda_powertools/utilities/parser/models/cloudwatch.py
@@ -28,7 +28,7 @@ class CloudWatchLogsDecode(BaseModel):
 class CloudWatchLogsData(BaseModel):
     decoded_data: CloudWatchLogsDecode = Field(None, alias="data")
 
-    @validator("decoded_data", pre=True)
+    @validator("decoded_data", pre=True, allow_reuse=True)
     def prepare_data(cls, value):
         try:
             logger.debug("Decoding base64 cloudwatch log data before parsing")

--- a/aws_lambda_powertools/utilities/parser/models/kinesis.py
+++ b/aws_lambda_powertools/utilities/parser/models/kinesis.py
@@ -18,7 +18,7 @@ class KinesisDataStreamRecordPayload(BaseModel):
     data: bytes  # base64 encoded str is parsed into bytes
     approximateArrivalTimestamp: float
 
-    @validator("data", pre=True)
+    @validator("data", pre=True, allow_reuse=True)
     def data_base64_decode(cls, value):
         try:
             logger.debug("Decoding base64 Kinesis data record before parsing")

--- a/aws_lambda_powertools/utilities/parser/models/sns.py
+++ b/aws_lambda_powertools/utilities/parser/models/sns.py
@@ -25,7 +25,7 @@ class SnsNotificationModel(BaseModel):
     Timestamp: datetime
     SignatureVersion: str
 
-    @root_validator(pre=True)
+    @root_validator(pre=True, allow_reuse=True)
     def check_sqs_protocol(cls, values):
         sqs_rewritten_keys = ("UnsubscribeURL", "SigningCertURL")
         if any(key in sqs_rewritten_keys for key in values):


### PR DESCRIPTION
**Issue #, if available:**

- https://github.com/awslabs/aws-lambda-powertools-python/issues/611

## Description of changes:


Set `allow_reuse=True` for all of the pydantic validators, so the docs can render.


**Checklist**

<!--- Leave unchecked if your change doesn't seem to apply --> 

* [x] [Meet tenets criteria](https://awslabs.github.io/aws-lambda-powertools-python/#tenets)
* [x] Update tests
* [x] Update docs
* [x] PR title follows [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-python/blob/376ec0a2ac0d2a40e0af5717bef42ff84ca0d1b9/.github/semantic.yml#L2)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
