### PR TITLE
feat(apigateway): add Router to allow large routing composition

### DIFF
--- a/aws_lambda_powertools/event_handler/api_gateway.py
+++ b/aws_lambda_powertools/event_handler/api_gateway.py
@@ -654,8 +654,8 @@ class Blueprint:
         def actual_decorator(func: Callable):
             @wraps(func)
             def wrapper(app: ApiGatewayResolver):
-                def inner_wrapper():
-                    return func(app)
+                def inner_wrapper(**kwargs):
+                    return func(app, **kwargs)
 
                 return inner_wrapper
 

--- a/aws_lambda_powertools/event_handler/api_gateway.py
+++ b/aws_lambda_powertools/event_handler/api_gateway.py
@@ -631,9 +631,13 @@ class ApiGatewayResolver:
     def _json_dump(self, obj: Any) -> str:
         return self._serializer(obj)
 
-    def register_blueprint(self, blueprint: "Blueprint") -> None:
+    def register_blueprint(self, blueprint: "Blueprint", prefix: Optional[str] = None) -> None:
         """Adds all routes defined in a blueprint"""
         for route, func in blueprint.api.items():
+            if prefix and route[0] == "/":
+                route = (prefix, *route[1:])
+            elif prefix:
+                route = (f"{prefix}{route[0]}" if prefix else route[0], *route[1:])
             self.route(*route)(func(app=self))
 
 

--- a/aws_lambda_powertools/event_handler/api_gateway.py
+++ b/aws_lambda_powertools/event_handler/api_gateway.py
@@ -637,7 +637,7 @@ class ApiGatewayResolver:
             if prefix and route[0] == "/":
                 route = (prefix, *route[1:])
             elif prefix:
-                route = (f"{prefix}{route[0]}" if prefix else route[0], *route[1:])
+                route = (f"{prefix}{route[0]}", *route[1:])
             self.route(*route)(func(app=self))
 
 

--- a/aws_lambda_powertools/event_handler/api_gateway.py
+++ b/aws_lambda_powertools/event_handler/api_gateway.py
@@ -6,9 +6,9 @@ import re
 import traceback
 import zlib
 from enum import Enum
-from functools import partial
+from functools import partial, wraps
 from http import HTTPStatus
-from typing import Any, Callable, Dict, List, Optional, Set, Union
+from typing import Any, Callable, Dict, List, Optional, Set, Tuple, Union
 
 from aws_lambda_powertools.event_handler import content_types
 from aws_lambda_powertools.event_handler.exceptions import ServiceError
@@ -630,3 +630,42 @@ class ApiGatewayResolver:
 
     def _json_dump(self, obj: Any) -> str:
         return self._serializer(obj)
+
+class Blueprint():
+    """Blueprint helper class to allow splitting ApiGatewayResolver into multiple files"""
+    def __init__(self):
+        self._api: Dict[tuple, Callable] = {}
+
+    def __call__(self, rule: str, method: Union[str, Tuple[str], List[str]], cors: Optional[bool] = None, compress: bool = False, cache_control: Optional[str] = None,):
+        def actual_decorator(func: Callable):
+            @wraps(func)
+            def wrapper(app: ApiGatewayResolver):
+                def inner_wrapper():
+                    return func(app)
+                return inner_wrapper
+            if isinstance(method, (list, tuple)):
+                for item in method:
+                    self._api[(rule, item, cors, compress, cache_control)] = wrapper
+            else:
+                self._api[(rule, method, cors, compress, cache_control)] = wrapper
+        return actual_decorator
+
+    def get(self, rule: str, cors: Optional[bool] = None, compress: bool = False, cache_control: Optional[str] = None):
+        return self.__call__(rule, "GET", cors, compress, cache_control)
+
+    def post(self, rule: str, cors: Optional[bool] = None, compress: bool = False, cache_control: Optional[str] = None):
+        return self.__call__(rule, "POST", cors, compress, cache_control)
+
+    def put(self, rule: str, cors: Optional[bool] = None, compress: bool = False, cache_control: Optional[str] = None):
+        return self.__call__(rule, "PUT", cors, compress, cache_control)
+
+    def delete(self, rule: str, cors: Optional[bool] = None, compress: bool = False, cache_control: Optional[str] = None):
+        return self.__call__(rule, "DELETE", cors, compress, cache_control)
+
+    def patch(self, rule: str, cors: Optional[bool] = None, compress: bool = False, cache_control: Optional[str] = None):
+        return self.__call__(rule, "PATCH", cors, compress, cache_control)
+
+    def register_to_app(self, app:ApiGatewayResolver):
+        """Bind a blueprint object to an existing ApiGatewayResolver instance"""
+        for route, func in self._api.items():
+            app.route(*route)(func(app=app))

