### PR TITLE
docs: fix indentation of SAM snippets in install section

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -43,8 +43,8 @@ Include Lambda Powertools in your function using the [AWS Lambda Console](https:
     MyLambdaFunction:
         Type: AWS::Serverless::Function
         Properties:
-        Layers:
-            - !Sub arn:aws:lambda:${AWS::Region}:017000801446:layer:AWSLambdaPowertoolsPython:3
+            Layers:
+                - !Sub arn:aws:lambda:${AWS::Region}:017000801446:layer:AWSLambdaPowertoolsPython:3
     ```
 
 === "Serverless framework"
@@ -196,16 +196,16 @@ If using SAM, you can include this SAR App as part of your shared Layers stack, 
     AwsLambdaPowertoolsPythonLayer:
         Type: AWS::Serverless::Application
         Properties:
-        Location:
-            ApplicationId: arn:aws:serverlessrepo:eu-west-1:057560766410:applications/aws-lambda-powertools-python-layer
-            SemanticVersion: 1.21.1 # change to latest semantic version available in SAR
+            Location:
+                ApplicationId: arn:aws:serverlessrepo:eu-west-1:057560766410:applications/aws-lambda-powertools-python-layer
+                SemanticVersion: 1.21.1 # change to latest semantic version available in SAR
 
     MyLambdaFunction:
         Type: AWS::Serverless::Function
         Properties:
-        Layers:
-            # fetch Layer ARN from SAR App stack output
-            - !GetAtt AwsLambdaPowertoolsPythonLayer.Outputs.LayerVersionArn
+            Layers:
+                # fetch Layer ARN from SAR App stack output
+                - !GetAtt AwsLambdaPowertoolsPythonLayer.Outputs.LayerVersionArn
     ```
 
 === "Serverless framework"
@@ -223,10 +223,10 @@ If using SAM, you can include this SAR App as part of your shared Layers stack, 
         AwsLambdaPowertoolsPythonLayer:
             Type: AWS::Serverless::Application
             Properties:
-            Location:
-                ApplicationId: arn:aws:serverlessrepo:eu-west-1:057560766410:applications/aws-lambda-powertools-python-layer
-                # Find latest from github.com/awslabs/aws-lambda-powertools-python/releases
-                SemanticVersion: 1.21.1
+                Location:
+                    ApplicationId: arn:aws:serverlessrepo:eu-west-1:057560766410:applications/aws-lambda-powertools-python-layer
+                    # Find latest from github.com/awslabs/aws-lambda-powertools-python/releases
+                    SemanticVersion: 1.21.1
     ```
 
 === "CDK"


### PR DESCRIPTION
**Issue #, if available:** N/A

## Description of changes:

The SAM snippets in the "Install" section on the homepage were invalid due to incorrect indentation. When copy-and-pasted into a SAM template, `sam build` would yield lengthy stack traces and with errors such as

```
samtranslator.model.exceptions.InvalidDocumentException: [InvalidResourceException('AwsLambdaPowertoolsPythonLayer', 'Resource is missing the required [Location] property.')]
```

This PR fixes the instances of incorrect indentation.  

For reference, the relevant section of the SAM syntax docs is [here](https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/sam-resource-layerversion.html).

**Checklist**

<!--- Leave unchecked if your change doesn't seem to apply --> 

* [ ] [Meet tenets criteria](https://awslabs.github.io/aws-lambda-powertools-python/#tenets)
* [ ] Update tests
* [ ] Update docs
* [x] PR title follows [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-python/blob/376ec0a2ac0d2a40e0af5717bef42ff84ca0d1b9/.github/semantic.yml#L2)

## Breaking change checklist

N/A: Not a breaking change.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


-----
[View rendered docs/index.md](https://github.com/jonemo/aws-lambda-powertools-python/blob/fix-sam-snippets/docs/index.md)