### PR TITLE
feat(apigateway): access parent api resolver from router

### DIFF
--- a/aws_lambda_powertools/event_handler/api_gateway.py
+++ b/aws_lambda_powertools/event_handler/api_gateway.py
@@ -380,7 +380,7 @@ class BaseRouter(ABC):
 
 
 class ApiGatewayResolver(BaseRouter):
-    """API Gateway and ALB proxy api_resolver
+    """API Gateway and ALB proxy resolver
 
     Examples
     --------

--- a/aws_lambda_powertools/event_handler/api_gateway.py
+++ b/aws_lambda_powertools/event_handler/api_gateway.py
@@ -688,6 +688,7 @@ class Router(BaseRouter):
         cache_control: Optional[str] = None,
     ):
         def register_route(func: Callable):
+            # Convert methods to tuple. It needs to be hashable as its part of the self._routes dict key
             methods = (method,) if isinstance(method, str) else tuple(method)
             self._routes[(rule, methods, cors, compress, cache_control)] = func
 

--- a/aws_lambda_powertools/event_handler/api_gateway.py
+++ b/aws_lambda_powertools/event_handler/api_gateway.py
@@ -380,7 +380,7 @@ class BaseRouter(ABC):
 
 
 class ApiGatewayResolver(BaseRouter):
-    """API Gateway and ALB proxy resolver
+    """API Gateway and ALB proxy api_resolver
 
     Examples
     --------