--- a/tests/functional/event_handler/test_api_gateway.py
+++ b/tests/functional/event_handler/test_api_gateway.py
@@ -903,3 +903,42 @@ def test_api_gateway_app_proxy_with_params():
     # THEN process event correctly
     assert result["statusCode"] == 200
     assert result["headers"]["Content-Type"] == content_types.APPLICATION_JSON
+
+
+def test_api_gateway_app_proxy_with_prefix():
+    # GIVEN a Blueprint with registered routes
+    # AND a prefix is defined during the registration
+    app = ApiGatewayResolver()
+    blueprint = Blueprint()
+
+    @blueprint.get(rule="/path")
+    def foo(app: ApiGatewayResolver):
+        return {}
+
+    app.register_blueprint(blueprint, prefix="/my")
+    # WHEN calling the event handler after applying routes from blueprint object
+    result = app(LOAD_GW_EVENT, {})
+
+    # THEN process event correctly
+    assert result["statusCode"] == 200
+    assert result["headers"]["Content-Type"] == content_types.APPLICATION_JSON
+
+
+def test_api_gateway_app_proxy_with_prefix_equals_path():
+    # GIVEN a Blueprint with registered routes
+    # AND a prefix is defined during the registration
+    app = ApiGatewayResolver()
+    blueprint = Blueprint()
+
+    @blueprint.get(rule="/")
+    def foo(app: ApiGatewayResolver):
+        return {}
+
+    app.register_blueprint(blueprint, prefix="/my/path")
+    # WHEN calling the event handler after applying routes from blueprint object
+    # WITH the request path matching the registration prefix
+    result = app(LOAD_GW_EVENT, {})
+
+    # THEN process event correctly
+    assert result["statusCode"] == 200
+    assert result["headers"]["Content-Type"] == content_types.APPLICATION_JSON

--- a/tests/functional/event_handler/test_api_gateway.py
+++ b/tests/functional/event_handler/test_api_gateway.py
@@ -879,3 +879,27 @@ def test_api_gateway_app_proxy():
     # THEN process event correctly
     assert result["statusCode"] == 200
     assert result["headers"]["Content-Type"] == content_types.APPLICATION_JSON
+
+
+def test_api_gateway_app_proxy_with_params():
+    # GIVEN a Blueprint with registered routes
+    app = ApiGatewayResolver()
+    blueprint = Blueprint()
+    req = "foo"
+    event = deepcopy(LOAD_GW_EVENT)
+    event["resource"] = "/accounts/{account_id}"
+    event["path"] = f"/accounts/{req}"
+
+    @blueprint.route(rule="/accounts/<account_id>", method=["GET", "POST"])
+    def foo(app: ApiGatewayResolver, account_id):
+        assert app.current_event.raw_event == event
+        assert account_id == f"{req}"
+        return {}
+
+    app.register_blueprint(blueprint)
+    # WHEN calling the event handler after applying routes from blueprint object
+    result = app(event, {})
+
+    # THEN process event correctly
+    assert result["statusCode"] == 200
+    assert result["headers"]["Content-Type"] == content_types.APPLICATION_JSON

