### PR TITLE
feat(parameters): Allow callable transforms

### DIFF
--- a/aws_lambda_powertools/utilities/feature_flags/appconfig.py
+++ b/aws_lambda_powertools/utilities/feature_flags/appconfig.py
@@ -3,12 +3,12 @@ import traceback
 from typing import Any, Dict, Optional, Union, cast
 
 from botocore.config import Config
-from aws_lambda_powertools.shared.types import AnyCallableT
 
 from aws_lambda_powertools.utilities import jmespath_utils
 from aws_lambda_powertools.utilities.parameters import AppConfigProvider, GetParameterError, TransformParameterError
 
 from ... import Logger
+from ...shared.types import AnyCallableT
 from .base import StoreProvider
 from .exceptions import ConfigurationStoreError, StoreClientError
 

--- a/aws_lambda_powertools/utilities/feature_flags/appconfig.py
+++ b/aws_lambda_powertools/utilities/feature_flags/appconfig.py
@@ -23,7 +23,7 @@ class AppConfigStore(StoreProvider):
         name: str,
         max_age: int = 5,
         sdk_config: Optional[Config] = None,
-        transform: Union[AnyCallableT, str] = TRANSFORM_TYPE,
+        transform: Optional[Union[AnyCallableT, str]] = TRANSFORM_TYPE,
         envelope: Optional[str] = "",
         jmespath_options: Optional[Dict] = None,
         logger: Optional[Union[logging.Logger, Logger]] = None,

--- a/aws_lambda_powertools/utilities/feature_flags/appconfig.py
+++ b/aws_lambda_powertools/utilities/feature_flags/appconfig.py
@@ -3,6 +3,7 @@ import traceback
 from typing import Any, Dict, Optional, Union, cast
 
 from botocore.config import Config
+from aws_lambda_powertools.shared.types import AnyCallableT
 
 from aws_lambda_powertools.utilities import jmespath_utils
 from aws_lambda_powertools.utilities.parameters import AppConfigProvider, GetParameterError, TransformParameterError
@@ -22,6 +23,7 @@ class AppConfigStore(StoreProvider):
         name: str,
         max_age: int = 5,
         sdk_config: Optional[Config] = None,
+        transform: Union[AnyCallableT, str] = TRANSFORM_TYPE,
         envelope: Optional[str] = "",
         jmespath_options: Optional[Dict] = None,
         logger: Optional[Union[logging.Logger, Logger]] = None,
@@ -54,6 +56,7 @@ class AppConfigStore(StoreProvider):
         self.name = name
         self.cache_seconds = max_age
         self.config = sdk_config
+        self.transform = transform
         self.envelope = envelope
         self.jmespath_options = jmespath_options
         self._conf_store = AppConfigProvider(environment=environment, application=application, config=sdk_config)
@@ -70,7 +73,7 @@ class AppConfigStore(StoreProvider):
                 dict,
                 self._conf_store.get(
                     name=self.name,
-                    transform=TRANSFORM_TYPE,
+                    transform=self.transform,
                     max_age=self.cache_seconds,
                 ),
             )

--- a/tests/functional/feature_flags/test_feature_flags.py
+++ b/tests/functional/feature_flags/test_feature_flags.py
@@ -1,3 +1,4 @@
+import json
 from typing import Dict, List, Optional
 
 import pytest
@@ -1197,3 +1198,30 @@ def test_flags_greater_than_or_equal_match_2(mocker, config):
         default=False,
     )
     assert toggle == expected_value
+
+
+def test_get_feature_toggle_appconfig_store_callable_transform(mocker, config):
+
+    mock_schema = {
+        "ten_percent_off_campaign": {
+            "default": False,
+        },
+    }
+
+    mock_value = json.dumps(mock_schema)
+
+    mocked__get_conf = mocker.patch("aws_lambda_powertools.utilities.parameters.AppConfigProvider._get")
+    mocked__get_conf.return_value = mock_value
+
+    app_conf_fetcher = AppConfigStore(
+        environment="test_env",
+        application="test_app",
+        name="test_conf_name",
+        max_age=600,
+        sdk_config=config,
+        transform=json.loads,
+    )
+
+    feature_flags: FeatureFlags = FeatureFlags(store=app_conf_fetcher)
+
+    assert feature_flags.get_configuration() == mock_schema

--- a/tests/functional/test_utilities_parameters.py
+++ b/tests/functional/test_utilities_parameters.py
@@ -1,9 +1,11 @@
 import base64
 import json
+import pickle
 import random
 import string
 from datetime import datetime, timedelta
 from io import BytesIO
+from tkinter import E
 from typing import Dict
 
 import pytest
@@ -1143,7 +1145,8 @@ def test_base_provider_get_transform_callable(mock_name, mock_value):
     Test BaseProvider.get() with a callable transform
     """
 
-    mock_data = str(mock_value)
+    mock_binary = mock_value.encode()
+    mock_data = base64.b16encode(mock_binary).decode()
 
     class TestProvider(BaseProvider):
         def _get(self, name: str, **kwargs) -> str:
@@ -1155,10 +1158,10 @@ def test_base_provider_get_transform_callable(mock_name, mock_value):
 
     provider = TestProvider()
 
-    value = provider.get(mock_name, transform=str)
+    value = provider.get(mock_name, transform=base64.b16decode)
 
-    assert isinstance(value, str)
-    assert value == mock_data
+    assert isinstance(value, bytes)
+    assert value == mock_binary
 
 
 def test_base_provider_get_transform_callable_exception(mock_name):
@@ -1166,7 +1169,8 @@ def test_base_provider_get_transform_callable_exception(mock_name):
     Test BaseProvider.get() with a callable transform that raises an exception
     """
 
