### PR TITLE
feat(appsync): add Router to allow large resolver composition

### DIFF
--- a/aws_lambda_powertools/event_handler/appsync.py
+++ b/aws_lambda_powertools/event_handler/appsync.py
@@ -174,17 +174,17 @@ class AppSyncResolver(BaseRouter):
         """Implicit lambda handler which internally calls `resolve`"""
         return self.resolve(event, context, data_model)
 
-    def include_resolver(self, resolver: "Resolver") -> None:
-        """Adds all resolvers defined in a resolver
+    def include_router(self, router: "Router") -> None:
+        """Adds all resolvers defined in a router
 
         Parameters
         ----------
-        resolver : Resolver
-            A resolver containing a dict of field resolvers
+        router : Router
+            A router containing a dict of field resolvers
         """
-        self._resolvers.update(resolver._resolvers)
+        self._resolvers.update(router._resolvers)
 
 
-class Resolver(BaseRouter):
+class Router(BaseRouter):
     def __init__(self):
         super().__init__()

--- a/tests/functional/event_handler/test_appsync.py
+++ b/tests/functional/event_handler/test_appsync.py
@@ -4,7 +4,7 @@ import sys
 import pytest
 
 from aws_lambda_powertools.event_handler import AppSyncResolver
-from aws_lambda_powertools.event_handler.appsync import Resolver
+from aws_lambda_powertools.event_handler.appsync import Router
 from aws_lambda_powertools.utilities.data_classes import AppSyncResolverEvent
 from aws_lambda_powertools.utilities.typing import LambdaContext
 from tests.functional.utils import load_event
@@ -167,9 +167,9 @@ def test_resolve_custom_data_model():
 def test_resolver_include_resolver():
     # GIVEN
     app = AppSyncResolver()
-    resolver = Resolver()
+    router = Router()
 
-    @resolver.resolver(type_name="Query", field_name="listLocations")
+    @router.resolver(type_name="Query", field_name="listLocations")
     def get_locations(name: str):
         return "get_locations#" + name
 
@@ -177,7 +177,7 @@ def test_resolver_include_resolver():
     def get_locations2(name: str):
         return "get_locations2#" + name
 
-    app.include_resolver(resolver)
+    app.include_router(router)
 
     # WHEN
     mock_event1 = {"typeName": "Query", "fieldName": "listLocations", "arguments": {"name": "value"}}


### PR DESCRIPTION
Add support for splitting resolvers into multiple files

**Issue #, if available:**
- #652

## Description of changes:

Add support for splitting an AppSyncResolver into multiple files (very similar to https://github.com/awslabs/aws-lambda-powertools-python/pull/645).

Example `main.py`:

```python3
from typing import Dict

from aws_lambda_powertools import Tracer, Logger
from aws_lambda_powertools.event_handler import AppSyncResolver
from aws_lambda_powertools.logging.correlation_paths import APPSYNC_RESOLVER
from aws_lambda_powertools.utilities.typing import LambdaContext

from .resolvers import location, merchant

tracer = Tracer()
logger = Logger()
app = AppSyncResolver()
app.include_router(location.router)
app.include_router(merchant.router)


@tracer.capture_lambda_handler
@logger.inject_lambda_context(correlation_id_path=APPSYNC_RESOLVER)
def lambda_handler(event: Dict, context: LambdaContext):
    app.resolve(event, context)
```

Example `resolvers/location.py`:

```python3
from typing import List, Dict, Any

from aws_lambda_powertools import Logger
from aws_lambda_powertools.event_handler.appsync import Router

logger = Logger(child=True)
router = Router()


@router.resolver(type_name="Query", field_name="listLocations")
def list_locations(merchant_id: str) -> List[Dict[str, Any]]:
    return [{"name": "Location name", "merchant_id": merchant_id}]


@router.resolver(type_name="Location", field_name="status")
def resolve_status(merchant_id: str) -> str:
    logger.debug(f"Resolve status for merchant_id: {merchant_id}")
    return "FOO"

```

**Checklist**

<!--- Leave unchecked if your change doesn't seem to apply --> 

* [X] [Meet tenets criteria](https://awslabs.github.io/aws-lambda-powertools-python/#tenets)
* [X] Update tests
* [ ] Update docs
* [X] PR title follows [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-python/blob/376ec0a2ac0d2a40e0af5717bef42ff84ca0d1b9/.github/semantic.yml#L2)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
