### PR TITLE
fix(feature-flags): rules should evaluate with an AND op

### DIFF
--- a/aws_lambda_powertools/utilities/feature_flags/feature_flags.py
+++ b/aws_lambda_powertools/utilities/feature_flags/feature_flags.py
@@ -102,10 +102,9 @@ class FeatureFlags:
             if self._evaluate_conditions(rule_name=rule_name, feature_name=feature_name, rule=rule, context=context):
                 return bool(rule_match_value)
 
-            # no rule matched, return default value of feature
-            logger.debug(f"no rule matched, returning feature default, default={feat_default}, name={feature_name}")
-            return feat_default
-        return False
+        # no rule matched, return default value of feature
+        logger.debug(f"no rule matched, returning feature default, default={feat_default}, name={feature_name}")
+        return feat_default
 
     def get_configuration(self) -> Dict:
         """Get validated feature flag schema from configured store.

--- a/tests/functional/feature_flags/test_feature_flags.py
+++ b/tests/functional/feature_flags/test_feature_flags.py
@@ -233,9 +233,9 @@ def test_flags_conditions_no_rule_match_equal_multiple_conditions(mocker, config
 # check rule match for multiple of action types
 def test_flags_conditions_rule_match_multiple_actions_multiple_rules_multiple_conditions(mocker, config):
     expected_value_first_check = True
-    expected_value_second_check = False
+    expected_value_second_check = True
     expected_value_third_check = False
-    expected_value_fourth_case = False
+    expected_value_fourth_check = False
     mocked_app_config_schema = {
         "my_feature": {
             "default": expected_value_third_check,
@@ -295,9 +295,9 @@ def test_flags_conditions_rule_match_multiple_actions_multiple_rules_multiple_co
     toggle = feature_flags.evaluate(
         name="my_fake_feature",
         context={"tenant_id": "11114446", "username": "ab"},
-        default=expected_value_fourth_case,
+        default=expected_value_fourth_check,
     )
-    assert toggle == expected_value_fourth_case
+    assert toggle == expected_value_fourth_check
 
 
 # check a case where the feature exists but the rule doesn't match so we revert to the default value of the feature


### PR DESCRIPTION
**Issue #, if available:**

## Description of changes:

<!--- One or two sentences as a summary of what's being changed -->

**Checklist**

<!--- Leave unchecked if your change doesn't seem to apply --> 

* [ ] [Meet tenets criteria](https://awslabs.github.io/aws-lambda-powertools-python/#tenets)
* [ ] Update tests
* [ ] Update docs
* [ ] PR title follows [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-python/blob/376ec0a2ac0d2a40e0af5717bef42ff84ca0d1b9/.github/semantic.yml#L2)

## Breaking change checklist

<!--- Ignore if it's not a breaking change -->

**RFC issue #**:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
