### PR TITLE
feat(data-classes): data_as_bytes prop KinesisStreamRecordPayload

### DIFF
--- a/aws_lambda_powertools/utilities/data_classes/kinesis_stream_event.py
+++ b/aws_lambda_powertools/utilities/data_classes/kinesis_stream_event.py
@@ -31,9 +31,13 @@ class KinesisStreamRecordPayload(DictWrapper):
         """The unique identifier of the record within its shard"""
         return self["kinesis"]["sequenceNumber"]
 
+    def data_as_bytes(self) -> bytes:
+        """Decode binary encoded data as bytes"""
+        return base64.b64decode(self.data)
+
     def data_as_text(self) -> str:
         """Decode binary encoded data as text"""
-        return base64.b64decode(self.data).decode("utf-8")
+        return self.data_as_bytes().decode("utf-8")
 
     def data_as_json(self) -> dict:
         """Decode binary encoded data as json"""

--- a/tests/functional/test_data_classes.py
+++ b/tests/functional/test_data_classes.py
@@ -1077,6 +1077,7 @@ def test_kinesis_stream_event():
     assert kinesis.partition_key == "1"
     assert kinesis.sequence_number == "49590338271490256608559692538361571095921575989136588898"
 
+    assert kinesis.data_as_bytes() == b"Hello, this is a test."
     assert kinesis.data_as_text() == "Hello, this is a test."
 
 


### PR DESCRIPTION
**Issue https://github.com/awslabs/aws-lambda-powertools-python/issues/617

## Description of changes:

<!--- One or two sentences as a summary of what's being changed -->
adding `data_as_bytes` helper to `KinesisStreamRecordPayload` as described in linked issue

**Checklist**

<!--- Leave unchecked if your change doesn't seem to apply --> 

* [x] [Meet tenets criteria](https://awslabs.github.io/aws-lambda-powertools-python/#tenets)
* [x] Update tests
* [ ] Update docs
* [x] PR title follows [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-python/blob/376ec0a2ac0d2a40e0af5717bef42ff84ca0d1b9/.github/semantic.yml#L2)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
