### PR TITLE
fix(parser): kinesis sequence number is str, not int

### DIFF
--- a/aws_lambda_powertools/utilities/parser/models/kinesis.py
+++ b/aws_lambda_powertools/utilities/parser/models/kinesis.py
@@ -4,7 +4,6 @@ from binascii import Error as BinAsciiError
 from typing import List, Union
 
 from pydantic import BaseModel, validator
-from pydantic.types import PositiveInt
 
 from aws_lambda_powertools.utilities.parser.types import Literal, Model
 
@@ -14,7 +13,7 @@ logger = logging.getLogger(__name__)
 class KinesisDataStreamRecordPayload(BaseModel):
     kinesisSchemaVersion: str
     partitionKey: str
-    sequenceNumber: PositiveInt
+    sequenceNumber: str
     data: Union[bytes, Model]  # base64 encoded str is parsed into bytes
     approximateArrivalTimestamp: float
 

--- a/tests/functional/parser/test_kinesis.py
+++ b/tests/functional/parser/test_kinesis.py
@@ -35,7 +35,7 @@ def handle_kinesis_no_envelope(event: KinesisDataStreamModel, _: LambdaContext):
     assert kinesis.approximateArrivalTimestamp == 1545084650.987
     assert kinesis.kinesisSchemaVersion == "1.0"
     assert kinesis.partitionKey == "1"
-    assert kinesis.sequenceNumber == 49590338271490256608559692538361571095921575989136588898
+    assert kinesis.sequenceNumber == "49590338271490256608559692538361571095921575989136588898"
     assert kinesis.data == b"Hello, this is a test."
 
 


### PR DESCRIPTION
**Issue #, if available:** #858 

## Description of changes:

<!--- One or two sentences as a summary of what's being changed -->

Kinesis Sequence Number was mistakenly set as `int` and Parser (Pydantic) coerces to `int`, this silently fails the new Batch Utility when reporting partial failure.

cc @ran-isenberg 


**Checklist**

<!--- Leave unchecked if your change doesn't seem to apply --> 

* [ ] [Meet tenets criteria](https://awslabs.github.io/aws-lambda-powertools-python/#tenets)
* [ ] Update tests
* [ ] Update docs
* [ ] PR title follows [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-python/blob/376ec0a2ac0d2a40e0af5717bef42ff84ca0d1b9/.github/semantic.yml#L2)

## Breaking change checklist

<!--- Ignore if it's not a breaking change -->

**RFC issue #**:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
