### PR TITLE
fix(event-sources): handle claimsOverrideDetails set to null

### DIFF
--- a/aws_lambda_powertools/metrics/metric.py
+++ b/aws_lambda_powertools/metrics/metric.py
@@ -1,7 +1,7 @@
 import json
 import logging
 from contextlib import contextmanager
-from typing import Dict, Optional, Union, Generator
+from typing import Dict, Generator, Optional, Union
 
 from .base import MetricManager, MetricUnit
 
@@ -61,7 +61,9 @@ class SingleMetric(MetricManager):
 
 
 @contextmanager
-def single_metric(name: str, unit: MetricUnit, value: float, namespace: Optional[str] = None) -> Generator[SingleMetric, None, None]:
+def single_metric(
+    name: str, unit: MetricUnit, value: float, namespace: Optional[str] = None
+) -> Generator[SingleMetric, None, None]:
     """Context manager to simplify creation of a single metric
 
     Example

--- a/aws_lambda_powertools/utilities/data_classes/cognito_user_pool_event.py
+++ b/aws_lambda_powertools/utilities/data_classes/cognito_user_pool_event.py
@@ -523,8 +523,9 @@ class ClaimsOverrideDetails(DictWrapper):
 class PreTokenGenerationTriggerEventResponse(DictWrapper):
     @property
     def claims_override_details(self) -> ClaimsOverrideDetails:
-        # Ensure we have a `claimsOverrideDetails` element
-        self._data["response"].setdefault("claimsOverrideDetails", {})
+        # Ensure we have a `claimsOverrideDetails` element and is not set to None
+        if self._data["response"].get("claimsOverrideDetails") is None:
+            self._data["response"]["claimsOverrideDetails"] = {}
         return ClaimsOverrideDetails(self._data["response"]["claimsOverrideDetails"])
 
 

--- a/tests/functional/test_data_classes.py
+++ b/tests/functional/test_data_classes.py
@@ -281,6 +281,16 @@ def test_cognito_pre_token_generation_trigger_event():
     assert claims_override_details.group_configuration.preferred_role == "role_name"
     assert event["response"]["claimsOverrideDetails"]["groupOverrideDetails"]["preferredRole"] == "role_name"
 
+    # Ensure that even if "claimsOverrideDetails" was explicitly set to None
+    # accessing `event.response.claims_override_details` would set it to `{}`
+    event["response"]["claimsOverrideDetails"] = None
+    claims_override_details = event.response.claims_override_details
+    assert claims_override_details._data == {}
+    assert event["response"]["claimsOverrideDetails"] == {}
+    claims_override_details.claims_to_suppress = ["email"]
+    assert claims_override_details.claims_to_suppress[0] == "email"
+    assert event["response"]["claimsOverrideDetails"]["claimsToSuppress"] == ["email"]
+
 
 def test_cognito_define_auth_challenge_trigger_event():
     event = DefineAuthChallengeTriggerEvent(load_event("cognitoDefineAuthChallengeEvent.json"))


### PR DESCRIPTION
**Issue #, if available:**
- #870 

## Description of changes:

`self._data["response"].setdefault("claimsOverrideDetails", {})` does not work, if `claimsOverrideDetails` was set to `null` in the json event (or `None` in the parsed Python)

**Checklist**

<!--- Leave unchecked if your change doesn't seem to apply --> 

* [x] [Meet tenets criteria](https://awslabs.github.io/aws-lambda-powertools-python/#tenets)
* [x] Update tests
* [x] Update docs
* [x] PR title follows [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-python/blob/376ec0a2ac0d2a40e0af5717bef42ff84ca0d1b9/.github/semantic.yml#L2)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
