### PR TITLE
fix(parser): body/QS can be null or omitted in apigw v1/v2

### DIFF
--- a/aws_lambda_powertools/utilities/parser/models/apigw.py
+++ b/aws_lambda_powertools/utilities/parser/models/apigw.py
@@ -89,4 +89,4 @@ class APIGatewayProxyEventModel(BaseModel):
     pathParameters: Optional[Dict[str, str]]
     stageVariables: Optional[Dict[str, str]]
     isBase64Encoded: bool
-    body: str
+    body: Optional[str]

--- a/aws_lambda_powertools/utilities/parser/models/apigwv2.py
+++ b/aws_lambda_powertools/utilities/parser/models/apigwv2.py
@@ -63,9 +63,9 @@ class APIGatewayProxyEventV2Model(BaseModel):
     rawQueryString: str
     cookies: Optional[List[str]]
     headers: Dict[str, str]
-    queryStringParameters: Dict[str, str]
+    queryStringParameters: Optional[Dict[str, str]]
     pathParameters: Optional[Dict[str, str]]
     stageVariables: Optional[Dict[str, str]]
     requestContext: RequestContextV2
-    body: str
+    body: Optional[str]
     isBase64Encoded: bool

--- a/tests/functional/parser/test_apigw.py
+++ b/tests/functional/parser/test_apigw.py
@@ -1,7 +1,7 @@
 import pytest
 from pydantic import ValidationError
 
-from aws_lambda_powertools.utilities.parser import envelopes, event_parser
+from aws_lambda_powertools.utilities.parser import envelopes, event_parser, parse
 from aws_lambda_powertools.utilities.parser.models import APIGatewayProxyEventModel
 from aws_lambda_powertools.utilities.typing import LambdaContext
 from tests.functional.parser.schemas import MyApiGatewayBusiness
@@ -144,3 +144,9 @@ def test_apigw_event_with_invalid_websocket_request():
     expected_msg = "messageId is available only when the `eventType` is `MESSAGE`"
     assert errors[0]["msg"] == expected_msg
     assert expected_msg in str(err.value)
+
+
+def test_apigw_event_empty_body():
+    event = load_event("apiGatewayProxyEvent.json")
+    event["body"] = None
+    parse(event=event, model=APIGatewayProxyEventModel)

