### PR TITLE
feat(apigateway): add exception_handler support

### DIFF
--- a/aws_lambda_powertools/event_handler/api_gateway.py
+++ b/aws_lambda_powertools/event_handler/api_gateway.py
@@ -679,8 +679,8 @@ class ApiGatewayResolver(BaseRouter):
 
             self.route(*route)(func)
 
-    def not_found(self):
-        return self.exception_handler(404)
+    def not_found(self, func: Callable):
+        return self.exception_handler(404)(func)
 
     def exception_handler(self, exc_class_or_status_code: Union[int, Type[Exception]]):
         def register_exception_handler(func: Callable):

--- a/tests/functional/event_handler/test_api_gateway.py
+++ b/tests/functional/event_handler/test_api_gateway.py
@@ -1103,3 +1103,22 @@ def test_exception_handler():
     assert result["statusCode"] == 418
     assert result["headers"]["Content-Type"] == content_types.TEXT_HTML
     assert result["body"] == "Foo!"
+
+
+def test_exception_handler_not_found():
+    # GIVEN a resolver with an exception handler defined for ValueError
+    app = ApiGatewayResolver(proxy_type=ProxyEventType.APIGatewayProxyEvent)
+
+    @app.not_found()
+    def handle_not_found(exc: NotFoundError):
+        assert isinstance(exc, NotFoundError)
+        return Response(status_code=404, content_type=content_types.TEXT_PLAIN, body="I am a teapot!")
+
+    # WHEN calling the event handler
+    # AND a ValueError is raised
+    result = app(LOAD_GW_EVENT, {})
+
+    # THEN call the exception_handler
+    assert result["statusCode"] == 404
+    assert result["headers"]["Content-Type"] == content_types.TEXT_PLAIN
+    assert result["body"] == "I am a teapot!"


### PR DESCRIPTION
**Issue #, if available:**
- https://github.com/awslabs/aws-lambda-powertools-python/issues/899

## Description of changes:

```python3
app = ApiGatewayResolver()


@app.exception_handler(SomeKindOfError)
def handle_error(ex: SomeKindOfError):
   print(f"request path is '{app.current_event.path}'")
   return Response(
       status_code=418,
       content_type=content_types.TEXT_HTML,
       body=str(ex),
   )


@app.not_found()
def handle_not_found(exc: NotFoundError):
    return Response(status_code=404, content_type=content_types.TEXT_PLAIN, body="I am a teapot!")


@app.exception_handler(ServiceError)
def service_error(ex: ServiceError):
    logger.debug(f"Log out sensitive stuff: {ex.msg}")
    return Response(
        status_code=ex.status_code,
        content_type=content_types.APPLICATION_JSON,
        body="CUSTOM ERROR FORMAT",
    )


@app.get("/my/path")
def call_with_error() -> Response:
   raise SomeKindOfError("Foo!")
```

**Checklist**

<!--- Leave unchecked if your change doesn't seem to apply --> 

* [x] [Meet tenets criteria](https://awslabs.github.io/aws-lambda-powertools-python/#tenets)
* [x] Update tests
* [ ] Update docs
* [x] PR title follows [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-python/blob/376ec0a2ac0d2a40e0af5717bef42ff84ca0d1b9/.github/semantic.yml#L2)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
