### PR TITLE
fix(metrics): explicit type to single_metric ctx manager

### DIFF
--- a/aws_lambda_powertools/metrics/metric.py
+++ b/aws_lambda_powertools/metrics/metric.py
@@ -1,7 +1,7 @@
 import json
 import logging
 from contextlib import contextmanager
-from typing import Dict, Optional, Union
+from typing import Dict, Iterator, Optional, Union
 
 from .base import MetricManager, MetricUnit
 
@@ -61,7 +61,7 @@ class SingleMetric(MetricManager):
 
 
 @contextmanager
-def single_metric(name: str, unit: MetricUnit, value: float, namespace: Optional[str] = None):
+def single_metric(name: str, unit: MetricUnit, value: float, namespace: Optional[str] = None) -> Iterator[SingleMetric]:
     """Context manager to simplify creation of a single metric
 
     Example

--- a/aws_lambda_powertools/metrics/metric.py
+++ b/aws_lambda_powertools/metrics/metric.py
@@ -1,7 +1,7 @@
 import json
 import logging
 from contextlib import contextmanager
-from typing import Dict, Iterator, Optional, Union
+from typing import Dict, Optional, Union, Generator
 
 from .base import MetricManager, MetricUnit
 
@@ -61,7 +61,7 @@ class SingleMetric(MetricManager):
 
 
 @contextmanager
-def single_metric(name: str, unit: MetricUnit, value: float, namespace: Optional[str] = None) -> Iterator[SingleMetric]:
+def single_metric(name: str, unit: MetricUnit, value: float, namespace: Optional[str] = None) -> Generator[SingleMetric, None, None]:
     """Context manager to simplify creation of a single metric
 
     Example


### PR DESCRIPTION
**Issue #, if available:**

* [Maintenance: address top papercuts #857](https://github.com/awslabs/aws-lambda-powertools-python/issues/857)

## Description of changes:

Simply update type return for `metrics.metric.single_metric`.

**Checklist**

<!--- Leave unchecked if your change doesn't seem to apply --> 

* [x] [Meet tenets criteria](https://awslabs.github.io/aws-lambda-powertools-python/#tenets)
* [ ] Update tests
* [ ] Update docs
* [x] PR title follows [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-python/blob/376ec0a2ac0d2a40e0af5717bef42ff84ca0d1b9/.github/semantic.yml#L2)

## Breaking change checklist

<!--- Ignore if it's not a breaking change -->

**RFC issue #**:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
