### PR TITLE
fix(data-classes): use correct asdict funciton

### DIFF
--- a/docs/utilities/data_classes.md
+++ b/docs/utilities/data_classes.md
@@ -299,7 +299,7 @@ In this example extract the `requestId` as the `correlation_id` for logging, use
 
         if not user:
             # No user found, return not authorized
-            return AppSyncAuthorizerResponse().to_dict()
+            return AppSyncAuthorizerResponse().asdict()
 
         return AppSyncAuthorizerResponse(
             authorize=True,


### PR DESCRIPTION
**Issue #, if available:**

## Description of changes:


Rename `to_dict` to `addict`


**Checklist**

<!--- Leave unchecked if your change doesn't seem to apply --> 

* [x] [Meet tenets criteria](https://awslabs.github.io/aws-lambda-powertools-python/#tenets)
* [x] Update tests
* [x] Update docs
* [x] PR title follows [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-python/blob/376ec0a2ac0d2a40e0af5717bef42ff84ca0d1b9/.github/semantic.yml#L2)

-----
[View rendered docs/utilities/data_classes.md](https://github.com/gyft/aws-lambda-powertools-python/blob/fix/app-sync-doc-typo/docs/utilities/data_classes.md)