### PR TITLE
docs(middleware): fix sample code

### DIFF
--- a/docs/utilities/middleware_factory.md
+++ b/docs/utilities/middleware_factory.md
@@ -48,7 +48,7 @@ You can also have your own keyword arguments after the mandatory arguments.
         if fields:
             for field in fields:
                 if field in event:
-                    event[field] = obfuscate(event.get(field, ""))
+                    event[field] = obfuscate(event[field])
 
         return handler(event, context)
 


### PR DESCRIPTION
## Description of changes:

<!--- One or two sentences as a summary of what's being changed -->
The sample provided in the documentation for the middleware is not working as expected. The value of the field variable is overwritten that later on causes failures. With this change we provide a sample that can be used as a starting point.

**Checklist**

* [ ] [Meet tenets criteria](https://awslabs.github.io/aws-lambda-powertools-python/#tenets)
* [ ] Update tests
* [x] Update docs
* [x] PR title follows [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-python/blob/376ec0a2ac0d2a40e0af5717bef42ff84ca0d1b9/.github/semantic.yml#L2)

## Breaking change checklist

<!--- Ignore if it's not a breaking change -->

**RFC issue #**:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


-----
[View rendered docs/utilities/middleware_factory.md](https://github.com/arthurf1969/aws-lambda-powertools-python/blob/fix-middleware-sample/docs/utilities/middleware_factory.md)