### PR TITLE
fix(idempotency): use ExpressionAttributeNames in DynamoDBPersistenceLayer _put_record

### DIFF
--- a/aws_lambda_powertools/utilities/idempotency/persistence/dynamodb.py
+++ b/aws_lambda_powertools/utilities/idempotency/persistence/dynamodb.py
@@ -121,7 +121,8 @@ class DynamoDBPersistenceLayer(BasePersistenceLayer):
             logger.debug(f"Putting record for idempotency key: {data_record.idempotency_key}")
             self.table.put_item(
                 Item=item,
-                ConditionExpression=f"attribute_not_exists({self.key_attr}) OR {self.expiry_attr} < :now",
+                ConditionExpression="attribute_not_exists(#id) OR #now < :now",
+                ExpressionAttributeNames={"#id": self.key_attr, "#now": self.expiry_attr},
                 ExpressionAttributeValues={":now": int(now.timestamp())},
             )
         except self._ddb_resource.meta.client.exceptions.ConditionalCheckFailedException:

--- a/tests/functional/idempotency/conftest.py
+++ b/tests/functional/idempotency/conftest.py
@@ -122,7 +122,8 @@ def expected_params_update_item_with_validation(
 @pytest.fixture
 def expected_params_put_item(hashed_idempotency_key):
     return {
-        "ConditionExpression": "attribute_not_exists(id) OR expiration < :now",
+        "ConditionExpression": "attribute_not_exists(#id) OR #now < :now",
+        "ExpressionAttributeNames": {"#id": "id", "#now": "expiration"},
         "ExpressionAttributeValues": {":now": stub.ANY},
         "Item": {"expiration": stub.ANY, "id": hashed_idempotency_key, "status": "INPROGRESS"},
         "TableName": "TEST_TABLE",
@@ -132,7 +133,8 @@ def expected_params_put_item(hashed_idempotency_key):
 @pytest.fixture
 def expected_params_put_item_with_validation(hashed_idempotency_key, hashed_validation_key):
     return {
-        "ConditionExpression": "attribute_not_exists(id) OR expiration < :now",
+        "ConditionExpression": "attribute_not_exists(#id) OR #now < :now",
+        "ExpressionAttributeNames": {"#id": "id", "#now": "expiration"},
         "ExpressionAttributeValues": {":now": stub.ANY},
         "Item": {
             "expiration": stub.ANY,


### PR DESCRIPTION
**Issue #, if available:** #693

## Description of changes:

<!--- One or two sentences as a summary of what's being changed -->
Use `ExpressionAttributeNames` in `DynamoDBPersistenceLayer` `_put_record` call to to `table.put_item`.

**Checklist**

<!--- Leave unchecked if your change doesn't seem to apply --> 

* [x] [Meet tenets criteria](https://awslabs.github.io/aws-lambda-powertools-python/#tenets)
* [x] Update tests
* [ ] Update docs
* [x] PR title follows [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-python/blob/376ec0a2ac0d2a40e0af5717bef42ff84ca0d1b9/.github/semantic.yml#L2)

## Breaking change checklist

<!--- Ignore if it's not a breaking change -->

**RFC issue #**:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
