### PR TITLE
fix(idempotency): include decorated fn name in hash

### DIFF
--- a/aws_lambda_powertools/utilities/idempotency/base.py
+++ b/aws_lambda_powertools/utilities/idempotency/base.py
@@ -56,7 +56,7 @@ class IdempotencyHandler:
         self.fn_args = function_args
         self.fn_kwargs = function_kwargs
 
-        persistence_store.configure(config)
+        persistence_store.configure(config, self.function.__name__)
         self.persistence_store = persistence_store
 
     def handle(self) -> Any:

--- a/aws_lambda_powertools/utilities/idempotency/persistence/base.py
+++ b/aws_lambda_powertools/utilities/idempotency/persistence/base.py
@@ -124,7 +124,7 @@ class BasePersistenceLayer(ABC):
         self._cache: Optional[LRUDict] = None
         self.hash_function = None
 
-    def configure(self, config: IdempotencyConfig) -> None:
+    def configure(self, config: IdempotencyConfig, function_name: str) -> None:
         """
         Initialize the base persistence layer from the configuration settings
 
@@ -133,6 +133,7 @@ class BasePersistenceLayer(ABC):
         config: IdempotencyConfig
             Idempotency configuration settings
         """
+        self.function_name = function_name
         if self.configured:
             # Prevent being reconfigured multiple times
             return
@@ -178,7 +179,7 @@ class BasePersistenceLayer(ABC):
             warnings.warn(f"No value found for idempotency_key. jmespath: {self.event_key_jmespath}")
 
         generated_hash = self._generate_hash(data=data)
-        function_name = os.getenv(constants.LAMBDA_FUNCTION_NAME_ENV, "test-func")
+        function_name = os.getenv(constants.LAMBDA_FUNCTION_NAME_ENV, "test-func") + "." + self.function_name
         return f"{function_name}#{generated_hash}"
 
     @staticmethod

--- a/aws_lambda_powertools/utilities/idempotency/persistence/base.py
+++ b/aws_lambda_powertools/utilities/idempotency/persistence/base.py
@@ -112,6 +112,7 @@ class BasePersistenceLayer(ABC):
 
     def __init__(self):
         """Initialize the defaults"""
+        self.function_name = None
         self.configured = False
         self.event_key_jmespath: Optional[str] = None
         self.event_key_compiled_jmespath = None

--- a/aws_lambda_powertools/utilities/idempotency/persistence/base.py
+++ b/aws_lambda_powertools/utilities/idempotency/persistence/base.py
@@ -112,7 +112,7 @@ class BasePersistenceLayer(ABC):
 
     def __init__(self):
         """Initialize the defaults"""
-        self.function_name = None
+        self.function_name = ""
         self.configured = False
         self.event_key_jmespath: Optional[str] = None
         self.event_key_compiled_jmespath = None
@@ -125,7 +125,7 @@ class BasePersistenceLayer(ABC):
         self._cache: Optional[LRUDict] = None
         self.hash_function = None
 
-    def configure(self, config: IdempotencyConfig, function_name: str) -> None:
+    def configure(self, config: IdempotencyConfig, function_name: Optional[str] = None) -> None:
         """
         Initialize the base persistence layer from the configuration settings
 
@@ -133,8 +133,11 @@ class BasePersistenceLayer(ABC):
         ----------
         config: IdempotencyConfig
             Idempotency configuration settings
+        function_name: str, Optional
+            The name of the function being decorated
         """
-        self.function_name = function_name
+        self.function_name = f"{os.getenv(constants.LAMBDA_FUNCTION_NAME_ENV, 'test-func')}.{function_name or ''}"
+
         if self.configured:
             # Prevent being reconfigured multiple times
             return
@@ -180,8 +183,7 @@ class BasePersistenceLayer(ABC):
             warnings.warn(f"No value found for idempotency_key. jmespath: {self.event_key_jmespath}")
 
         generated_hash = self._generate_hash(data=data)
-        function_name = os.getenv(constants.LAMBDA_FUNCTION_NAME_ENV, "test-func") + "." + self.function_name
-        return f"{function_name}#{generated_hash}"
+        return f"{self.function_name}#{generated_hash}"
 
     @staticmethod
     def is_missing_idempotency_key(data) -> bool:

