### PR TITLE
chore(license): Add THIRD-PARTY-LICENSES to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "aws_lambda_powertools"
 version = "1.20.1"
 description = "A suite of utilities for AWS Lambda functions to ease adopting best practices such as tracing, structured logging, custom metrics, batching, idempotency, feature flags, and more."
 authors = ["Amazon Web Services"]
-include = ["aws_lambda_powertools/py.typed"]
+include = ["aws_lambda_powertools/py.typed", "THIRD-PARTY-LICENSES"]
 classifiers=[
     "Development Status :: 5 - Production/Stable",
     "Intended Audience :: Developers",


### PR DESCRIPTION
**Issue #, if available:** #634

## Description of changes:

<!--- One or two sentences as a summary of what's being changed -->

Adds THIRD-PARTY-LICENSES to the tarball.

Following #635, this adds (hopefully) the THIRD-PARTY-LICENSES to the tarball. Apparently, Poetry [doesn't use](https://stackoverflow.com/questions/64654860/replacing-manifest-in-with-pyproject-toml) Manifest anymore which is why it didn't work in the first try.

**Checklist**

<!--- Leave unchecked if your change doesn't seem to apply --> 

* [x] [Meet tenets criteria](https://awslabs.github.io/aws-lambda-powertools-python/#tenets)
* [ ] Update tests
* [ ] Update docs
* [x] PR title follows [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-python/blob/376ec0a2ac0d2a40e0af5717bef42ff84ca0d1b9/.github/semantic.yml#L2)

## Breaking change checklist

<!--- Ignore if it's not a breaking change -->

**RFC issue #**:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
