### PR TITLE
feat(jmespath): sha256 fn to ease idempotency use cases

### DIFF
--- a/aws_lambda_powertools/utilities/jmespath_utils/__init__.py
+++ b/aws_lambda_powertools/utilities/jmespath_utils/__init__.py
@@ -30,9 +30,10 @@ class PowertoolsFunctions(Functions):
 
         return uncompressed.decode()
 
-    @signature({"types": ["string"]})
-    def _func_powertools_sha256(self, value: str):
-        hashed_content = hashlib.sha256(value.encode())
+    @signature({"types": ["string"]}, {"types": ["string"]})  # No support for optional
+    def _func_powertools_hash(self, value: str, alg: str = "md5"):
+        hash_function = getattr(hashlib, alg)
+        hashed_content: hashlib._Hash = hash_function(value.encode())
         return hashed_content.hexdigest()
 
 

--- a/aws_lambda_powertools/utilities/jmespath_utils/__init__.py
+++ b/aws_lambda_powertools/utilities/jmespath_utils/__init__.py
@@ -1,5 +1,6 @@
 import base64
 import gzip
+import hashlib
 import json
 import logging
 from typing import Any, Dict, Optional, Union
@@ -28,6 +29,11 @@ class PowertoolsFunctions(Functions):
         uncompressed = gzip.decompress(encoded)
 
         return uncompressed.decode()
+
+    @signature({"types": ["string"]})
+    def _func_powertools_md5(self, value: str):
+        hashed_content = hashlib.md5(value.encode())
+        return hashed_content.hexdigest()
 
 
 def extract_data_from_envelope(data: Union[Dict, str], envelope: str, jmespath_options: Optional[Dict] = None) -> Any:

--- a/aws_lambda_powertools/utilities/jmespath_utils/__init__.py
+++ b/aws_lambda_powertools/utilities/jmespath_utils/__init__.py
@@ -31,8 +31,8 @@ class PowertoolsFunctions(Functions):
         return uncompressed.decode()
 
     @signature({"types": ["string"]})
-    def _func_powertools_md5(self, value: str):
-        hashed_content = hashlib.md5(value.encode())
+    def _func_powertools_sha256(self, value: str):
+        hashed_content = hashlib.sha256(value.encode())
         return hashed_content.hexdigest()
 
 

--- a/docs/utilities/jmespath_functions.md
+++ b/docs/utilities/jmespath_functions.md
@@ -230,13 +230,13 @@ This sample will decompress and decode base64 data, then use JMESPath pipeline e
     ```
 
 
-#### powertools_md5 function
+#### powertools_sha256 function
 
-Use `powertools_md5` function to create a hash digest of any string data.
+Use `powertools_sha256` function to create a hash digest of any string data.
 
 > Idempotency scenario
 
-This sample will hash the base64 encoded binary data within the `body` key of an API Gateway event. Idempotency utility then use the hash digest as an idempotency token - e.g. using the entire base64 encoded data could surpass DynamoDB item limit.
+This sample will hash the base64 encoded binary data within the `body` key of an API Gateway event. Idempotency utility then use the hash digest as an idempotency token - e.g.using the entire base64 encoded data could exceed [DynamoDB's item limit (400K)](hhttps://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Limits.html#limits-items){target="_blank"}.
 
 === "powertools_json_jmespath_function.py"
 
@@ -247,7 +247,7 @@ This sample will hash the base64 encoded binary data within the `body` key of an
     )
 
     persistence_layer = DynamoDBPersistenceLayer(table_name="IdempotencyTable")
-    config = IdempotencyConfig(event_key_jmespath="powertools_md5(body)")
+    config = IdempotencyConfig(event_key_jmespath="powertools_sha256(body)")
 
     @idempotent(config=config, persistence_store=persistence_layer)
     def handler(event:APIGatewayProxyEvent, context):

--- a/docs/utilities/jmespath_functions.md
+++ b/docs/utilities/jmespath_functions.md
@@ -230,13 +230,13 @@ This sample will decompress and decode base64 data, then use JMESPath pipeline e
     ```
 
 
-#### powertools_sha256 function
+#### powertools_hash function
 