--- a/tests/functional/parser/test_apigwv2.py
+++ b/tests/functional/parser/test_apigwv2.py
@@ -1,4 +1,4 @@
-from aws_lambda_powertools.utilities.parser import envelopes, event_parser
+from aws_lambda_powertools.utilities.parser import envelopes, event_parser, parse
 from aws_lambda_powertools.utilities.parser.models import (
     APIGatewayProxyEventV2Model,
     RequestContextV2,
@@ -90,3 +90,16 @@ def test_api_gateway_proxy_v2_event_iam_authorizer():
     assert iam.principalOrgId == "AwsOrgId"
     assert iam.userArn == "arn:aws:iam::1234567890:user/Admin"
     assert iam.userId == "AROA2ZJZYVRE7Y3TUXHH6"
+
+
+def test_apigw_event_empty_body():
+    event = load_event("apiGatewayProxyV2Event.json")
+    event.pop("body")  # API GW v2 removes certain keys when no data is passed
+    parse(event=event, model=APIGatewayProxyEventV2Model)
+
+
+def test_apigw_event_empty_query_strings():
+    event = load_event("apiGatewayProxyV2Event.json")
+    event["rawQueryString"] = ""
+    event.pop("queryStringParameters")  # API GW v2 removes certain keys when no data is passed
+    parse(event=event, model=APIGatewayProxyEventV2Model)


### PR DESCRIPTION
**Issue #, if available:** #797

## Description of changes:

<!--- One or two sentences as a summary of what's being changed -->

Parser incorrectly expected `body` to always be non-empty; this addresses it.

**Actual event tested to repro #797**

```json
{
    "body": null,
    "resource": "/users",
    "path": "/users",
    "httpMethod": "GET",
    "headers": {
        "Accept": "*/*",
        "CloudFront-Forwarded-Proto": "https",
        "CloudFront-Is-Desktop-Viewer": "true",
        "CloudFront-Is-Mobile-Viewer": "false",
        "CloudFront-Is-SmartTV-Viewer": "false",
        "CloudFront-Is-Tablet-Viewer": "false",
        "CloudFront-Viewer-Country": "NL",
        "Host": "a1c2k0n4x4.execute-api.eu-west-1.amazonaws.com",
        "User-Agent": "Mozilla/5.0 (compatible; MSIE 9.0; Windows NT 6.1; Trident/5.0)",
        "Via": "2.0 b619a16f6f8fe9793bf642d2a8434284.cloudfront.net (CloudFront)",
        "X-Amz-Cf-Id": "sj5uo2ZyuF8WvtxH6IYxHMQFHCuMWaD-xE5T-7WFZR28Jz-Kp4Zvsw==",
        "X-Amzn-Trace-Id": "Root=1-618ff3e6-6e0fdf4f4197d0e7437264dd",
        "X-Forwarded-For": "83.41.50.10, 54.200.158.122",
        "X-Forwarded-Port": "443",
        "X-Forwarded-Proto": "https"
    },
    "multiValueHeaders": {
        "Accept": [
            "*/*"
        ],
        "CloudFront-Forwarded-Proto": [
            "https"
        ],
        "CloudFront-Is-Desktop-Viewer": [
            "true"
        ],
        "CloudFront-Is-Mobile-Viewer": [
            "false"
        ],
        "CloudFront-Is-SmartTV-Viewer": [
            "false"
        ],
        "CloudFront-Is-Tablet-Viewer": [
            "false"
        ],
        "CloudFront-Viewer-Country": [
            "NL"
        ],
        "Host": [
            "a1c2k0n4x4.execute-api.eu-west-1.amazonaws.com"
        ],
        "User-Agent": [
            "Mozilla/5.0 (compatible; MSIE 9.0; Windows NT 6.1; Trident/5.0)"
        ],
        "Via": [
            "2.0 b619a16f6f8fe9793bf642d2a8434284.cloudfront.net (CloudFront)"
        ],
        "X-Amz-Cf-Id": [
            "sj5uo2ZyuF8WvtxH6IYxHMQFHCuMWaD-xE5T-7WFZR28Jz-Kp4Zvsw=="
        ],
        "X-Amzn-Trace-Id": [
            "Root=1-618ff3e6-6e0fdf4f4197d0e7437264dd"
        ],
        "X-Forwarded-For": [
            "83.41.50.10, 54.200.158.122"
        ],
        "X-Forwarded-Port": [
            "443"
        ],
        "X-Forwarded-Proto": [
            "https"
        ]
    },
    "queryStringParameters": null,
    "multiValueQueryStringParameters": null,
    "pathParameters": null,
    "stageVariables": null,
    "requestContext": {
        "resourceId": "sfqe1d",
        "resourcePath": "/users",
        "httpMethod": "GET",
        "extendedRequestId": "IwMMEGaOjoEF_zw=",
        "requestTime": "13/Nov/2021:17:20:38 +0000",
        "path": "/Prod/users",
        "accountId": "231436140809",
        "protocol": "HTTP/1.1",
        "stage": "Prod",
        "domainPrefix": "a1c2k0n4x4",
        "requestTimeEpoch": 1636824038666,
        "requestId": "4fdd98f4-0570-46cb-b683-b0d02afe9dca",
        "identity": {
            "cognitoIdentityPoolId": null,
            "accountId": null,
            "cognitoIdentityId": null,
            "caller": null,
            "sourceIp": "83.41.50.10",
            "principalOrgId": null,
            "accessKey": null,
            "cognitoAuthenticationType": null,
            "cognitoAuthenticationProvider": null,
            "userArn": null,
            "userAgent": "Mozilla/5.0 (compatible; MSIE 9.0; Windows NT 6.1; Trident/5.0)",
            "user": null
        },
        "domainName": "a1c2k0n4x4.execute-api.eu-west-1.amazonaws.com",
        "apiId": "a1c2k0n4x4"
    },
    "isBase64Encoded": false
}
```

**Checklist**

<!--- Leave unchecked if your change doesn't seem to apply --> 

* [ ] [Meet tenets criteria](https://awslabs.github.io/aws-lambda-powertools-python/#tenets)
* [ ] Update tests
* [ ] Update docs
* [ ] PR title follows [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-python/blob/376ec0a2ac0d2a40e0af5717bef42ff84ca0d1b9/.github/semantic.yml#L2)

## Breaking change checklist

<!--- Ignore if it's not a breaking change -->

**RFC issue #**:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