@@ -664,6 +664,10 @@ class ApiGatewayResolver(BaseRouter):
         prefix : str, optional
             An optional prefix to be added to the originally defined rule
         """
+
+        # Add reference to parent ApiGatewayResolver to support use cases where people subclass it to add custom logic
+        router.api_resolver = self
+
         for route, func in router._routes.items():
             if prefix:
                 rule = route[0]
@@ -678,6 +682,7 @@ class Router(BaseRouter):
 
     def __init__(self):
         self._routes: Dict[tuple, Callable] = {}
+        self.api_resolver: Optional[BaseRouter] = None
 
     def route(
         self,

--- a/aws_lambda_powertools/event_handler/api_gateway.py
+++ b/aws_lambda_powertools/event_handler/api_gateway.py
@@ -10,7 +10,7 @@ from abc import ABC, abstractmethod
 from enum import Enum
 from functools import partial
 from http import HTTPStatus
-from typing import Any, Callable, Dict, List, Optional, Set, Union
+from typing import Any, Callable, Dict, List, Optional, Set, Tuple, Union
 
 from aws_lambda_powertools.event_handler import content_types
 from aws_lambda_powertools.event_handler.exceptions import ServiceError
@@ -453,7 +453,7 @@ class ApiGatewayResolver(BaseRouter):
     def route(
         self,
         rule: str,
-        method: str,
+        method: Union[str, Union[List[str], Tuple[str]]],
         cors: Optional[bool] = None,
         compress: bool = False,
         cache_control: Optional[str] = None,
@@ -461,19 +461,22 @@ class ApiGatewayResolver(BaseRouter):
         """Route decorator includes parameter `method`"""
 
         def register_resolver(func: Callable):
-            logger.debug(f"Adding route using rule {rule} and method {method.upper()}")
+            methods = (method,) if isinstance(method, str) else method
+            logger.debug(f"Adding route using rule {rule} and methods: {','.join((m.upper() for m in methods))}")
             if cors is None:
                 cors_enabled = self._cors_enabled
             else:
                 cors_enabled = cors
-            self._routes.append(Route(method, self._compile_regex(rule), func, cors_enabled, compress, cache_control))
-            route_key = method + rule
-            if route_key in self._route_keys:
-                warnings.warn(f"A route like this was already registered. method: '{method}' rule: '{rule}'")
-            self._route_keys.append(route_key)
-            if cors_enabled:
-                logger.debug(f"Registering method {method.upper()} to Allow Methods in CORS")
-                self._cors_methods.add(method.upper())
+
+            for item in methods:
+                self._routes.append(Route(item, self._compile_regex(rule), func, cors_enabled, compress, cache_control))
+                route_key = item + rule
+                if route_key in self._route_keys:
+                    warnings.warn(f"A route like this was already registered. method: '{item}' rule: '{rule}'")
+                self._route_keys.append(route_key)
+                if cors_enabled:
+                    logger.debug(f"Registering method {item.upper()} to Allow Methods in CORS")
+                    self._cors_methods.add(item.upper())
             return func
 
         return register_resolver
@@ -679,14 +682,13 @@ class Router(BaseRouter):
     def route(
         self,
         rule: str,
-        method: Union[str, List[str]],
+        method: Union[str, Union[List[str], Tuple[str]]],
         cors: Optional[bool] = None,
         compress: bool = False,
         cache_control: Optional[str] = None,
     ):
         def register_route(func: Callable):
-            methods = method if isinstance(method, list) else [method]
-            for item in methods:
-                self._routes[(rule, item, cors, compress, cache_control)] = func
+            methods = (method,) if isinstance(method, str) else tuple(method)
+            self._routes[(rule, methods, cors, compress, cache_control)] = func
 
         return register_route

--- a/tests/functional/event_handler/test_api_gateway.py
+++ b/tests/functional/event_handler/test_api_gateway.py
@@ -1057,3 +1057,22 @@ def test_route_multiple_methods():
     assert post_result["headers"]["Content-Type"] == content_types.APPLICATION_JSON
     assert put_result["statusCode"] == 404
     assert put_result["headers"]["Content-Type"] == content_types.APPLICATION_JSON
+
+
+def test_api_gateway_app_router_access_to_resolver():
+    # GIVEN a Router with registered routes
+    app = ApiGatewayResolver()
+    router = Router()
+
+    @router.get("/my/path")
+    def foo():
+        # WHEN accessing the api resolver instance via the router
+        # THEN it is accessible and equal to the instantiated api resolver
+        assert app == router.api_resolver
+        return {}
+
+    app.include_router(router)
+    result = app(LOAD_GW_EVENT, {})
+
+    assert result["statusCode"] == 200
+    assert result["headers"]["Content-Type"] == content_types.APPLICATION_JSON

--- a/tests/functional/event_handler/test_api_gateway.py
+++ b/tests/functional/event_handler/test_api_gateway.py
@@ -1021,3 +1021,39 @@ def test_duplicate_routes():
     # THEN only execute the first registered route
     # AND print warnings
     assert result["statusCode"] == 200
+
+
+def test_route_multiple_methods():
+    # GIVEN a function with http methods passed as a list
+    app = ApiGatewayResolver()
+    req = "foo"
+    get_event = deepcopy(LOAD_GW_EVENT)
+    get_event["resource"] = "/accounts/{account_id}"
+    get_event["path"] = f"/accounts/{req}"
+
+    post_event = deepcopy(get_event)
+    post_event["httpMethod"] = "POST"
+
+    put_event = deepcopy(get_event)
+    put_event["httpMethod"] = "PUT"
+
+    lambda_context = {}
+
+    @app.route(rule="/accounts/<account_id>", method=["GET", "POST"])
+    def foo(account_id):
+        assert app.lambda_context == lambda_context
+        assert account_id == f"{req}"
+        return {}
+
+    # WHEN calling the event handler with the supplied methods
+    get_result = app(get_event, lambda_context)
+    post_result = app(post_event, lambda_context)
+    put_result = app(put_event, lambda_context)
+
+    # THEN events are processed correctly
+    assert get_result["statusCode"] == 200
+    assert get_result["headers"]["Content-Type"] == content_types.APPLICATION_JSON
+    assert post_result["statusCode"] == 200
+    assert post_result["headers"]["Content-Type"] == content_types.APPLICATION_JSON
+    assert put_result["statusCode"] == 404
+    assert put_result["headers"]["Content-Type"] == content_types.APPLICATION_JSON


### PR DESCRIPTION
**Issue #, if available:** #834

## Description of changes:

Enable access to parent api resolver class from child router classes. Example:

app.py
```python
...
app = ApiGatewayResolver()
app.include_router(users.router, prefix="/users") # prefix 

def lambda_handler(event: Dict, context: LambdaContext):
    return app.resolve(event, context)

```

users.py
```python
...

router = Router()

@router.get("/users/")
def get_users() -> Dict:
    router.api_resolver.custom_functionality()
    return {"message": "success"}

```

**Checklist**

<!--- Leave unchecked if your change doesn't seem to apply --> 

* [X] [Meet tenets criteria](https://awslabs.github.io/aws-lambda-powertools-python/#tenets)
* [X] Update tests
* [X] Update docs
* [X] PR title follows [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-python/blob/376ec0a2ac0d2a40e0af5717bef42ff84ca0d1b9/.github/semantic.yml#L2)

## Breaking change checklist

<!--- Ignore if it's not a breaking change -->

**RFC issue #**:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
