### PR TITLE
refactor(event_handler): match to match_results; 3.10 new keyword

### DIFF
--- a/aws_lambda_powertools/event_handler/api_gateway.py
+++ b/aws_lambda_powertools/event_handler/api_gateway.py
@@ -525,10 +525,10 @@ class ApiGatewayResolver:
         for route in self._routes:
             if method != route.method:
                 continue
-            match: Optional[re.Match] = route.rule.match(path)
-            if match:
+            match_results: Optional[re.Match] = route.rule.match(path)
+            if match_results:
                 logger.debug("Found a registered route. Calling function")
-                return self._call_route(route, match.groupdict())  # pass fn args
+                return self._call_route(route, match_results.groupdict())  # pass fn args
 
         logger.debug(f"No match found for path {path} and method {method}")
         return self._not_found(method)

--- a/aws_lambda_powertools/utilities/data_classes/appsync_authorizer_event.py
+++ b/aws_lambda_powertools/utilities/data_classes/appsync_authorizer_event.py
@@ -68,18 +68,18 @@ class AppSyncAuthorizerResponse:
         is authorized to make calls to the GraphQL API. If this value is
         true, execution of the GraphQL API continues. If this value is false,
         an UnauthorizedException is raised
-    max_age: Optional[int]
+    max_age: int, optional
         Set the ttlOverride. The number of seconds that the response should be
         cached for. If no value is returned, the value from the API (if configured)
         or the default of 300 seconds (five minutes) is used. If this is 0, the response
         is not cached.
-    resolver_context: Optional[Dict[str, Any]]
+    resolver_context: Dict[str, Any], optional
         A JSON object visible as `$ctx.identity.resolverContext` in resolver templates
 
         The resolverContext object only supports key-value pairs. Nested keys are not supported.
 
         Warning: The total size of this JSON object must not exceed 5MB.
-    deny_fields: Optional[List[str]]
+    deny_fields: List[str], optional
         A list of fields that will be set to `null` regardless of the resolver's return.
 
         A field is either `TypeName.FieldName`, or an ARN such as


### PR DESCRIPTION
**Issue #, if available:**

## Description of changes:

- Rename `match` to `match_results`
- fix Docstrings for optionals.

**Checklist**

<!--- Leave unchecked if your change doesn't seem to apply --> 

* [x] [Meet tenets criteria](https://awslabs.github.io/aws-lambda-powertools-python/#tenets)
* [x] Update tests
* [x] Update docs
* [x] PR title follows [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-python/blob/376ec0a2ac0d2a40e0af5717bef42ff84ca0d1b9/.github/semantic.yml#L2)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
