### PR TITLE
docs: add amplify-cli instructions for public layer

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -131,6 +131,32 @@ We build, release and distribute packaged Lambda Powertools layers for each regi
 
     ```
 
+=== "Amplify"
+
+    ```zsh
+    # Create a new one with the layer
+    ❯ amplify add function
+    ? Select which capability you want to add: Lambda function (serverless function)
+    ? Provide an AWS Lambda function name: <NAME-OF-FUNCTION>
+    ? Choose the runtime that you want to use: Python
+    ? Do you want to configure advanced settings? Yes
+    ...
+    ? Do you want to enable Lambda layers for this function? Yes
+    ? Enter up to 5 existing Lambda layer ARNs (comma-separated): arn:aws:lambda:eu-central-1:017000801446:layer:AWSLambdaPowertoolsPython:3
+    ❯ amplify push -y
+
+    
+    # Updating an existing function and add the layer
+    ❯ amplify update function
+    ? Select the Lambda function you want to update test2
+    General information
+    - Name: <NAME-OF-FUNCTION>
+    ? Which setting do you want to update? Lambda layers configuration
+    ? Do you want to enable Lambda layers for this function? Yes
+    ? Enter up to 5 existing Lambda layer ARNs (comma-separated): arn:aws:lambda:eu-central-1:017000801446:layer:AWSLambdaPowertoolsPython:3
+    ? Do you want to edit the local lambda function now? No
+    ```
+
 ??? note "Layer ARN per region"
 
     !!! tip "Click to copy to clipboard"


### PR DESCRIPTION
## Description of changes:
After discussing with Alex and Heitor on this [tweet](https://twitter.com/sandro_vol/status/1446340381298282498) and in DMs I've added a section on how to add `aws-lambda-powertools-python` in an existing Amplify project.

Just documentation changes

**Checklist**

<!--- Leave unchecked if your change doesn't seem to apply --> 

* [ ] [Meet tenets criteria](https://awslabs.github.io/aws-lambda-powertools-python/#tenets)
* [ ] Update tests
* [x] Update docs
* [x] PR title follows [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-python/blob/376ec0a2ac0d2a40e0af5717bef42ff84ca0d1b9/.github/semantic.yml#L2)


-----
[View rendered docs/index.md](https://github.com/AlessandroVol23/aws-lambda-powertools-python/blob/docss/public-arn-amplify-project/docs/index.md)