### PR TITLE
docs: Terraform reference for SAR Lambda Layer

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -126,6 +126,8 @@ If using SAM, you can include this SAR App as part of your shared Layers stack, 
 
 === "Terraform"
 
+	> Credits to [Dani Comnea](https://github.com/DanyC97) for providing the Terraform equivalent.
+
     ```terraform hl_lines="12-13 15-20 23-25 40"
     terraform {
       required_version = "~> 0.13"

--- a/docs/index.md
+++ b/docs/index.md
@@ -126,7 +126,7 @@ If using SAM, you can include this SAR App as part of your shared Layers stack, 
 
 === "Terraform"
 
-    ```terraform hl_lines="12-13 15-20 23-25"
+    ```terraform hl_lines="12-13 15-20 23-25 40"
     terraform {
       required_version = "~> 0.13"
       required_providers {
@@ -163,6 +163,11 @@ If using SAM, you can include this SAR App as part of your shared Layers stack, 
     output "deployed_powertools_sar_version" {
       value = data.aws_serverlessapplicationrepository_application.sar_app.semantic_version
     }
+
+	# Fetch Lambda Powertools Layer ARN from deployed SAR App
+	output "aws_lambda_powertools_layer_arn" {
+	  value = aws_serverlessapplicationrepository_cloudformation_stack.deploy_sar_stack.outputs.LayerVersionArn
+	}
     ```
 
 ??? tip "Example of least-privileged IAM permissions to deploy Layer"

--- a/docs/index.md
+++ b/docs/index.md
@@ -126,7 +126,7 @@ If using SAM, you can include this SAR App as part of your shared Layers stack, 
 
 === "Terraform"
 
-    ```ruby hl_lines="24-25"
+    ```terraform hl_lines="24-25"
     terraform {
       required_version = "~> 0.13"
       required_providers {

--- a/docs/index.md
+++ b/docs/index.md
@@ -126,7 +126,7 @@ If using SAM, you can include this SAR App as part of your shared Layers stack, 
 
 === "Terraform"
 
-    ```terraform hl_lines="24-25"
+    ```terraform hl_lines="12-13 15-20 23-25"
     terraform {
       required_version = "~> 0.13"
       required_providers {
@@ -161,7 +161,7 @@ If using SAM, you can include this SAR App as part of your shared Layers stack, 
     }
 
     output "deployed_powertools_sar_version" {
-      value = data.aws_serverlessapplicationrepository_application.app.semantic_version
+      value = data.aws_serverlessapplicationrepository_application.sar_app.semantic_version
     }
     ```
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -124,6 +124,47 @@ If using SAM, you can include this SAR App as part of your shared Layers stack, 
             )
     ```
 
+=== "Terraform"
+
+    ```ruby hl_lines="24-25"
+    terraform {
+      required_version = "~> 0.13"
+      required_providers {
+        aws = "~> 3.50.0"
+      }
+    }
+
+    provider "aws" {
+      region  = "us-east-1"
+    }
+
+    resource "aws_serverlessapplicationrepository_cloudformation_stack" "deploy_sar_stack" {
+      name = "aws-lambda-powertools-python-layer"
+
+      application_id   = data.aws_serverlessapplicationrepository_application.sar_app.application_id
+      semantic_version = data.aws_serverlessapplicationrepository_application.sar_app.semantic_version
+      capabilities = [
+        "CAPABILITY_IAM",
+        "CAPABILITY_NAMED_IAM"
+      ]
+    }
+
+    data "aws_serverlessapplicationrepository_application" "sar_app" {
+      application_id   = "arn:aws:serverlessrepo:eu-west-1:057560766410:applications/aws-lambda-powertools-python-layer"
+      semantic_version = var.aws_powertools_version
+    }
+
+    variable "aws_powertools_version" {
+      type        = string
+      default     = "1.20.2"
+      description = "The AWS Powertools release version"
+    }
+
+    output "deployed_powertools_sar_version" {
+      value = data.aws_serverlessapplicationrepository_application.app.semantic_version
+    }
+    ```
+
 ??? tip "Example of least-privileged IAM permissions to deploy Layer"
 
     > Credits to [mwarkentin](https://github.com/mwarkentin) for providing the scoped down IAM permissions.


### PR DESCRIPTION
**Issue #, if available:** https://github.com/awslabs/aws-lambda-powertools-python/issues/684

## Description of changes:

<!--- One or two sentences as a summary of what's being changed -->
Currently the documentation provides example of installing the deploying
the SAR app using various frameworks.

This commit extend the list by providing a Terraform example.


**Checklist**

<!--- Leave unchecked if your change doesn't seem to apply --> 

* [x] [Meet tenets criteria](https://awslabs.github.io/aws-lambda-powertools-python/#tenets)
* [ ] Update tests
* [x] Update docs
* [x] PR title follows [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-python/blob/376ec0a2ac0d2a40e0af5717bef42ff84ca0d1b9/.github/semantic.yml#L2)

## Breaking change checklist

<!--- Ignore if it's not a breaking change -->

**RFC issue #**:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


-----
[View rendered docs/index.md](https://github.com/DanyC97/aws-lambda-powertools-python/blob/fix-684-terraform-docs-example/docs/index.md)