-    mock_data = str(mock_value) + "a"
+    mock_data = "qw"
+    print(mock_data)
 
     class TestProvider(BaseProvider):
         def _get(self, name: str, **kwargs) -> str:
@@ -1179,9 +1183,9 @@ def test_base_provider_get_transform_callable_exception(mock_name):
     provider = TestProvider()
 
     with pytest.raises(parameters.TransformParameterError) as excinfo:
-        provider.get(mock_name, transform=int)
+        provider.get(mock_name, transform=base64.b16decode)
 
-    assert "invalid literal for int() with base 10" in str(excinfo)
+    assert "Non-base16 digit found" in str(excinfo)
 
 
 def test_base_provider_get_multiple_transform_json(mock_name, mock_value):
@@ -1332,7 +1336,8 @@ def test_base_provider_get_multiple_transform_callable(mock_name, mock_value):
     Test BaseProvider.get_multiple() with a callable transform
     """
 
-    mock_data = str(mock_value)
+    mock_binary = mock_value.encode()
+    mock_data = base64.b16encode(mock_binary).decode()
 
     class TestProvider(BaseProvider):
         def _get(self, name: str, **kwargs) -> str:
@@ -1344,10 +1349,10 @@ def test_base_provider_get_multiple_transform_callable(mock_name, mock_value):
 
     provider = TestProvider()
 
-    value = provider.get_multiple(mock_name, transform=str)
+    value = provider.get_multiple(mock_name, transform=base64.b16decode)
 
     assert isinstance(value, dict)
-    assert value["A"] == mock_data
+    assert value["A"] == mock_binary
 
 
 def test_base_provider_get_multiple_transform_callable_partial_failure(mock_name, mock_value):
@@ -1355,9 +1360,9 @@ def test_base_provider_get_multiple_transform_callable_partial_failure(mock_name
     Test BaseProvider.get_multiple() with a callable transform that contains a partial failure
     """
 
-    mock_integer = 1234
-    mock_data_a = str(mock_integer)
-    mock_data_b = str(mock_value) + "a"
+    mock_binary = mock_value.encode()
+    mock_data_a = base64.b16encode(mock_binary).decode()
+    mock_data_b = "qw"
 
     class TestProvider(BaseProvider):
         def _get(self, name: str, **kwargs) -> str:
@@ -1369,19 +1374,19 @@ def test_base_provider_get_multiple_transform_callable_partial_failure(mock_name
 
     provider = TestProvider()
 
-    value = provider.get_multiple(mock_name, transform=int)
+    value = provider.get_multiple(mock_name, transform=base64.b16decode)
 
     assert isinstance(value, dict)
-    assert value["A"] == mock_integer
+    assert value["A"] == mock_binary
     assert value["B"] is None
 
 
-def test_base_provider_get_multiple_transform_callable_exception(mock_name, mock_value):
+def test_base_provider_get_multiple_transform_callable_exception(mock_name):
     """
     Test BaseProvider.get_multiple() with a callable transform that raises an exception
     """
 
-    mock_data = str(mock_value) + "a"
+    mock_data = "qw"
 
     class TestProvider(BaseProvider):
         def _get(self, name: str, **kwargs) -> str:
@@ -1394,9 +1399,9 @@ def test_base_provider_get_multiple_transform_callable_exception(mock_name, mock
     provider = TestProvider()
 
     with pytest.raises(parameters.TransformParameterError) as excinfo:
-        provider.get_multiple(mock_name, transform=int, raise_on_transform_error=True)
+        provider.get_multiple(mock_name, transform=base64.b16decode, raise_on_transform_error=True)
 
-    assert "invalid literal for int() with base 10" in str(excinfo)
+    assert "Non-base16 digit found" in str(excinfo)
 
 
 def test_base_provider_get_multiple_cached(mock_name, mock_value):

--- a/tests/functional/test_utilities_parameters.py
+++ b/tests/functional/test_utilities_parameters.py
@@ -1,6 +1,5 @@
 import base64
 import json
-import pickle
 import random
 import string
 from datetime import datetime, timedelta

--- a/tests/functional/test_utilities_parameters.py
+++ b/tests/functional/test_utilities_parameters.py
@@ -4,7 +4,6 @@ import random
 import string
 from datetime import datetime, timedelta
 from io import BytesIO
-from tkinter import E
 from typing import Dict
 
 import pytest


### PR DESCRIPTION
**Issue #, if available:**

#893 

## Description of changes:

Add in changes to base parameter classes and feature flags appconfig store to allow for callable transforms to be used as well as the available stringy references.

**Checklist**

<!--- Leave unchecked if your change doesn't seem to apply --> 

* [x] [Meet tenets criteria](https://awslabs.github.io/aws-lambda-powertools-python/#tenets)
* [x] Update tests
* [ ] Update docs
* [x] PR title follows [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-python/blob/376ec0a2ac0d2a40e0af5717bef42ff84ca0d1b9/.github/semantic.yml#L2)

## Breaking change checklist

<!--- Ignore if it's not a breaking change -->

**RFC issue #**:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
