### PR TITLE
fix(parser): overload parse when using envelope

### DIFF
--- a/aws_lambda_powertools/utilities/parser/envelopes/base.py
+++ b/aws_lambda_powertools/utilities/parser/envelopes/base.py
@@ -2,7 +2,7 @@ import logging
 from abc import ABC, abstractmethod
 from typing import Any, Dict, Optional, Type, TypeVar, Union
 
-from ..types import Model
+from aws_lambda_powertools.utilities.parser.types import Model
 
 logger = logging.getLogger(__name__)
 

--- a/aws_lambda_powertools/utilities/parser/parser.py
+++ b/aws_lambda_powertools/utilities/parser/parser.py
@@ -1,7 +1,7 @@
 import logging
-from typing import Any, Callable, Dict, Optional, Type, TypeVar, overload
+from typing import Any, Callable, Dict, Optional, Type, overload
 
-from aws_lambda_powertools.utilities.parser.types import Model
+from aws_lambda_powertools.utilities.parser.types import EnvelopeModel, EventParserReturnType, Model
 
 from ...middleware_factory import lambda_handler_decorator
 from ..typing import LambdaContext
@@ -9,8 +9,6 @@ from .envelopes.base import Envelope
 from .exceptions import InvalidEnvelopeError, InvalidModelTypeError
 
 logger = logging.getLogger(__name__)
-
-EventParserReturnType = TypeVar("EventParserReturnType")
 
 
 @lambda_handler_decorator
@@ -92,7 +90,7 @@ def parse(event: Dict[str, Any], model: Type[Model]) -> Model:
 
 
 @overload
-def parse(event: Dict[str, Any], model: Type[Model], envelope: Type[Envelope]):
+def parse(event: Dict[str, Any], model: Type[Model], envelope: Type[Envelope]) -> EnvelopeModel:
     ...
 
 

--- a/aws_lambda_powertools/utilities/parser/types.py
+++ b/aws_lambda_powertools/utilities/parser/types.py
@@ -12,3 +12,5 @@ else:
     from typing_extensions import Literal  # noqa: F401
 
 Model = TypeVar("Model", bound=BaseModel)
+EnvelopeModel = TypeVar("EnvelopeModel")
+EventParserReturnType = TypeVar("EventParserReturnType")


### PR DESCRIPTION
**Issue #, if available:**

## Description of changes:

<!--- One or two sentences as a summary of what's being changed -->

When using parse function with an envelope, Mypy doesn't allow setting an explicit type as `parse` returns a `Model` while an envelope parse could return various types ranging from List[Model], Dict[str, Model], List[Optional[Model], and this can grow over time as more event types are defined too.

This PR uses type function overload to ensure `parse` continues to return a `Model` when no envelope is used, and when an envelope is used it'll propagate a generic type allowing an explicit type to be set at runtime.

## Gotcha

If you don't set an explicit type when using `parse` with envelope, Mypy will detect as `Any` since MyPy can't have a generic return type in this case.

## Example

This uses a sample valid SNS payload as per the issue with an empty payload and with non-empty payload.

**Mypy output**

```bash
mypy check.py
check.py:59:13: note: Revealed type is "builtins.list[check.Item]"
check.py:60:13: note: Revealed type is "builtins.list[check.NoItem]"
```

**Python type evaluation**

```bash
Item list type: <class 'list'>
No item list type: <class 'list'>
```

```python
from aws_lambda_powertools.utilities.parser import parse, BaseModel, envelopes

from typing import List


class Item(BaseModel):
    message: str


class NoItem(BaseModel):
    ...


payload = {
    "Records": [
        {
            "EventVersion": "1.0",
            "EventSubscriptionArn": "arn:aws:sns:us-east-2:123456789012:sns-lambda",
            "EventSource": "aws:sns",
            "Sns": {
                "SignatureVersion": "1",
                "Timestamp": "2019-01-02T12:45:07.000Z",
                "Signature": "tcc6faL2yUC6dgZdmrwh1Y4cGa/ebXEkAi6RibDsvpi+tE/1+82j...65r==",
                "SigningCertUrl": "https://sns.us-east-2.amazonaws.com/SimpleNotification",
                "MessageId": "95df01b4-ee98-5cb9-9903-4c221d41eb5e",
                "Message": '{"message": "Hello from SNS!"}',
                "Type": "Notification",
                "UnsubscribeUrl": "https://sns.us-east-2.amazonaws.com/?Action=Unsubscribe",
                "TopicArn": "arn:aws:sns:us-east-2:123456789012:sns-lambda",
            },
        }
    ]
}

no_item_payload = {
    "Records": [
        {
            "EventVersion": "1.0",
            "EventSubscriptionArn": "arn:aws:sns:us-east-2:123456789012:sns-lambda",
            "EventSource": "aws:sns",
            "Sns": {
                "SignatureVersion": "1",
                "Timestamp": "2019-01-02T12:45:07.000Z",
                "Signature": "tcc6faL2yUC6dgZdmrwh1Y4cGa/ebXEkAi6RibDsvpi+tE/1+82j...65r==",
                "SigningCertUrl": "https://sns.us-east-2.amazonaws.com/SimpleNotification",
                "MessageId": "95df01b4-ee98-5cb9-9903-4c221d41eb5e",
                "Message": "",
                "Type": "Notification",
                "UnsubscribeUrl": "https://sns.us-east-2.amazonaws.com/?Action=Unsubscribe",
                "TopicArn": "arn:aws:sns:us-east-2:123456789012:sns-lambda",
            },
        }
    ]
}

item_list: List[Item] = parse(model=Item, event=payload, envelope=envelopes.SnsEnvelope)
no_item_list: List[NoItem] = parse(model=NoItem, event=payload, envelope=envelopes.SnsEnvelope)

assert item_list[0].message == "Hello from SNS!"

# reveal_type(item_list)
# reveal_type(no_item_list)

print(f"Item list type: {type(item_list)}")
print(f"No item list type: {type(no_item_list)}")
```


**Checklist**

<!--- Leave unchecked if your change doesn't seem to apply --> 

* [ ] [Meet tenets criteria](https://awslabs.github.io/aws-lambda-powertools-python/#tenets)
* [ ] Update tests
* [ ] Update docs
* [ ] PR title follows [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-python/blob/376ec0a2ac0d2a40e0af5717bef42ff84ca0d1b9/.github/semantic.yml#L2)

## Breaking change checklist

<!--- Ignore if it's not a breaking change -->

**RFC issue #**:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