--- a/tests/functional/event_handler/test_api_gateway.py
+++ b/tests/functional/event_handler/test_api_gateway.py
@@ -13,6 +13,7 @@ import pytest
 from aws_lambda_powertools.event_handler import content_types
 from aws_lambda_powertools.event_handler.api_gateway import (
     ApiGatewayResolver,
+    Blueprint,
     CORSConfig,
     ProxyEventType,
     Response,
@@ -856,6 +857,24 @@ def test_api_gateway_request_path_equals_strip_prefix():
     # WHEN calling the event handler
     # WITH a route "/"
     result = app(event, {})
+
+    # THEN process event correctly
+    assert result["statusCode"] == 200
+    assert result["headers"]["Content-Type"] == content_types.APPLICATION_JSON
+
+
+def test_api_gateway_app_proxy():
+    # GIVEN a Blueprint with registered routes
+    app = ApiGatewayResolver()
+    blueprint = Blueprint()
+
+    @blueprint.get("/my/path")
+    def foo(app):
+        return {}
+
+    blueprint.register_to_app(app)
+    # WHEN calling the event handler after applying routes from blueprint object
+    result = app(LOAD_GW_EVENT, {})
 
     # THEN process event correctly
     assert result["statusCode"] == 200

--- a/tests/functional/event_handler/test_api_gateway.py
+++ b/tests/functional/event_handler/test_api_gateway.py
@@ -872,7 +872,7 @@ def test_api_gateway_app_proxy():
     def foo(app):
         return {}
 
-    blueprint.register_to_app(app)
+    app.register_blueprint(blueprint)
     # WHEN calling the event handler after applying routes from blueprint object
     result = app(LOAD_GW_EVENT, {})
 

--- a/tests/functional/event_handler/test_api_gateway.py
+++ b/tests/functional/event_handler/test_api_gateway.py
@@ -869,7 +869,7 @@ def test_api_gateway_app_proxy():
     blueprint = Blueprint()
 
     @blueprint.get("/my/path")
-    def foo(app):
+    def foo(app: ApiGatewayResolver):
         return {}
 
     app.register_blueprint(blueprint)


### PR DESCRIPTION
Add Router class to ApiGatewayResolver

**Issue #, if available: #644**

## Description of changes:

Add a `Router` class to be used as a proxy for `ApiGatewayResolver`.  The class is able to at as a placeholder for the app instance and collect routes to later be applied; it includes all the functionality of current routes.

To access query strings or headers the original `event` and `context` are made available as `router.current_event` and `router.lambda_context` respectively.  Also, to improve performance of a function which uses an endpoint with multiple methods, it offers a slight variation of the `route()` method's signature allowing a `list`/`tuple`.

### Usage example:

app/main.py:
```python
from aws_lambda_powertools import Logger, Tracer
from aws_lambda_powertools.event_handler.api_gateway import ApiGatewayResolver
from aws_lambda_powertools.logging import correlation_paths

from .routers import users, items

tracer = Tracer()
logger = Logger()
app = ApiGatewayResolver()
app.include_router(users.router)
app.include_router(items.router, prefix="/items")

@logger.inject_lambda_context(correlation_id_path=correlation_paths.API_GATEWAY_REST)
@tracer.capture_lambda_handler
def lambda_handler(event, context):
    return app.resolve(event, context)
```

app/routers/items.py:
```python
from aws_lambda_powertools import Logger, Tracer
from aws_lambda_powertools.event_handler.api_gateway import Router

tracer = Tracer()
logger = Logger(child=True)
router = Router()

@router.get('/hello')
@tracer.capture_method
def get_hello():
    return {
        "message": ['/hello', 'GET'],
        "query_string": router.current_event.query_string_parameters,
    }

@router.route('/world', ('GET','POST'))
@tracer.capture_method
def multi_world():
    return {
        "message": ['/world', 'GET/POST'],
        "query_string": router.current_event.query_string_parameters,
    }
```



**Checklist**

* [x] [Meet tenets criteria](https://awslabs.github.io/aws-lambda-powertools-python/#tenets)
* [x] Update tests
* [ ] Update docs
* [x] PR title follows [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-python/blob/376ec0a2ac0d2a40e0af5717bef42ff84ca0d1b9/.github/semantic.yml#L2)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
