### PR TITLE
refactor(data-classes): clean up internal logic for APIGatewayAuthorizerResponse

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -1,0 +1,12 @@
+[MESSAGES CONTROL]
+disable=
+    too-many-arguments,
+    too-many-instance-attributes,
+    too-few-public-methods,
+    anomalous-backslash-in-string,
+    missing-class-docstring,
+    missing-module-docstring,
+    missing-function-docstring,
+
+[FORMAT]
+max-line-length=120

--- a/aws_lambda_powertools/utilities/data_classes/api_gateway_authorizer_event.py
+++ b/aws_lambda_powertools/utilities/data_classes/api_gateway_authorizer_event.py
@@ -324,6 +324,21 @@ class HttpVerb(enum.Enum):
     ALL = "*"
 
 
+DENY_ALL_RESPONSE = {
+    "principalId": "deny-all-user",
+    "policyDocument": {
+        "Version": "2012-10-17",
+        "Statement": [
+            {
+                "Action": "execute-api:Invoke",
+                "Effect": "Deny",
+                "Resource": ["*"],
+            }
+        ],
+    },
+}
+
+
 class APIGatewayAuthorizerResponse:
     """Api Gateway HTTP API V1 payload or Rest api authorizer response helper
 

--- a/docs/utilities/data_classes.md
+++ b/docs/utilities/data_classes.md
@@ -96,18 +96,15 @@ Use **`APIGatewayAuthorizerRequestEvent`** for type `REQUEST` and **`APIGatewayA
 
     When the user is found, it includes the user details in the request context that will be available to the back-end, and returns a full access policy for admin users.
 
-    ```python hl_lines="2-5 29 36-42 47 49"
+    ```python hl_lines="2-6 29 36-42 47 49"
     from aws_lambda_powertools.utilities.data_classes import event_source
     from aws_lambda_powertools.utilities.data_classes.api_gateway_authorizer_event import (
+        DENY_ALL_RESPONSE,
         APIGatewayAuthorizerRequestEvent,
         APIGatewayAuthorizerResponse,
         HttpVerb,
     )
     from secrets import compare_digest
-
-
-    class UnAuthorizedError(Exception):
-        ...
 
 
     def get_user_by_token(token):
@@ -124,8 +121,11 @@ Use **`APIGatewayAuthorizerRequestEvent`** for type `REQUEST` and **`APIGatewayA
         user = get_user_by_token(event.get_header_value("Authorization"))
 
         if user is None:
-            # No user was found, so we raised a not authorized error
-            raise UnAuthorizedError("Not authorized to perform this action")
+            # No user was found
+            # to return 401 - `{"message":"Unauthorized"}`, but polutes lambda metrics
+            # raise Exception("Unauthorized")
+            # to return 403 - `{"message":"Forbidden"}`
+            return DENY_ALL_RESPONSE
 
         # parse the `methodArn` as an `APIGatewayRouteArn`
         arn = event.parsed_arn

--- a/docs/utilities/data_classes.md
+++ b/docs/utilities/data_classes.md
@@ -96,7 +96,7 @@ Use **`APIGatewayAuthorizerRequestEvent`** for type `REQUEST` and **`APIGatewayA
 
     When the user is found, it includes the user details in the request context that will be available to the back-end, and returns a full access policy for admin users.
 
-    ```python hl_lines="2-5 26-31 36-37 40 44 46"
+    ```python hl_lines="2-5 29 36-42 47 49"
     from aws_lambda_powertools.utilities.data_classes import event_source
     from aws_lambda_powertools.utilities.data_classes.api_gateway_authorizer_event import (
         APIGatewayAuthorizerRequestEvent,
@@ -106,11 +106,15 @@ Use **`APIGatewayAuthorizerRequestEvent`** for type `REQUEST` and **`APIGatewayA
     from secrets import compare_digest
 
 
+    class UnAuthorizedError(Exception):
+        ...
+
+
     def get_user_by_token(token):
         if compare_digest(token, "admin-foo"):
-            return {"isAdmin": True, "name": "Admin"}
+            return {"id": 0, "name": "Admin", "isAdmin": True}
         elif compare_digest(token, "regular-foo"):
-            return {"name": "Joe"}
+            return {"id": 1, "name": "Joe"}
         else:
             return None
 
@@ -119,24 +123,23 @@ Use **`APIGatewayAuthorizerRequestEvent`** for type `REQUEST` and **`APIGatewayA
     def handler(event: APIGatewayAuthorizerRequestEvent, context):
         user = get_user_by_token(event.get_header_value("Authorization"))
 
+        if user is None:
+            # No user was found, so we raised a not authorized error
+            raise UnAuthorizedError("Not authorized to perform this action")
+
         # parse the `methodArn` as an `APIGatewayRouteArn`
         arn = event.parsed_arn
+
         # Create the response builder from parts of the `methodArn`
+        # and set the logged in user id and context
         policy = APIGatewayAuthorizerResponse(
-            principal_id="user",
+            principal_id=user["id"],
+            context=user,
             region=arn.region,
             aws_account_id=arn.aws_account_id,
             api_id=arn.api_id,
-            stage=arn.stage
+            stage=arn.stage,
         )
-
-        if user is None:
-            # No user was found, so we return not authorized
-            policy.deny_all_routes()
-            return policy.asdict()
-
-        # Found the user and setting the details in the context
-        policy.context = user
 
         # Conditional IAM Policy
         if user.get("isAdmin", False):

--- a/docs/utilities/data_classes.md
+++ b/docs/utilities/data_classes.md
@@ -122,7 +122,7 @@ Use **`APIGatewayAuthorizerRequestEvent`** for type `REQUEST` and **`APIGatewayA
 
         if user is None:
             # No user was found
-            # to return 401 - `{"message":"Unauthorized"}`, but polutes lambda metrics
+            # to return 401 - `{"message":"Unauthorized"}`, but pollutes lambda error count metrics
             # raise Exception("Unauthorized")
             # to return 403 - `{"message":"Forbidden"}`
             return DENY_ALL_RESPONSE

--- a/tests/functional/data_classes/test_api_gateway_authorizer.py
+++ b/tests/functional/data_classes/test_api_gateway_authorizer.py
@@ -37,7 +37,8 @@ def test_authorizer_response_invalid_resource(builder: APIGatewayAuthorizerRespo
 
 
 def test_authorizer_response_allow_all_routes_with_context():
-    builder = APIGatewayAuthorizerResponse("foo", "us-west-1", "123456789", "fantom", "dev", context={"name": "Foo"})
+    arn = "arn:aws:execute-api:us-west-1:123456789:fantom/dev/GET/foo"
+    builder = APIGatewayAuthorizerResponse.from_route_arn(arn, principal_id="foo", context={"name": "Foo"})
     builder.allow_all_routes()
     assert builder.asdict() == {
         "principalId": "foo",
@@ -56,7 +57,8 @@ def test_authorizer_response_allow_all_routes_with_context():
 
 
 def test_authorizer_response_allow_all_routes_with_usage_identifier_key():
-    builder = APIGatewayAuthorizerResponse("cow", "us-east-1", "1111111111", "api", "dev", usage_identifier_key="key")
+    arn = "arn:aws:execute-api:us-east-1:1111111111:api/dev/ANY/y"
+    builder = APIGatewayAuthorizerResponse.from_route_arn(arn, principal_id="cow", usage_identifier_key="key")
     builder.allow_all_routes()
     assert builder.asdict() == {
         "principalId": "cow",

--- a/tests/functional/data_classes/test_api_gateway_authorizer.py
+++ b/tests/functional/data_classes/test_api_gateway_authorizer.py
@@ -37,7 +37,7 @@ def test_authorizer_response_invalid_resource(builder: APIGatewayAuthorizerRespo
 
 
 def test_authorizer_response_allow_all_routes_with_context():
-    builder = APIGatewayAuthorizerResponse("foo", "us-west-1", "123456789", "fantom", "dev", {"name": "Foo"})
+    builder = APIGatewayAuthorizerResponse("foo", "us-west-1", "123456789", "fantom", "dev", context={"name": "Foo"})
     builder.allow_all_routes()
     assert builder.asdict() == {
         "principalId": "foo",
@@ -52,6 +52,25 @@ def test_authorizer_response_allow_all_routes_with_context():
             ],
         },
         "context": {"name": "Foo"},
+    }
+
+
+def test_authorizer_response_allow_all_routes_with_usage_identifier_key():
+    builder = APIGatewayAuthorizerResponse("cow", "us-east-1", "1111111111", "api", "dev", usage_identifier_key="key")
+    builder.allow_all_routes()
+    assert builder.asdict() == {
+        "principalId": "cow",
+        "policyDocument": {
+            "Version": "2012-10-17",
+            "Statement": [
+                {
+                    "Action": "execute-api:Invoke",
+                    "Effect": "Allow",
+                    "Resource": ["arn:aws:execute-api:us-east-1:1111111111:api/dev/*/*"],
+                }
+            ],
+        },
+        "usageIdentifierKey": "key",
     }
 
 

--- a/tests/functional/data_classes/test_api_gateway_authorizer.py
+++ b/tests/functional/data_classes/test_api_gateway_authorizer.py
@@ -1,6 +1,7 @@
 import pytest
 
 from aws_lambda_powertools.utilities.data_classes.api_gateway_authorizer_event import (
+    DENY_ALL_RESPONSE,
     APIGatewayAuthorizerResponse,
     HttpVerb,
 )
@@ -144,4 +145,15 @@ def test_authorizer_response_deny_route_with_conditions(builder: APIGatewayAutho
                 }
             ],
         },
+    }
+
+
+def test_deny_all():
+    # CHECK we always explicitly deny all
+    statements = DENY_ALL_RESPONSE["policyDocument"]["Statement"]
+    assert len(statements) == 1
+    assert statements[0] == {
+        "Action": "execute-api:Invoke",
+        "Effect": "Deny",
+        "Resource": ["*"],
     }


### PR DESCRIPTION
**Issue #, if available:**

## Description of changes:

> **NOTE:** We might want to explain "This will also pollute Lambda metrics with errors, also causing cold starts since it's not handled." in the docs to.

Changes:
- Clean up the internal logic for `APIGatewayAuthorizerResponse` 
- Update the internal docs to include a new `DENY_ALL_RESPONSE`
- Add missing property `usageIdentifierKey` for Rest API responses only
- Add `from_route_arn` to build APIGatewayAuthorizerResponse from an `arn`
- Add a relaxed pylintrc configuration for those use have this installed

### Update Example

```python
from aws_lambda_powertools.utilities.data_classes import event_source
from aws_lambda_powertools.utilities.data_classes.api_gateway_authorizer_event import (
    DENY_ALL_RESPONSE,
    APIGatewayAuthorizerRequestEvent,
    APIGatewayAuthorizerResponse,
    HttpVerb,
)
from secrets import compare_digest


def get_user_by_token(token):
    if compare_digest(token, "admin-foo"):
        return {"id": 0, "name": "Admin", "isAdmin": True}
    elif compare_digest(token, "regular-foo"):
        return {"id": 1, "name": "Joe"}
    else:
        return None


@event_source(data_class=APIGatewayAuthorizerRequestEvent)
def handler(event: APIGatewayAuthorizerRequestEvent, context):
    user = get_user_by_token(event.get_header_value("Authorization"))

    if user is None:
        # No user was found
        # to return 401 - `{"message":"Unauthorized"}`, but pollutes lambda metrics
        # raise Exception("Unauthorized")
        # to return 403 - `{"message":"Forbidden"}`
        return DENY_ALL_RESPONSE

    # Create the response builder from parts of the `methodArn`
    # and set the logged in user id and context
    policy = APIGatewayAuthorizerResponse.from_route_arn(
        arn=event.method_arn, principal_id=user["id"], context=user
    )

    # Conditional IAM Policy
    if user.get("isAdmin", False):
        policy.allow_all_routes()
    else:
        policy.allow_route(HttpVerb.GET, "/user-profile")

    return policy.asdict()
```

**Checklist**

<!--- Leave unchecked if your change doesn't seem to apply --> 

* [x] [Meet tenets criteria](https://awslabs.github.io/aws-lambda-powertools-python/#tenets)
* [x] Update tests
* [x] Update docs
* [x] PR title follows [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-python/blob/376ec0a2ac0d2a40e0af5717bef42ff84ca0d1b9/.github/semantic.yml#L2)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


-----
[View rendered docs/utilities/data_classes.md](https://github.com/gyft/aws-lambda-powertools-python/blob/refactor/api-authorizer/docs/utilities/data_classes.md)