### PR TITLE
fix: Fix issue with strip_prefixes

### DIFF
--- a/aws_lambda_powertools/event_handler/api_gateway.py
+++ b/aws_lambda_powertools/event_handler/api_gateway.py
@@ -546,6 +546,8 @@ class ApiGatewayResolver:
             return path
 
         for prefix in self._strip_prefixes:
+            if path == prefix:
+                return "/"
             if self._path_starts_with(path, prefix):
                 return path[len(prefix) :]
 

--- a/docs/core/event_handler/api_gateway.md
+++ b/docs/core/event_handler/api_gateway.md
@@ -476,6 +476,8 @@ This will lead to a HTTP 404 despite having your Lambda configured correctly. Se
     }
     ```
 
+Note: After removing a path prefix with `strip_prefixes`, the new root path will automatically be mapped to the path argument of `/`. For example, when using `strip_prefixes` value of `/pay`, there is no difference between a request path of `/pay` and `/pay/`; and the path argument would be defined as `/`.
+
 ## Advanced
 
 ### CORS

--- a/tests/functional/event_handler/test_api_gateway.py
+++ b/tests/functional/event_handler/test_api_gateway.py
@@ -842,3 +842,21 @@ def test_api_gateway_v2_raw_path():
     # THEN process event correctly
     assert result["statusCode"] == 200
     assert result["headers"]["Content-Type"] == content_types.APPLICATION_JSON
+
+
+def test_api_gateway_request_path_equals_strip_prefix():
+    # GIVEN a strip_prefix matches the request path
+    app = ApiGatewayResolver(strip_prefixes=["/foo"])
+    event = {"httpMethod": "GET", "path": "/foo"}
+
+    @app.get("/")
+    def base():
+        return {}
+
+    # WHEN calling the event handler
+    # WITH a route "/"
+    result = app(event, {})
+
+    # THEN process event correctly
+    assert result["statusCode"] == 200
+    assert result["headers"]["Content-Type"] == content_types.APPLICATION_JSON


### PR DESCRIPTION
**Issue #, if available: #646**

## Description of changes:

After removing path prefixes, allow an empty path to return `"/"` so that it will match a normal routing rule.

**Checklist**

<!--- Leave unchecked if your change doesn't seem to apply --> 

* [x] [Meet tenets criteria](https://awslabs.github.io/aws-lambda-powertools-python/#tenets)
* [x] Update tests
* [x] Update docs
* [x] PR title follows [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-python/blob/376ec0a2ac0d2a40e0af5717bef42ff84ca0d1b9/.github/semantic.yml#L2)

## Breaking change checklist

<!--- Ignore if it's not a breaking change -->

**RFC issue #**:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
