### PR TITLE
docs(apigateway): fix sample layout provided

### DIFF
--- a/docs/core/event_handler/api_gateway.md
+++ b/docs/core/event_handler/api_gateway.md
@@ -1073,7 +1073,7 @@ This sample project contains a Users function with two distinct set of routes, `
             Runtime: python3.9
             Tracing: Active
             Architectures:
-                - arm64
+                - x86_64
             Environment:
                 Variables:
                     LOG_LEVEL: INFO


### PR DESCRIPTION
Current version does not work when deployed

**Issue #, if available:**

- https://github.com/awslabs/aws-lambda-powertools-python/issues/835

## Description of changes:

Fixes the sample layout for multiple file project

**Checklist**

<!--- Leave unchecked if your change doesn't seem to apply --> 

* [X] [Meet tenets criteria](https://awslabs.github.io/aws-lambda-powertools-python/#tenets)
* [X] Update tests
* [X] Update docs
* [X] PR title follows [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-python/blob/376ec0a2ac0d2a40e0af5717bef42ff84ca0d1b9/.github/semantic.yml#L2)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


-----
[View rendered docs/core/event_handler/api_gateway.md](https://github.com/gyft/aws-lambda-powertools-python/blob/doc-updated-layout/docs/core/event_handler/api_gateway.md)