### PR TITLE
revert(metrics): typing regression on log_metrics callable

### DIFF
--- a/aws_lambda_powertools/metrics/metrics.py
+++ b/aws_lambda_powertools/metrics/metrics.py
@@ -2,9 +2,8 @@ import functools
 import json
 import logging
 import warnings
-from typing import Any, Callable, Dict, Optional, Union, cast
+from typing import Any, Callable, Dict, Optional, Union
 
-from ..shared.types import AnyCallableT
 from .base import MetricManager, MetricUnit
 from .metric import single_metric
 
@@ -130,7 +129,7 @@ class Metrics(MetricManager):
         capture_cold_start_metric: bool = False,
         raise_on_empty_metrics: bool = False,
         default_dimensions: Optional[Dict[str, str]] = None,
-    ) -> AnyCallableT:
+    ):
         """Decorator to serialize and publish metrics at the end of a function execution.
 
         Be aware that the log_metrics **does call* the decorated function (e.g. lambda_handler).
@@ -170,14 +169,11 @@ class Metrics(MetricManager):
         # Return a partial function with args filled
         if lambda_handler is None:
             logger.debug("Decorator called with parameters")
-            return cast(
-                AnyCallableT,
-                functools.partial(
-                    self.log_metrics,
-                    capture_cold_start_metric=capture_cold_start_metric,
-                    raise_on_empty_metrics=raise_on_empty_metrics,
-                    default_dimensions=default_dimensions,
-                ),
+            return functools.partial(
+                self.log_metrics,
+                capture_cold_start_metric=capture_cold_start_metric,
+                raise_on_empty_metrics=raise_on_empty_metrics,
+                default_dimensions=default_dimensions,
             )
 
         @functools.wraps(lambda_handler)
@@ -198,7 +194,7 @@ class Metrics(MetricManager):
 
             return response
 
-        return cast(AnyCallableT, decorate)
+        return decorate
 
     def __add_cold_start_metric(self, context: Any) -> None:
         """Add cold start metric and function_name dimension


### PR DESCRIPTION
**Issue #, if available:** #743

## Description of changes:

<!--- One or two sentences as a summary of what's being changed -->

Fixes a typing regression for `log_metrics` where the return had an explicit Callable and this confuses MyPy and loses the param spec.

```python
from aws_lambda_powertools import Metrics
from aws_lambda_powertools.utilities.typing import LambdaContext

metrics = Metrics(namespace="test")


@metrics.log_metrics
def lambda_handler(evt: dict, ctx: LambdaContext):
    metrics.add_metric(name="test", unit="Count", value=1)
```

**Error**

```python
$ mypy ~/Library/Application\ Support/JetBrains/PyCharm2021.2/scratches/scratch.py
/Users/lessa/Library/Application Support/JetBrains/PyCharm2021.2/scratches/scratch.py:11:1: error: <nothing> not callable  [misc]
/Users/lessa/Library/Application Support/JetBrains/PyCharm2021.2/scratches/scratch.py:12:1: error: <nothing> not callable  [misc]
Found 2 errors in 1 file (checked 1 source file)

```

**Checklist**

<!--- Leave unchecked if your change doesn't seem to apply --> 

* [ ] [Meet tenets criteria](https://awslabs.github.io/aws-lambda-powertools-python/#tenets)
* [ ] Update tests
* [ ] Update docs
* [ ] PR title follows [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-python/blob/376ec0a2ac0d2a40e0af5717bef42ff84ca0d1b9/.github/semantic.yml#L2)

## Breaking change checklist

<!--- Ignore if it's not a breaking change -->

**RFC issue #**:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