-Use `powertools_sha256` function to create a hash digest of any string data.
+Use `powertools_hash` to hash any string data using your [preferred hashing algorithm]((https://docs.python.org/3/library/hashlib.html){target="_blank"}), e.g. `md5`, `sha256`, `sha3256`.
 
 > Idempotency scenario
 
-This sample will hash the base64 encoded binary data within the `body` key of an API Gateway event. Idempotency utility then use the hash digest as an idempotency token - e.g.using the entire base64 encoded data could exceed [DynamoDB's item limit (400K)](hhttps://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Limits.html#limits-items){target="_blank"}.
+This sample will hash base64 encoded binary data received via API Gateway within the `body` key. Idempotency utility then uses the hash digest as an idempotency token, instead of the its content to not exceed [DynamoDB's item limit (400K)](hhttps://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Limits.html#limits-items){target="_blank"}.
 
 === "powertools_json_jmespath_function.py"
 
@@ -247,7 +247,7 @@ This sample will hash the base64 encoded binary data within the `body` key of an
     )
 
     persistence_layer = DynamoDBPersistenceLayer(table_name="IdempotencyTable")
-    config = IdempotencyConfig(event_key_jmespath="powertools_sha256(body)")
+    config = IdempotencyConfig(event_key_jmespath="powertools_sha256(body, 'md5')")
 
     @idempotent(config=config, persistence_store=persistence_layer)
     def handler(event:APIGatewayProxyEvent, context):

--- a/docs/utilities/jmespath_functions.md
+++ b/docs/utilities/jmespath_functions.md
@@ -247,7 +247,7 @@ This sample will hash base64 encoded binary data received via API Gateway within
     )
 
     persistence_layer = DynamoDBPersistenceLayer(table_name="IdempotencyTable")
-    config = IdempotencyConfig(event_key_jmespath="powertools_sha256(body, 'md5')")
+    config = IdempotencyConfig(event_key_jmespath="powertools_hash(body, 'md5')")
 
     @idempotent(config=config, persistence_store=persistence_layer)
     def handler(event:APIGatewayProxyEvent, context):

--- a/docs/utilities/jmespath_functions.md
+++ b/docs/utilities/jmespath_functions.md
@@ -146,13 +146,14 @@ This sample will decode the value within the `body` key of an API Gateway event 
 
     ```python hl_lines="8"
     import json
+    from aws_lambda_powertools.utilities.data_classes import APIGatewayProxyEvent
     from aws_lambda_powertools.utilities.idempotency import (
         IdempotencyConfig, DynamoDBPersistenceLayer, idempotent
     )
 
     persistence_layer = DynamoDBPersistenceLayer(table_name="IdempotencyTable")
-
     config = IdempotencyConfig(event_key_jmespath="powertools_json(body)")
+
     @idempotent(config=config, persistence_store=persistence_layer)
     def handler(event:APIGatewayProxyEvent, context):
         body = json.loads(event['body'])
@@ -226,6 +227,35 @@ This sample will decompress and decode base64 data, then use JMESPath pipeline e
 
     ```python hl_lines="7 14 16 23 39 45 47 52"
     --8<-- "docs/shared/validation_basic_jsonschema.py"
+    ```
+
+
+#### powertools_md5 function
+
+Use `powertools_md5` function to create a hash digest of any string data.
+
+> Idempotency scenario
+
+This sample will hash the base64 encoded binary data within the `body` key of an API Gateway event. Idempotency utility then use the hash digest as an idempotency token - e.g. using the entire base64 encoded data could surpass DynamoDB item limit.
+
+=== "powertools_json_jmespath_function.py"
+
+    ```python hl_lines="7"
+    from aws_lambda_powertools.utilities.data_classes import APIGatewayProxyEvent
+    from aws_lambda_powertools.utilities.idempotency import (
+        IdempotencyConfig, DynamoDBPersistenceLayer, idempotent
+    )
+
+    persistence_layer = DynamoDBPersistenceLayer(table_name="IdempotencyTable")
+    config = IdempotencyConfig(event_key_jmespath="powertools_md5(body)")
+
+    @idempotent(config=config, persistence_store=persistence_layer)
+    def handler(event:APIGatewayProxyEvent, context):
+        ...
+        return {
+            "message": "binary processed successfully",
+            "statusCode": 200
+        }
     ```
 
 ### Bring your own JMESPath function

--- a/tests/functional/test_jmespath_functions.py
+++ b/tests/functional/test_jmespath_functions.py
@@ -5,13 +5,13 @@ import hashlib
 from aws_lambda_powertools.utilities.jmespath_utils import extract_data_from_envelope
 
 
-def test_md5():
+def test_sha256():
     # GIVEN
     payload = {"body": "c2FtcGxlIHRpbnkgYmluYXJ5IGNvbnRlbnQ="}
-    expected_digest = hashlib.md5(payload["body"].encode()).hexdigest()
+    expected_digest = hashlib.sha256(payload["body"].encode()).hexdigest()
 
     # WHEN
-    digest = extract_data_from_envelope(data=payload, envelope="powertools_md5(body)")
+    digest = extract_data_from_envelope(data=payload, envelope="powertools_sha256(body)")
 
     # THEN
     assert digest == expected_digest

--- a/tests/functional/test_jmespath_functions.py
+++ b/tests/functional/test_jmespath_functions.py
@@ -2,16 +2,20 @@
 # e.g. idempotency, validation, parser, etc.
 import hashlib
 
+import pytest
+
 from aws_lambda_powertools.utilities.jmespath_utils import extract_data_from_envelope
 
 
-def test_sha256():
+@pytest.mark.parametrize("alg", ["md5", "sha256", "sha512", "sha3_256"])
+def test_hash_default_alg(alg):
     # GIVEN
     payload = {"body": "c2FtcGxlIHRpbnkgYmluYXJ5IGNvbnRlbnQ="}
-    expected_digest = hashlib.sha256(payload["body"].encode()).hexdigest()
+    hasher = getattr(hashlib, alg)
+    expected_digest: str = hasher(payload["body"].encode()).hexdigest()
 
     # WHEN
-    digest = extract_data_from_envelope(data=payload, envelope="powertools_sha256(body)")
+    digest = extract_data_from_envelope(data=payload, envelope=f"powertools_hash(body, '{alg}')")
 
     # THEN
     assert digest == expected_digest

--- a/tests/functional/test_jmespath_functions.py
+++ b/tests/functional/test_jmespath_functions.py
@@ -1,0 +1,17 @@
+# Note: other functions are originally tested in other utilities
+# e.g. idempotency, validation, parser, etc.
+import hashlib
+
+from aws_lambda_powertools.utilities.jmespath_utils import extract_data_from_envelope
+
+
+def test_md5():
+    # GIVEN
+    payload = {"body": "c2FtcGxlIHRpbnkgYmluYXJ5IGNvbnRlbnQ="}
+    expected_digest = hashlib.md5(payload["body"].encode()).hexdigest()
+
+    # WHEN
+    digest = extract_data_from_envelope(data=payload, envelope="powertools_md5(body)")
+
+    # THEN
+    assert digest == expected_digest


### PR DESCRIPTION
**Issue #, if available:**

## Description of changes:

<!--- One or two sentences as a summary of what's being changed -->

Working on a customer project that can't easily calculate an idempotency token due to missing information. Hashing the binary base64 encoded file is an option. This PR adds a new custom JMESPath function, `powertools_hash`, to make this process seamless.

**UX**

```python
from aws_lambda_powertools.utilities.jmespath_utils import extract_data_from_envelope

payload = {
    "body": "longBase64StringEncodedBinaryFile"
}

digest = extract_data_from_envelope(data=payload, envelope=""powertools_sha256(body, 'sha256')"")
```

**Idempotency scenario:** Mobile device (binary data ~3MB) -> API GW -> Lambda -> Storage

```python
from aws_lambda_powertools.utilities.data_classes import APIGatewayProxyEvent
from aws_lambda_powertools.utilities.idempotency import (
    IdempotencyConfig, DynamoDBPersistenceLayer, idempotent
)

persistence_layer = DynamoDBPersistenceLayer(table_name="IdempotencyTable")
config = IdempotencyConfig(event_key_jmespath=""powertools_hash(body, 'md5')"")

@idempotent(config=config, persistence_store=persistence_layer)
def handler(event:APIGatewayProxyEvent, context):
    ...
    return {
        "message": "binary processed successfully",
        "statusCode": 200
    }
```

**Checklist**

<!--- Leave unchecked if your change doesn't seem to apply --> 

* [x] [Meet tenets criteria](https://awslabs.github.io/aws-lambda-powertools-python/#tenets)
* [x] Update tests
* [x] Update docs
* [x] PR title follows [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-python/blob/376ec0a2ac0d2a40e0af5717bef42ff84ca0d1b9/.github/semantic.yml#L2)

## Breaking change checklist

<!--- Ignore if it's not a breaking change -->

**RFC issue #**:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
