### PR TITLE
fix(event-sources): Pass authorizer data to APIGatewayEventAuthorizer

### DIFF
--- a/aws_lambda_powertools/utilities/data_classes/api_gateway_proxy_event.py
+++ b/aws_lambda_powertools/utilities/data_classes/api_gateway_proxy_event.py
@@ -17,6 +17,17 @@ class APIGatewayEventAuthorizer(DictWrapper):
     def scopes(self) -> Optional[List[str]]:
         return self.get("scopes")
 
+    @property
+    def principal_id(self) -> Optional[str]:
+        """The principal user identification associated with the token sent by the client and returned from an
+        API Gateway Lambda authorizer (formerly known as a custom authorizer)"""
+        return self.get("principalId")
+
+    @property
+    def integration_latency(self) -> Optional[int]:
+        """The authorizer latency in ms."""
+        return self.get("integrationLatency")
+
 
 class APIGatewayEventRequestContext(BaseRequestContext):
     @property

--- a/aws_lambda_powertools/utilities/data_classes/api_gateway_proxy_event.py
+++ b/aws_lambda_powertools/utilities/data_classes/api_gateway_proxy_event.py
@@ -11,11 +11,11 @@ from aws_lambda_powertools.utilities.data_classes.common import (
 class APIGatewayEventAuthorizer(DictWrapper):
     @property
     def claims(self) -> Optional[Dict[str, Any]]:
-        return self["requestContext"]["authorizer"].get("claims")
+        return self.get("claims")
 
     @property
     def scopes(self) -> Optional[List[str]]:
-        return self["requestContext"]["authorizer"].get("scopes")
+        return self.get("scopes")
 
 
 class APIGatewayEventRequestContext(BaseRequestContext):
@@ -56,7 +56,7 @@ class APIGatewayEventRequestContext(BaseRequestContext):
 
     @property
     def authorizer(self) -> APIGatewayEventAuthorizer:
-        return APIGatewayEventAuthorizer(self._data)
+        return APIGatewayEventAuthorizer(self._data["requestContext"]["authorizer"])
 
 
 class APIGatewayProxyEvent(BaseProxyEvent):

--- a/aws_lambda_powertools/utilities/data_classes/common.py
+++ b/aws_lambda_powertools/utilities/data_classes/common.py
@@ -18,8 +18,8 @@ class DictWrapper:
 
         return self._data == other._data
 
-    def get(self, key: str) -> Optional[Any]:
-        return self._data.get(key)
+    def get(self, key: str, default: Optional[Any] = None) -> Optional[Any]:
+        return self._data.get(key, default)
 
     @property
     def raw_event(self) -> Dict[str, Any]:

--- a/tests/events/apiGatewayProxyEventPrincipalId.json
+++ b/tests/events/apiGatewayProxyEventPrincipalId.json
@@ -1,0 +1,13 @@
+{
+  "resource": "/trip",
+  "path": "/trip",
+  "httpMethod": "POST",
+  "requestContext": {
+    "requestId": "34972478-2843-4ced-a657-253108738274",
+    "authorizer": {
+      "user_id": "fake_username",
+      "principalId": "fake",
+      "integrationLatency": 451
+    }
+  }
+}

--- a/tests/functional/test_data_classes.py
+++ b/tests/functional/test_data_classes.py
@@ -897,6 +897,18 @@ def test_api_gateway_proxy_event():
     assert request_context.identity.client_cert.subject_dn == "www.example.com"
 
 
+def test_api_gateway_proxy_event_with_principal_id():
+    event = APIGatewayProxyEvent(load_event("apiGatewayProxyEventPrincipalId.json"))
+
+    request_context = event.request_context
+    authorizer = request_context.authorizer
+    assert authorizer.claims is None
+    assert authorizer.scopes is None
+    assert authorizer["principalId"] == "fake"
+    assert authorizer.get("principalId") == "fake"
+    assert authorizer.get("foo", "default") == "default"
+
+
 def test_api_gateway_proxy_v2_event():
     event = APIGatewayProxyEventV2(load_event("apiGatewayProxyV2Event.json"))
 

--- a/tests/functional/test_data_classes.py
+++ b/tests/functional/test_data_classes.py
@@ -906,7 +906,9 @@ def test_api_gateway_proxy_event_with_principal_id():
     assert authorizer.scopes is None
     assert authorizer["principalId"] == "fake"
     assert authorizer.get("principalId") == "fake"
-    assert authorizer.get("foo", "default") == "default"
+    assert authorizer.principal_id == "fake"
+    assert authorizer.integration_latency == 451
+    assert authorizer.get("integrationStatus", "failed") == "failed"
 
 
 def test_api_gateway_proxy_v2_event():


### PR DESCRIPTION

**Issue #, if available:**

## Description of changes:

Changes:
- contract APIGatewayEventAuthorizer from the authorizer data
- add test cases for the additional fields that can optional be in the authorizer dict
- Update DictWrapper to allow for a default in `get`

**Checklist**

<!--- Leave unchecked if your change doesn't seem to apply --> 

* [X] [Meet tenets criteria](https://awslabs.github.io/aws-lambda-powertools-python/#tenets)
* [X] Update tests
* [X] Update docs
* [X] PR title follows [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-python/blob/376ec0a2ac0d2a40e0af5717bef42ff84ca0d1b9/.github/semantic.yml#L2)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
