### PR TITLE
docs: use higher contrast font

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -30,6 +30,8 @@ nav:
 
 theme:
   name: material
+  font:
+    text: Ubuntu
   palette:
     - scheme: default
       primary: deep purple


### PR DESCRIPTION
**Issue #, if available:**

## Description of changes:

Changing to Ubuntu type font to improve reading 

![image](https://user-images.githubusercontent.com/3340292/141655891-71320a84-db62-400e-843a-bca9978269ed.png)


### BEFORE

![image](https://user-images.githubusercontent.com/3340292/141655879-9d180a91-f49d-4d24-8a9b-2a9e71eb5188.png)



**Checklist**

<!--- Leave unchecked if your change doesn't seem to apply --> 

* [ ] [Meet tenets criteria](https://awslabs.github.io/aws-lambda-powertools-python/#tenets)
* [ ] Update tests
* [ ] Update docs
* [ ] PR title follows [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-python/blob/376ec0a2ac0d2a40e0af5717bef42ff84ca0d1b9/.github/semantic.yml#L2)

## Breaking change checklist

<!--- Ignore if it's not a breaking change -->

**RFC issue #**:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