--- a/tests/functional/idempotency/conftest.py
+++ b/tests/functional/idempotency/conftest.py
@@ -150,7 +150,7 @@ def expected_params_put_item_with_validation(hashed_idempotency_key, hashed_vali
 def hashed_idempotency_key(lambda_apigw_event, default_jmespath, lambda_context):
     compiled_jmespath = jmespath.compile(default_jmespath)
     data = compiled_jmespath.search(lambda_apigw_event)
-    return "test-func#" + hashlib.md5(serialize(data).encode()).hexdigest()
+    return "test-func.lambda_handler#" + hashlib.md5(serialize(data).encode()).hexdigest()
 
 
 @pytest.fixture
@@ -158,7 +158,7 @@ def hashed_idempotency_key_with_envelope(lambda_apigw_event):
     event = extract_data_from_envelope(
         data=lambda_apigw_event, envelope=envelopes.API_GATEWAY_HTTP, jmespath_options={}
     )
-    return "test-func#" + hashlib.md5(serialize(event).encode()).hexdigest()
+    return "test-func.lambda_handler#" + hashlib.md5(serialize(event).encode()).hexdigest()
 
 
 @pytest.fixture

--- a/tests/functional/idempotency/test_idempotency.py
+++ b/tests/functional/idempotency/test_idempotency.py
@@ -648,7 +648,7 @@ def test_in_progress_never_saved_to_cache(
 ):
     # GIVEN a data record with status "INPROGRESS"
     # and persistence_store has use_local_cache = True
-    persistence_store.configure(idempotency_config)
+    persistence_store.configure(idempotency_config, "handler")
     data_record = DataRecord("key", status="INPROGRESS")
 
     # WHEN saving to local cache
@@ -661,7 +661,7 @@ def test_in_progress_never_saved_to_cache(
 @pytest.mark.parametrize("idempotency_config", [{"use_local_cache": False}], indirect=True)
 def test_user_local_disabled(idempotency_config: IdempotencyConfig, persistence_store: DynamoDBPersistenceLayer):
     # GIVEN a persistence_store with use_local_cache = False
-    persistence_store.configure(idempotency_config)
+    persistence_store.configure(idempotency_config, "")
 
     # WHEN calling any local cache options
     data_record = DataRecord("key", status="COMPLETED")
@@ -683,7 +683,7 @@ def test_delete_from_cache_when_empty(
     idempotency_config: IdempotencyConfig, persistence_store: DynamoDBPersistenceLayer
 ):
     # GIVEN use_local_cache is True AND the local cache is empty
-    persistence_store.configure(idempotency_config)
+    persistence_store.configure(idempotency_config, "handler")
 
     try:
         # WHEN we _delete_from_cache
@@ -735,7 +735,8 @@ def test_default_no_raise_on_missing_idempotency_key(
     idempotency_config: IdempotencyConfig, persistence_store: DynamoDBPersistenceLayer, lambda_context
 ):
     # GIVEN a persistence_store with use_local_cache = False and event_key_jmespath = "body"
-    persistence_store.configure(idempotency_config)
+    function_name = "foo"
+    persistence_store.configure(idempotency_config, function_name)
     assert persistence_store.use_local_cache is False
     assert "body" in persistence_store.event_key_jmespath
 
@@ -743,7 +744,7 @@ def test_default_no_raise_on_missing_idempotency_key(
     hashed_key = persistence_store._get_hashed_idempotency_key({})
 
     # THEN return the hash of None
-    expected_value = "test-func#" + md5(serialize(None).encode()).hexdigest()
+    expected_value = f"test-func.{function_name}#" + md5(serialize(None).encode()).hexdigest()
     assert expected_value == hashed_key
 
 
@@ -754,7 +755,7 @@ def test_raise_on_no_idempotency_key(
     idempotency_config: IdempotencyConfig, persistence_store: DynamoDBPersistenceLayer, lambda_context
 ):
     # GIVEN a persistence_store with raise_on_no_idempotency_key and no idempotency key in the request
-    persistence_store.configure(idempotency_config)
+    persistence_store.configure(idempotency_config, "handler")
     persistence_store.raise_on_no_idempotency_key = True
     assert persistence_store.use_local_cache is False
     assert "body" in persistence_store.event_key_jmespath
@@ -781,7 +782,7 @@ def test_jmespath_with_powertools_json(
     idempotency_config: IdempotencyConfig, persistence_store: DynamoDBPersistenceLayer, lambda_context
 ):
     # GIVEN an event_key_jmespath with powertools_json custom function
-    persistence_store.configure(idempotency_config)
+    persistence_store.configure(idempotency_config, "handler")
     sub_attr_value = "cognito_user"
     static_pk_value = "some_key"
     expected_value = [sub_attr_value, static_pk_value]
@@ -794,7 +795,7 @@ def test_jmespath_with_powertools_json(
     result = persistence_store._get_hashed_idempotency_key(api_gateway_proxy_event)
 
     # THEN the hashed idempotency key should match the extracted values generated hash
-    assert result == "test-func#" + persistence_store._generate_hash(expected_value)
+    assert result == "test-func.handler#" + persistence_store._generate_hash(expected_value)
 
 
 @pytest.mark.parametrize("config_with_jmespath_options", ["powertools_json(data).payload"], indirect=True)
@@ -803,7 +804,7 @@ def test_custom_jmespath_function_overrides_builtin_functions(
 ):
     # GIVEN an persistence store with a custom jmespath_options
     # AND use a builtin powertools custom function
-    persistence_store.configure(config_with_jmespath_options)
+    persistence_store.configure(config_with_jmespath_options, "handler")
 
     with pytest.raises(jmespath.exceptions.UnknownFunctionError, match="Unknown function: powertools_json()"):
         # WHEN calling _get_hashed_idempotency_key
@@ -871,7 +872,9 @@ class MockPersistenceLayer(BasePersistenceLayer):
 def test_idempotent_lambda_event_source(lambda_context):
     # Scenario to validate that we can use the event_source decorator before or after the idempotent decorator
     mock_event = load_event("apiGatewayProxyV2Event.json")
-    persistence_layer = MockPersistenceLayer("test-func#" + hashlib.md5(serialize(mock_event).encode()).hexdigest())
+    persistence_layer = MockPersistenceLayer(
+        "test-func.lambda_handler#" + hashlib.md5(serialize(mock_event).encode()).hexdigest()
+    )
     expected_result = {"message": "Foo"}
 
     # GIVEN an event_source decorator
@@ -891,7 +894,9 @@ def test_idempotent_lambda_event_source(lambda_context):
 def test_idempotent_function():
     # Scenario to validate we can use idempotent_function with any function
     mock_event = {"data": "value"}
-    persistence_layer = MockPersistenceLayer("test-func#" + hashlib.md5(serialize(mock_event).encode()).hexdigest())
+    persistence_layer = MockPersistenceLayer(
+        "test-func.record_handler#" + hashlib.md5(serialize(mock_event).encode()).hexdigest()
+    )
     expected_result = {"message": "Foo"}
 
     @idempotent_function(persistence_store=persistence_layer, data_keyword_argument="record")
@@ -908,7 +913,9 @@ def test_idempotent_function_arbitrary_args_kwargs():
     # Scenario to validate we can use idempotent_function with a function
     # with an arbitrary number of args and kwargs
     mock_event = {"data": "value"}
-    persistence_layer = MockPersistenceLayer("test-func#" + hashlib.md5(serialize(mock_event).encode()).hexdigest())
+    persistence_layer = MockPersistenceLayer(
+        "test-func.record_handler#" + hashlib.md5(serialize(mock_event).encode()).hexdigest()
+    )
     expected_result = {"message": "Foo"}
 
     @idempotent_function(persistence_store=persistence_layer, data_keyword_argument="record")
@@ -923,7 +930,9 @@ def test_idempotent_function_arbitrary_args_kwargs():
 
 def test_idempotent_function_invalid_data_kwarg():
     mock_event = {"data": "value"}
-    persistence_layer = MockPersistenceLayer("test-func#" + hashlib.md5(serialize(mock_event).encode()).hexdigest())
+    persistence_layer = MockPersistenceLayer(
+        "test-func.record_handler#" + hashlib.md5(serialize(mock_event).encode()).hexdigest()
+    )
     expected_result = {"message": "Foo"}
     keyword_argument = "payload"
 
@@ -940,7 +949,9 @@ def test_idempotent_function_invalid_data_kwarg():
 
 def test_idempotent_function_arg_instead_of_kwarg():
     mock_event = {"data": "value"}
-    persistence_layer = MockPersistenceLayer("test-func#" + hashlib.md5(serialize(mock_event).encode()).hexdigest())
+    persistence_layer = MockPersistenceLayer(
+        "test-func.record_handler#" + hashlib.md5(serialize(mock_event).encode()).hexdigest()
+    )
     expected_result = {"message": "Foo"}
     keyword_argument = "record"
 
@@ -958,12 +969,18 @@ def test_idempotent_function_arg_instead_of_kwarg():
 def test_idempotent_function_and_lambda_handler(lambda_context):
     # Scenario to validate we can use both idempotent_function and idempotent decorators
     mock_event = {"data": "value"}
-    persistence_layer = MockPersistenceLayer("test-func#" + hashlib.md5(serialize(mock_event).encode()).hexdigest())
+    persistence_layer = MockPersistenceLayer(
+        "test-func.record_handler#" + hashlib.md5(serialize(mock_event).encode()).hexdigest()
+    )
     expected_result = {"message": "Foo"}
 
     @idempotent_function(persistence_store=persistence_layer, data_keyword_argument="record")
     def record_handler(record):
         return expected_result
+
+    persistence_layer = MockPersistenceLayer(
+        "test-func.lambda_handler#" + hashlib.md5(serialize(mock_event).encode()).hexdigest()
+    )
 
     @idempotent(persistence_store=persistence_layer)
     def lambda_handler(event, _):
@@ -986,7 +1003,9 @@ def test_idempotent_data_sorting():
     data_two = {"more_data": "more data 1", "data": "test message 1"}
 
     # Assertion will happen in MockPersistenceLayer
-    persistence_layer = MockPersistenceLayer("test-func#" + hashlib.md5(json.dumps(data_one).encode()).hexdigest())
+    persistence_layer = MockPersistenceLayer(
+        "test-func.dummy#" + hashlib.md5(json.dumps(data_one).encode()).hexdigest()
+    )
 
     # GIVEN
     @idempotent_function(data_keyword_argument="payload", persistence_store=persistence_layer)

--- a/tests/functional/idempotency/test_idempotency.py
+++ b/tests/functional/idempotency/test_idempotency.py
@@ -648,7 +648,7 @@ def test_in_progress_never_saved_to_cache(
 ):
     # GIVEN a data record with status "INPROGRESS"
     # and persistence_store has use_local_cache = True
-    persistence_store.configure(idempotency_config, "handler")
+    persistence_store.configure(idempotency_config)
     data_record = DataRecord("key", status="INPROGRESS")
 
     # WHEN saving to local cache
@@ -661,7 +661,7 @@ def test_in_progress_never_saved_to_cache(
 @pytest.mark.parametrize("idempotency_config", [{"use_local_cache": False}], indirect=True)
 def test_user_local_disabled(idempotency_config: IdempotencyConfig, persistence_store: DynamoDBPersistenceLayer):
     # GIVEN a persistence_store with use_local_cache = False
-    persistence_store.configure(idempotency_config, "")
+    persistence_store.configure(idempotency_config)
 
     # WHEN calling any local cache options
     data_record = DataRecord("key", status="COMPLETED")
@@ -683,7 +683,7 @@ def test_delete_from_cache_when_empty(
     idempotency_config: IdempotencyConfig, persistence_store: DynamoDBPersistenceLayer
 ):
     # GIVEN use_local_cache is True AND the local cache is empty
-    persistence_store.configure(idempotency_config, "handler")
+    persistence_store.configure(idempotency_config)
 
     try:
         # WHEN we _delete_from_cache
@@ -755,7 +755,7 @@ def test_raise_on_no_idempotency_key(
     idempotency_config: IdempotencyConfig, persistence_store: DynamoDBPersistenceLayer, lambda_context
 ):
     # GIVEN a persistence_store with raise_on_no_idempotency_key and no idempotency key in the request
-    persistence_store.configure(idempotency_config, "handler")
+    persistence_store.configure(idempotency_config)
     persistence_store.raise_on_no_idempotency_key = True
     assert persistence_store.use_local_cache is False
     assert "body" in persistence_store.event_key_jmespath
@@ -802,9 +802,9 @@ def test_jmespath_with_powertools_json(
 def test_custom_jmespath_function_overrides_builtin_functions(
     config_with_jmespath_options: IdempotencyConfig, persistence_store: DynamoDBPersistenceLayer, lambda_context
 ):
-    # GIVEN an persistence store with a custom jmespath_options
+    # GIVEN a persistence store with a custom jmespath_options
     # AND use a builtin powertools custom function
-    persistence_store.configure(config_with_jmespath_options, "handler")
+    persistence_store.configure(config_with_jmespath_options)
 
     with pytest.raises(jmespath.exceptions.UnknownFunctionError, match="Unknown function: powertools_json()"):
         # WHEN calling _get_hashed_idempotency_key


### PR DESCRIPTION
**Issue #, if available:**

- #855

## Description of changes:

Include the callable function name in the generated idempotent key

**Checklist**

<!--- Leave unchecked if your change doesn't seem to apply --> 

* [X] [Meet tenets criteria](https://awslabs.github.io/aws-lambda-powertools-python/#tenets)
* [x] Update tests
* [X] Update docs
* [X] PR title follows [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-python/blob/376ec0a2ac0d2a40e0af5717bef42ff84ca0d1b9/.github/semantic.yml#L2)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
