### PR TITLE
feat(apigateway): allow customizing response for non-matched requests

### DIFF
--- a/tests/functional/event_handler/test_api_gateway.py
+++ b/tests/functional/event_handler/test_api_gateway.py
@@ -864,17 +864,18 @@ def test_api_gateway_request_path_equals_strip_prefix():
 
 def test_custom_not_found_string():
     # GIVEN a resolver with a custom not found string
-    response_body = "foo"
+    response_body = "Forbidden"
+    response = Response(status_code=403, content_type=content_types.TEXT_PLAIN, body=response_body)
 
-    app = ApiGatewayResolver(custom_not_found=response_body)
+    app = ApiGatewayResolver(custom_not_found=response)
 
     # WHEN calling the event handler
     result = app(LOAD_GW_EVENT, {})
 
     # THEN attempt to process th event
     # AND on error return the custom body string
-    assert result["statusCode"] == 404
-    assert result["headers"]["Content-Type"] == content_types.APPLICATION_JSON
+    assert result["statusCode"] == 403
+    assert result["headers"]["Content-Type"] == content_types.TEXT_PLAIN
     assert result["body"] == response_body
 
 
@@ -885,7 +886,7 @@ def test_custom_not_found_function():
     def response_body_function(method: str, path: str):
         assert method == "GET"
         assert path == "/my/path"
-        return response_body
+        return Response(status_code=404, content_type=content_types.TEXT_PLAIN, body=response_body)
 
     app = ApiGatewayResolver(custom_not_found=response_body_function)
 
@@ -895,5 +896,5 @@ def test_custom_not_found_function():
     # THEN attempt to process th event
     # AND on error return the custom body string
     assert result["statusCode"] == 404
-    assert result["headers"]["Content-Type"] == content_types.APPLICATION_JSON
+    assert result["headers"]["Content-Type"] == content_types.TEXT_PLAIN
     assert result["body"] == response_body

--- a/tests/functional/event_handler/test_api_gateway.py
+++ b/tests/functional/event_handler/test_api_gateway.py
@@ -860,3 +860,40 @@ def test_api_gateway_request_path_equals_strip_prefix():
     # THEN process event correctly
     assert result["statusCode"] == 200
     assert result["headers"]["Content-Type"] == content_types.APPLICATION_JSON
+
+
+def test_custom_not_found_string():
+    # GIVEN a resolver with a custom not found string
+    response_body = "foo"
+
+    app = ApiGatewayResolver(custom_not_found=response_body)
+
+    # WHEN calling the event handler
+    result = app(LOAD_GW_EVENT, {})
+
+    # THEN attempt to process th event
+    # AND on error return the custom body string
+    assert result["statusCode"] == 404
+    assert result["headers"]["Content-Type"] == content_types.APPLICATION_JSON
+    assert result["body"] == response_body
+
+
+def test_custom_not_found_function():
+    # GIVEN a resolver with a custom not found as a callable function
+    response_body = "foo"
+
+    def response_body_function(method: str, path: str):
+        assert method == "GET"
+        assert path == "/my/path"
+        return response_body
+
+    app = ApiGatewayResolver(custom_not_found=response_body_function)
+
+    # WHEN calling the event handler
+    result = app(LOAD_GW_EVENT, {})
+
+    # THEN attempt to process th event
+    # AND on error return the custom body string
+    assert result["statusCode"] == 404
+    assert result["headers"]["Content-Type"] == content_types.APPLICATION_JSON
+    assert result["body"] == response_body


### PR DESCRIPTION
**Issue #, if available:**

## Description of changes:

Allow custom HTTP response for requests which would normally result in 404 messages.  Supports a static Response object, or a callable function that returns one.  Callable function takes the method and path as parameters.  All of the Response can be overridden, including the status code.

Examples:
```python
not_found_body = open("404.html", "r").read()
not_found_response = Response(status_code=404, content_type=content_types.TEXT_HTML, body=not_found_body)
app = ApiGatewayResolver(custom_not_found=not_found_response)
```
```python
def not_found_body(method: str, path: str):
    return Response(
        status_code=404,
        content_type=content_types.TEXT_PLAIN,
        body=f"Sorry, {path} not found!"
    )

app = ApiGatewayResolver(custom_not_found=not_found_body)
```

**Checklist**

* [x] [Meet tenets criteria](https://awslabs.github.io/aws-lambda-powertools-python/#tenets)
* [x] Update tests
* [ ] Update docs
* [x] PR title follows [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-python/blob/376ec0a2ac0d2a40e0af5717bef42ff84ca0d1b9/.github/semantic.yml#L2)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.