### PR TITLE
fix(api-gateway): strip stage name from request path

### DIFF
--- a/aws_lambda_powertools/utilities/data_classes/api_gateway_proxy_event.py
+++ b/aws_lambda_powertools/utilities/data_classes/api_gateway_proxy_event.py
@@ -440,6 +440,9 @@ class APIGatewayProxyEventV2(BaseProxyEvent):
 
     @property
     def path(self) -> str:
+        stage = self.request_context.stage
+        if stage != "$default":
+            return self.raw_path[len("/" + stage) :]
         return self.raw_path
 
     @property

--- a/tests/functional/event_handler/test_api_gateway.py
+++ b/tests/functional/event_handler/test_api_gateway.py
@@ -769,3 +769,22 @@ def test_custom_serializer():
     body = response["body"]
     expected = '{"color": 1, "variations": ["dark", "light"]}'
     assert expected == body
+
+
+def test_api_gateway_v2_raw_path():
+    # GIVEN a Http API V2 proxy type event
+    # AND a custom stage name "dev" and raw path "/dev/foo"
+    app = ApiGatewayResolver(proxy_type=ProxyEventType.APIGatewayProxyEventV2)
+    event = {"rawPath": "/dev/foo", "requestContext": {"http": {"method": "GET"}, "stage": "dev"}}
+
+    @app.get("/foo")
+    def foo():
+        return {}
+
+    # WHEN calling the event handler
+    # WITH a route "/foo"
+    result = app(event, {})
+
+    # THEN process event correctly
+    assert result["statusCode"] == 200
+    assert result["headers"]["Content-Type"] == content_types.APPLICATION_JSON

--- a/tests/functional/event_handler/test_api_gateway.py
+++ b/tests/functional/event_handler/test_api_gateway.py
@@ -824,8 +824,8 @@ def test_ignore_invalid(prefix):
     # so no prefix was stripped from the request path
     assert response["statusCode"] == 200
 
- 
- def test_api_gateway_v2_raw_path():
+
+def test_api_gateway_v2_raw_path():
     # GIVEN a Http API V2 proxy type event
     # AND a custom stage name "dev" and raw path "/dev/foo"
     app = ApiGatewayResolver(proxy_type=ProxyEventType.APIGatewayProxyEventV2)


### PR DESCRIPTION
**Issue #, if available:**
- https://github.com/awslabs/aws-lambda-powertools-python/issues/621

## Description of changes:

Automatically strip out "/" + `stage` when building the request path.

**Checklist**

<!--- Leave unchecked if your change doesn't seem to apply --> 

* [x] [Meet tenets criteria](https://awslabs.github.io/aws-lambda-powertools-python/#tenets)
* [x] Update tests
* [ ] Update docs
* [x] PR title follows [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-python/blob/376ec0a2ac0d2a40e0af5717bef42ff84ca0d1b9/.github/semantic.yml#L2)

## Breaking change checklist

This is potentially a break change, if mapping against the stage name

**RFC issue #**:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
