### PR TITLE
fix(parameters): appconfig transform and return types

### DIFF
--- a/aws_lambda_powertools/metrics/metric.py
+++ b/aws_lambda_powertools/metrics/metric.py
@@ -1,7 +1,7 @@
 import json
 import logging
 from contextlib import contextmanager
-from typing import Dict, Optional, Union, Generator
+from typing import Dict, Generator, Optional, Union
 
 from .base import MetricManager, MetricUnit
 
@@ -61,7 +61,9 @@ class SingleMetric(MetricManager):
 
 
 @contextmanager
-def single_metric(name: str, unit: MetricUnit, value: float, namespace: Optional[str] = None) -> Generator[SingleMetric, None, None]:
+def single_metric(
+    name: str, unit: MetricUnit, value: float, namespace: Optional[str] = None
+) -> Generator[SingleMetric, None, None]:
     """Context manager to simplify creation of a single metric
 
     Example

--- a/aws_lambda_powertools/utilities/parameters/appconfig.py
+++ b/aws_lambda_powertools/utilities/parameters/appconfig.py
@@ -84,7 +84,7 @@ class AppConfigProvider(BaseProvider):
 
         super().__init__()
 
-    def _get(self, name: str, **sdk_options) -> bytes:
+    def _get(self, name: str, **sdk_options) -> str:
         """
         Retrieve a parameter value from AWS App config.
 
@@ -104,7 +104,7 @@ class AppConfigProvider(BaseProvider):
         sdk_options["ClientId"] = CLIENT_ID
 
         response = self.client.get_configuration(**sdk_options)
-        return response["Content"].read()  # read() of botocore.response.StreamingBody
+        return response["Content"].read().decode("utf-8")  # read() of botocore.response.StreamingBody
 
     def _get_multiple(self, path: str, **sdk_options) -> Dict[str, str]:
         """
@@ -121,7 +121,7 @@ def get_app_config(
     force_fetch: bool = False,
     max_age: int = DEFAULT_MAX_AGE_SECS,
     **sdk_options
-) -> Union[str, list, dict, bytes]:
+) -> Union[str, list, dict]:
     """
     Retrieve a configuration value from AWS App Config.
 

--- a/aws_lambda_powertools/utilities/parameters/appconfig.py
+++ b/aws_lambda_powertools/utilities/parameters/appconfig.py
@@ -84,7 +84,7 @@ class AppConfigProvider(BaseProvider):
 
         super().__init__()
 
-    def _get(self, name: str, **sdk_options) -> str:
+    def _get(self, name: str, **sdk_options) -> bytes:
         """
         Retrieve a parameter value from AWS App config.
 

--- a/aws_lambda_powertools/utilities/parameters/appconfig.py
+++ b/aws_lambda_powertools/utilities/parameters/appconfig.py
@@ -104,7 +104,7 @@ class AppConfigProvider(BaseProvider):
         sdk_options["ClientId"] = CLIENT_ID
 
         response = self.client.get_configuration(**sdk_options)
-        return response["Content"].read().decode("utf-8")  # read() of botocore.response.StreamingBody
+        return response["Content"].read()  # read() of botocore.response.StreamingBody
 
     def _get_multiple(self, path: str, **sdk_options) -> Dict[str, str]:
         """
