### PR TITLE
fix(parser): mypy support for payload type override as models

### DIFF
--- a/aws_lambda_powertools/utilities/parser/models/alb.py
+++ b/aws_lambda_powertools/utilities/parser/models/alb.py
@@ -1,6 +1,8 @@
-from typing import Dict
+from typing import Dict, Union
 
 from pydantic import BaseModel
+
+from aws_lambda_powertools.utilities.parser.types import Model
 
 
 class AlbRequestContextData(BaseModel):
@@ -14,7 +16,7 @@ class AlbRequestContext(BaseModel):
 class AlbModel(BaseModel):
     httpMethod: str
     path: str
-    body: str
+    body: Union[str, Model]
     isBase64Encoded: bool
     headers: Dict[str, str]
     queryStringParameters: Dict[str, str]

--- a/aws_lambda_powertools/utilities/parser/models/apigw.py
+++ b/aws_lambda_powertools/utilities/parser/models/apigw.py
@@ -1,10 +1,10 @@
 from datetime import datetime
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Union
 
 from pydantic import BaseModel, root_validator
 from pydantic.networks import IPvAnyNetwork
 
-from ..types import Literal
+from aws_lambda_powertools.utilities.parser.types import Literal, Model
 
 
 class ApiGatewayUserCertValidity(BaseModel):
@@ -89,4 +89,4 @@ class APIGatewayProxyEventModel(BaseModel):
     pathParameters: Optional[Dict[str, str]]
     stageVariables: Optional[Dict[str, str]]
     isBase64Encoded: bool
-    body: Optional[str]
+    body: Optional[Union[str, Model]]

--- a/aws_lambda_powertools/utilities/parser/models/apigwv2.py
+++ b/aws_lambda_powertools/utilities/parser/models/apigwv2.py
@@ -1,10 +1,10 @@
 from datetime import datetime
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Union
 
 from pydantic import BaseModel, Field
 from pydantic.networks import IPvAnyNetwork
 
-from ..types import Literal
+from aws_lambda_powertools.utilities.parser.types import Literal, Model
 
 
 class RequestContextV2AuthorizerIamCognito(BaseModel):
@@ -67,5 +67,5 @@ class APIGatewayProxyEventV2Model(BaseModel):
     pathParameters: Optional[Dict[str, str]]
     stageVariables: Optional[Dict[str, str]]
     requestContext: RequestContextV2
-    body: Optional[str]
+    body: Optional[Union[str, Model]]
     isBase64Encoded: bool

--- a/aws_lambda_powertools/utilities/parser/models/cloudwatch.py
+++ b/aws_lambda_powertools/utilities/parser/models/cloudwatch.py
@@ -3,9 +3,11 @@ import json
 import logging
 import zlib
 from datetime import datetime
-from typing import List
+from typing import List, Union
 
 from pydantic import BaseModel, Field, validator
+
+from aws_lambda_powertools.utilities.parser.types import Model
 
 logger = logging.getLogger(__name__)
 
@@ -13,7 +15,7 @@ logger = logging.getLogger(__name__)
 class CloudWatchLogsLogEvent(BaseModel):
     id: str  # noqa AA03 VNE003
     timestamp: datetime
-    message: str
+    message: Union[str, Model]
 
 
 class CloudWatchLogsDecode(BaseModel):

--- a/aws_lambda_powertools/utilities/parser/models/dynamodb.py
+++ b/aws_lambda_powertools/utilities/parser/models/dynamodb.py
@@ -1,16 +1,16 @@
 from datetime import date
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Union
 
 from pydantic import BaseModel
 
-from ..types import Literal
+from aws_lambda_powertools.utilities.parser.types import Literal, Model
 
 
 class DynamoDBStreamChangedRecordModel(BaseModel):
     ApproximateCreationDateTime: Optional[date]
     Keys: Dict[str, Dict[str, Any]]