@@ -121,7 +121,7 @@ def get_app_config(
     force_fetch: bool = False,
     max_age: int = DEFAULT_MAX_AGE_SECS,
     **sdk_options
-) -> Union[str, list, dict]:
+) -> Union[str, list, dict, bytes]:
     """
     Retrieve a configuration value from AWS App Config.
 

--- a/aws_lambda_powertools/utilities/parameters/base.py
+++ b/aws_lambda_powertools/utilities/parameters/base.py
@@ -93,6 +93,8 @@ class BaseProvider(ABC):
             raise GetParameterError(str(exc))
 
         if transform is not None:
+            if isinstance(value, bytes):
+                value = value.decode("utf-8")
             value = transform_value(value, transform)
 
         self.store[key] = ExpirableValue(value, datetime.now() + timedelta(seconds=max_age))
@@ -100,7 +102,7 @@ class BaseProvider(ABC):
         return value
 
     @abstractmethod
-    def _get(self, name: str, **sdk_options) -> str:
+    def _get(self, name: str, **sdk_options) -> bytes:
         """
         Retrieve parameter value from the underlying parameter store
         """

--- a/aws_lambda_powertools/utilities/parameters/base.py
+++ b/aws_lambda_powertools/utilities/parameters/base.py
@@ -102,7 +102,7 @@ class BaseProvider(ABC):
         return value
 
     @abstractmethod
-    def _get(self, name: str, **sdk_options) -> bytes:
+    def _get(self, name: str, **sdk_options) -> Union[str, bytes]:
         """
         Retrieve parameter value from the underlying parameter store
         """

--- a/tests/functional/test_utilities_parameters.py
+++ b/tests/functional/test_utilities_parameters.py
@@ -1503,9 +1503,8 @@ def test_appconf_provider_get_configuration_no_transform(mock_name, config):
     stubber.activate()
 
     try:
-        value = provider.get(mock_name)
-        str_value = value.decode("utf-8")
-        assert str_value == json.dumps(mock_body_json)
+        value: str = provider.get(mock_name)
+        assert value == json.dumps(mock_body_json)
         stubber.assert_no_pending_responses()
     finally:
         stubber.deactivate()

--- a/tests/functional/test_utilities_parameters.py
+++ b/tests/functional/test_utilities_parameters.py
@@ -1504,7 +1504,8 @@ def test_appconf_provider_get_configuration_no_transform(mock_name, config):
 
     try:
         value: str = provider.get(mock_name)
-        assert value == json.dumps(mock_body_json)
+        str_value = value.decode("utf-8")
+        assert str_value == json.dumps(mock_body_json)
         stubber.assert_no_pending_responses()
     finally:
         stubber.deactivate()
@@ -1515,11 +1516,12 @@ def test_appconf_get_app_config_no_transform(monkeypatch, mock_name):
     Test get_app_config()
     """
     mock_body_json = {"myenvvar1": "Black Panther", "myenvvar2": 3}
+    mock_body_bytes = str.encode(json.dumps(mock_body_json))
 
     class TestProvider(BaseProvider):
-        def _get(self, name: str, **kwargs) -> str:
+        def _get(self, name: str, **kwargs) -> bytes:
             assert name == mock_name
-            return json.dumps(mock_body_json).encode("utf-8")
+            return mock_body_bytes
 
         def _get_multiple(self, path: str, **kwargs) -> Dict[str, str]:
             raise NotImplementedError()
@@ -1531,6 +1533,30 @@ def test_appconf_get_app_config_no_transform(monkeypatch, mock_name):
     value = parameters.get_app_config(mock_name, environment=environment, application=application)
     str_value = value.decode("utf-8")
     assert str_value == json.dumps(mock_body_json)
+    assert value == mock_body_bytes
+
+
+def test_appconf_get_app_config_transform_json(monkeypatch, mock_name):
+    """
+    Test get_app_config()
+    """
+    mock_body_json = {"myenvvar1": "Black Panther", "myenvvar2": 3}
+    mock_body_bytes = str.encode(json.dumps(mock_body_json))
+
+    class TestProvider(BaseProvider):
+        def _get(self, name: str, **kwargs) -> str:
+            assert name == mock_name
+            return mock_body_bytes
+
+        def _get_multiple(self, path: str, **kwargs) -> Dict[str, str]:
+            raise NotImplementedError()
+
+    monkeypatch.setitem(parameters.base.DEFAULT_PROVIDERS, "appconfig", TestProvider())
+
+    environment = "dev"
+    application = "myapp"
+    value = parameters.get_app_config(mock_name, environment=environment, application=application, transform="json")
+    assert value == mock_body_json
 
 
 def test_appconf_get_app_config_new(monkeypatch, mock_name, mock_value):


### PR DESCRIPTION
**Issue #, if available:**: 

## Description of changes:

Fix return type and handling transform value as str instead of bytes

**Checklist**

<!--- Leave unchecked if your change doesn't seem to apply --> 

* [x] [Meet tenets criteria](https://awslabs.github.io/aws-lambda-powertools-python/#tenets)
* [x] Update tests
* [ ] Update docs
* [x] PR title follows [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-python/blob/376ec0a2ac0d2a40e0af5717bef42ff84ca0d1b9/.github/semantic.yml#L2)

## Breaking change checklist

No breaking changes.  Introduces no new exception handling and would fix batch handling of more than 10 records.

**No RFC**:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