-    NewImage: Optional[Dict[str, Any]]
-    OldImage: Optional[Dict[str, Any]]
+    NewImage: Optional[Union[Dict[str, Any], Model]]
+    OldImage: Optional[Union[Dict[str, Any], Model]]
     SequenceNumber: str
     SizeBytes: int
     StreamViewType: Literal["NEW_AND_OLD_IMAGES", "KEYS_ONLY", "NEW_IMAGE", "OLD_IMAGE"]

--- a/aws_lambda_powertools/utilities/parser/models/event_bridge.py
+++ b/aws_lambda_powertools/utilities/parser/models/event_bridge.py
@@ -1,7 +1,9 @@
 from datetime import datetime
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Union
 
 from pydantic import BaseModel, Field
+
+from aws_lambda_powertools.utilities.parser.types import Model
 
 
 class EventBridgeModel(BaseModel):
@@ -13,5 +15,5 @@ class EventBridgeModel(BaseModel):
     region: str
     resources: List[str]
     detail_type: str = Field(None, alias="detail-type")
-    detail: Dict[str, Any]
+    detail: Union[Dict[str, Any], Model]
     replay_name: Optional[str] = Field(None, alias="replay-name")

--- a/aws_lambda_powertools/utilities/parser/models/kinesis.py
+++ b/aws_lambda_powertools/utilities/parser/models/kinesis.py
@@ -1,12 +1,12 @@
 import base64
 import logging
 from binascii import Error as BinAsciiError
-from typing import List
+from typing import List, Union
 
 from pydantic import BaseModel, validator
 from pydantic.types import PositiveInt
 
-from ..types import Literal
+from aws_lambda_powertools.utilities.parser.types import Literal, Model
 
 logger = logging.getLogger(__name__)
 
@@ -15,7 +15,7 @@ class KinesisDataStreamRecordPayload(BaseModel):
     kinesisSchemaVersion: str
     partitionKey: str
     sequenceNumber: PositiveInt
-    data: bytes  # base64 encoded str is parsed into bytes
+    data: Union[bytes, Model]  # base64 encoded str is parsed into bytes
     approximateArrivalTimestamp: float
 
     @validator("data", pre=True, allow_reuse=True)

--- a/aws_lambda_powertools/utilities/parser/models/s3.py
+++ b/aws_lambda_powertools/utilities/parser/models/s3.py
@@ -6,7 +6,7 @@ from pydantic.fields import Field
 from pydantic.networks import IPvAnyNetwork
 from pydantic.types import NonNegativeFloat
 
-from ..types import Literal
+from aws_lambda_powertools.utilities.parser.types import Literal
 
 
 class S3EventRecordGlacierRestoreEventData(BaseModel):

--- a/aws_lambda_powertools/utilities/parser/models/s3_object_event.py
+++ b/aws_lambda_powertools/utilities/parser/models/s3_object_event.py
@@ -1,6 +1,8 @@
-from typing import Dict, Optional
+from typing import Dict, Optional, Union
 
 from pydantic import BaseModel, HttpUrl
+
+from aws_lambda_powertools.utilities.parser.types import Model
 
 
 class S3ObjectContext(BaseModel):
@@ -12,7 +14,7 @@ class S3ObjectContext(BaseModel):
 class S3ObjectConfiguration(BaseModel):
     accessPointArn: str
     supportingAccessPointArn: str
-    payload: str
+    payload: Union[str, Model]
 
 
 class S3ObjectUserRequest(BaseModel):

--- a/aws_lambda_powertools/utilities/parser/models/sns.py
+++ b/aws_lambda_powertools/utilities/parser/models/sns.py
@@ -1,10 +1,10 @@
 from datetime import datetime
-from typing import Dict, List, Optional
+from typing import Dict, List, Optional, Union
 
 from pydantic import BaseModel, root_validator
 from pydantic.networks import HttpUrl
 
-from ..types import Literal
+from aws_lambda_powertools.utilities.parser.types import Literal, Model
 
 
 class SnsMsgAttributeModel(BaseModel):
@@ -18,7 +18,7 @@ class SnsNotificationModel(BaseModel):
     UnsubscribeUrl: HttpUrl
     Type: Literal["Notification"]
     MessageAttributes: Optional[Dict[str, SnsMsgAttributeModel]]
-    Message: str
+    Message: Union[str, Model]
     MessageId: str
     SigningCertUrl: HttpUrl
     Signature: str

--- a/aws_lambda_powertools/utilities/parser/models/sqs.py
+++ b/aws_lambda_powertools/utilities/parser/models/sqs.py
@@ -1,9 +1,9 @@
 from datetime import datetime
-from typing import Dict, List, Optional
+from typing import Dict, List, Optional, Union
 
 from pydantic import BaseModel
 
-from ..types import Literal
+from aws_lambda_powertools.utilities.parser.types import Literal, Model
 
 
 class SqsAttributesModel(BaseModel):
@@ -52,7 +52,7 @@ class SqsMsgAttributeModel(BaseModel):
 class SqsRecordModel(BaseModel):
     messageId: str
     receiptHandle: str
-    body: str
+    body: Union[str, Model]
     attributes: SqsAttributesModel
     messageAttributes: Dict[str, SqsMsgAttributeModel]
     md5OfBody: str

--- a/docs/utilities/parser.md
+++ b/docs/utilities/parser.md
@@ -170,7 +170,7 @@ Parser comes with the following built-in models:
 
 You can extend them to include your own models, and yet have all other known fields parsed along the way.
 
-!!! tip "For Mypy customers, we only allow type override for fields where payload is injected e.g. `detail`, `body`, etc."
+!!! tip "For Mypy users, we only allow type override for fields where payload is injected e.g. `detail`, `body`, etc."
 
 **EventBridge example**
 

--- a/docs/utilities/parser.md
+++ b/docs/utilities/parser.md
@@ -170,6 +170,8 @@ Parser comes with the following built-in models:
 
 You can extend them to include your own models, and yet have all other known fields parsed along the way.
 
+!!! tip "For Mypy customers, we only allow type override for fields where payload is injected e.g. `detail`, `body`, etc."
+
 **EventBridge example**
 
 === "extending_builtin_models.py"


### PR DESCRIPTION
**Issue #, if available:** https://github.com/awslabs/aws-lambda-powertools-python/issues/857

## Description of changes:

<!--- One or two sentences as a summary of what's being changed -->

This PR allows MyPy to not trigger an error when overriding payload types in built-in models provided by Parser, as described: https://awslabs.github.io/aws-lambda-powertools-python/latest/utilities/parser/#extending-built-in-models

**Scenario**: There are cases where you want to provide your own Model while retaining access to metadata information about the event. Previously, when using MyPy, this would cause a type override error since payload fields would only support what's expected, not a custom model as docs suggest for non-MyPy customers.

```python
from aws_lambda_powertools.utilities.parser import parse, BaseModel
from aws_lambda_powertools.utilities.parser.models import EventBridgeModel

from typing import List, Optional


class OrderItem(BaseModel):
    id: int
    quantity: int
    description: str


class Order(BaseModel):
    id: int
    description: str
    items: List[OrderItem]


class OrderEventModel(EventBridgeModel):
    detail: Order
```

**Checklist**

<!--- Leave unchecked if your change doesn't seem to apply --> 

* [ ] [Meet tenets criteria](https://awslabs.github.io/aws-lambda-powertools-python/#tenets)
* [ ] Update tests
* [ ] Update docs
* [ ] PR title follows [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-python/blob/376ec0a2ac0d2a40e0af5717bef42ff84ca0d1b9/.github/semantic.yml#L2)

## Breaking change checklist

<!--- Ignore if it's not a breaking change -->

**RFC issue #**:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
