### PR TITLE
feat(idempotency): support dataclasses & pydantic models payloads

### DIFF
--- a/aws_lambda_powertools/utilities/idempotency/base.py
+++ b/aws_lambda_powertools/utilities/idempotency/base.py
@@ -21,6 +21,20 @@ MAX_RETRIES = 2
 logger = logging.getLogger(__name__)
 
 
+def _prepare_data(data: Any) -> Any:
+    """Prepare data for json serialization.
+    This will convert dataclasses, pydantic models or event source data classes to a dict."""
+    if hasattr(data, "__dataclass_fields__"):
+        import dataclasses
+
+        return dataclasses.asdict(data)
+
+    if callable(getattr(data, "dict", None)):
+        return data.dict()
+
+    return getattr(data, "raw_event", data)
+
+
 class IdempotencyHandler:
     """
     Base class to orchestrate calls to persistence layer.
@@ -52,7 +66,7 @@ class IdempotencyHandler:
             Function keyword arguments
         """
         self.function = function
-        self.data = function_payload
+        self.data = _prepare_data(function_payload)
         self.fn_args = function_args
         self.fn_kwargs = function_kwargs
 

--- a/aws_lambda_powertools/utilities/idempotency/base.py
+++ b/aws_lambda_powertools/utilities/idempotency/base.py
@@ -23,7 +23,10 @@ logger = logging.getLogger(__name__)
 
 def _prepare_data(data: Any) -> Any:
     """Prepare data for json serialization.
-    This will convert dataclasses, pydantic models or event source data classes to a dict."""
+
+    We will convert Python dataclasses, pydantic models or event source data classes to a dict,
+    otherwise return data as-is.
+    """
     if hasattr(data, "__dataclass_fields__"):
         import dataclasses
 

--- a/aws_lambda_powertools/utilities/idempotency/persistence/base.py
+++ b/aws_lambda_powertools/utilities/idempotency/persistence/base.py
@@ -1,7 +1,6 @@
 """
 Persistence layers supporting idempotency
 """
-
 import datetime
 import hashlib
 import json
@@ -226,7 +225,13 @@ class BasePersistenceLayer(ABC):
             Hashed representation of the provided data
 
         """
-        data = getattr(data, "raw_event", data)  # could be a data class depending on decorator order
+        if hasattr(data, "__dataclass_fields__"):
+            import dataclasses
+
+            data = dataclasses.asdict(data)
+        else:
+            data = getattr(data, "raw_event", data)
+
         hashed_data = self.hash_function(json.dumps(data, cls=Encoder, sort_keys=True).encode())
         return hashed_data.hexdigest()
 

--- a/aws_lambda_powertools/utilities/idempotency/persistence/base.py
+++ b/aws_lambda_powertools/utilities/idempotency/persistence/base.py
@@ -105,6 +105,8 @@ class DataRecord:
 
 
 def _prepare_data(data: Any) -> Any:
+    """Prepare data for json serialization.
+    This will convert dataclasses, pydantic models or event source data classes to a dict."""
     if callable(getattr(data, "dict", None)):
         return data.dict()
 

--- a/aws_lambda_powertools/utilities/idempotency/persistence/base.py
+++ b/aws_lambda_powertools/utilities/idempotency/persistence/base.py
@@ -107,13 +107,13 @@ class DataRecord:
 def _prepare_data(data: Any) -> Any:
     """Prepare data for json serialization.
     This will convert dataclasses, pydantic models or event source data classes to a dict."""
-    if callable(getattr(data, "dict", None)):
-        return data.dict()
-
     if hasattr(data, "__dataclass_fields__"):
         import dataclasses
 
         return dataclasses.asdict(data)
+
+    if callable(getattr(data, "dict", None)):
+        return data.dict()
 
     return getattr(data, "raw_event", data)
 

--- a/aws_lambda_powertools/utilities/idempotency/persistence/base.py
+++ b/aws_lambda_powertools/utilities/idempotency/persistence/base.py
@@ -104,20 +104,6 @@ class DataRecord:
         return json.loads(self.response_data)
 
 
-def _prepare_data(data: Any) -> Any:
-    """Prepare data for json serialization.
-    This will convert dataclasses, pydantic models or event source data classes to a dict."""
-    if hasattr(data, "__dataclass_fields__"):
-        import dataclasses
-
-        return dataclasses.asdict(data)
-
-    if callable(getattr(data, "dict", None)):
-        return data.dict()
-
-    return getattr(data, "raw_event", data)
-
-
 class BasePersistenceLayer(ABC):
     """
     Abstract Base Class for Idempotency persistence layer.
@@ -239,7 +225,7 @@ class BasePersistenceLayer(ABC):
             Hashed representation of the provided data
 
         """
-        hashed_data = self.hash_function(json.dumps(_prepare_data(data), cls=Encoder, sort_keys=True).encode())
+        hashed_data = self.hash_function(json.dumps(data, cls=Encoder, sort_keys=True).encode())
         return hashed_data.hexdigest()
 
     def _validate_payload(self, data: Dict[str, Any], data_record: DataRecord) -> None:

--- a/aws_lambda_powertools/utilities/idempotency/persistence/base.py
+++ b/aws_lambda_powertools/utilities/idempotency/persistence/base.py
@@ -105,12 +105,9 @@ class DataRecord:
 
 
 def _prepare_data(data: Any) -> Any:
-    # Convert pydantic as a dict
-    _dict = getattr(data, "dict", None)
-    if callable(_dict):
-        return _dict()
+    if callable(getattr(data, "dict", None)):
+        return data.dict()
 
-    # Convert dataclasses as a dict
     if hasattr(data, "__dataclass_fields__"):
         import dataclasses
 

--- a/docs/utilities/idempotency.md
+++ b/docs/utilities/idempotency.md
@@ -208,7 +208,7 @@ When using `idempotent_function`, you must tell us which keyword parameter in yo
 
     dynamodb = DynamoDBPersistenceLayer(table_name="idem")
     config =  IdempotencyConfig(
-        event_key_jmespath="messageId",  # see Choosing a payload subset section
+        event_key_jmespath="order_id",  # see Choosing a payload subset section
         use_local_cache=True,
     )
 
@@ -244,7 +244,7 @@ When using `idempotent_function`, you must tell us which keyword parameter in yo
 
     dynamodb = DynamoDBPersistenceLayer(table_name="idem")
     config =  IdempotencyConfig(
-        event_key_jmespath="messageId",  # see Choosing a payload subset section
+        event_key_jmespath="order_id",  # see Choosing a payload subset section
         use_local_cache=True,
     )
 

--- a/docs/utilities/idempotency.md
+++ b/docs/utilities/idempotency.md
@@ -124,45 +124,50 @@ You can quickly start by initializing the `DynamoDBPersistenceLayer` class and u
 
 Similar to [idempotent decorator](#idempotent-decorator), you can use `idempotent_function` decorator for any synchronous Python function.
 
-When using `idempotent_function`, you must tell us which keyword parameter in your function signature has the data we should use via **`data_keyword_argument`** - Such data must be JSON serializable.
+When using `idempotent_function`, you must tell us which keyword parameter in your function signature has the data we should use via **`data_keyword_argument`**.
+
+!!! info "We support JSON serializable data, [Python Dataclasses](https://docs.python.org/3.7/library/dataclasses.html){target="_blank"}, [Parser/Pydantic Models](parser.md){target="_blank"}, and our [Event Source Data Classes](./data_classes.md){target="_blank"}."
 
 !!! warning "Make sure to call your decorated function using keyword arguments"
 
-=== "app.py"
+=== "batch_sample.py"
 
     This example also demonstrates how you can integrate with [Batch utility](batch.md), so you can process each record in an idempotent manner.
 
-    ```python hl_lines="4 13 18 25"
-    import uuid
+    ```python hl_lines="4-5 16 21 29"
+    from aws_lambda_powertools.utilities.batch import (BatchProcessor, EventType,
+                                                       batch_processor)
+    from aws_lambda_powertools.utilities.data_classes.sqs_event import SQSRecord
+    from aws_lambda_powertools.utilities.idempotency import (
+        DynamoDBPersistenceLayer, IdempotencyConfig, idempotent_function)
 
-    from aws_lambda_powertools.utilities.batch import sqs_batch_processor
-    from aws_lambda_powertools.utilities.idempotency import idempotent_function, DynamoDBPersistenceLayer, IdempotencyConfig
 
-
+    processor = BatchProcessor(event_type=EventType.SQS)
     dynamodb = DynamoDBPersistenceLayer(table_name="idem")
     config =  IdempotencyConfig(
-        event_key_jmespath="messageId",  # see "Choosing a payload subset for idempotency" section
+        event_key_jmespath="messageId",  # see Choosing a payload subset section
         use_local_cache=True,
     )
+
+
+    @idempotent_function(data_keyword_argument="record", config=config, persistence_store=dynamodb)
+    def record_handler(record: SQSRecord):
+        return {"message": record["body"]}
+
 
     @idempotent_function(data_keyword_argument="data", config=config, persistence_store=dynamodb)
     def dummy(arg_one, arg_two, data: dict, **kwargs):
         return {"data": data}
 
 
-    @idempotent_function(data_keyword_argument="record", config=config, persistence_store=dynamodb)
-    def record_handler(record):
-        return {"message": record["body"]}
-
-
-    @sqs_batch_processor(record_handler=record_handler)
+    @batch_processor(record_handler=record_handler, processor=processor)
     def lambda_handler(event, context):
         # `data` parameter must be called as a keyword argument to work
         dummy("hello", "universe", data="test")
-        return {"statusCode": 200}
+        return processor.response()
     ```
 
-=== "Example event"
+=== "Batch event"
 
     ```json hl_lines="4"
     {
@@ -193,6 +198,79 @@ When using `idempotent_function`, you must tell us which keyword parameter in yo
     }
     ```
 
+=== "dataclass_sample.py"
+
+    ```python hl_lines="3-4 23 32"
+    from dataclasses import dataclass
+
+    from aws_lambda_powertools.utilities.idempotency import (
+        DynamoDBPersistenceLayer, IdempotencyConfig, idempotent_function)
+
+    dynamodb = DynamoDBPersistenceLayer(table_name="idem")
+    config =  IdempotencyConfig(
+        event_key_jmespath="messageId",  # see Choosing a payload subset section
+        use_local_cache=True,
+    )
+
+    @dataclass
+    class OrderItem:
+        sku: str
+        description: str
+
+    @dataclass
+    class Order:
+        item: OrderItem
+        order_id: int
+
+
+    @idempotent_function(data_keyword_argument="order", config=config, persistence_store=dynamodb)
+    def process_order(order: Order):
+        return f"processed order {order.order_id}"
+
+
+    order_item = OrderItem(sku="fake", description="sample")
+    order = Order(item=order_item, order_id="fake-id")
+
+    # `order` parameter must be called as a keyword argument to work
+    process_order(order=order)
+    ```
+
+=== "parser_pydantic_sample.py"
+
+    ```python hl_lines="1-2 22 31"
+    from aws_lambda_powertools.utilities.idempotency import (
+        DynamoDBPersistenceLayer, IdempotencyConfig, idempotent_function)
+    from aws_lambda_powertools.utilities.parser import BaseModel
+
+    dynamodb = DynamoDBPersistenceLayer(table_name="idem")
+    config =  IdempotencyConfig(
+        event_key_jmespath="messageId",  # see Choosing a payload subset section
+        use_local_cache=True,
+    )
+
+
+    class OrderItem(BaseModel):
+        sku: str
+        description: str
+
+
+    class Order(BaseModel):
+        item: OrderItem
+        order_id: int
+
+
+    @idempotent_function(data_keyword_argument="order", config=config, persistence_store=dynamodb)
+    def process_order(order: Order):
+        return f"processed order {order.order_id}"
+
+
+    order_item = OrderItem(sku="fake", description="sample")
+    order = Order(item=order_item, order_id="fake-id")
+
+    # `order` parameter must be called as a keyword argument to work
+    process_order(order=order)
+    ```
+
 ### Choosing a payload subset for idempotency
 
 !!! tip "Dealing with always changing payloads"
@@ -209,7 +287,7 @@ Imagine the function executes successfully, but the client never receives the re
 !!! warning "Idempotency for JSON payloads"
     The payload extracted by the `event_key_jmespath` is treated as a string by default, so will be sensitive to differences in whitespace even when the JSON payload itself is identical.
 
-    To alter this behaviour, we can use the [JMESPath built-in function](jmespath_functions.md#powertools_json-function) `powertools_json()` to treat the payload as a JSON object rather than a string.
+    To alter this behaviour, we can use the [JMESPath built-in function](jmespath_functions.md#powertools_json-function) `powertools_json()` to treat the payload as a JSON object (dict) rather than a string.
 
 === "payment.py"
 

--- a/tests/functional/idempotency/conftest.py
+++ b/tests/functional/idempotency/conftest.py
@@ -1,5 +1,4 @@
 import datetime
-import hashlib
 import json
 from collections import namedtuple
 from decimal import Decimal
@@ -11,18 +10,13 @@ from botocore import stub
 from botocore.config import Config
 from jmespath import functions
 
-from aws_lambda_powertools.shared.json_encoder import Encoder
 from aws_lambda_powertools.utilities.idempotency import DynamoDBPersistenceLayer
 from aws_lambda_powertools.utilities.idempotency.idempotency import IdempotencyConfig
 from aws_lambda_powertools.utilities.jmespath_utils import extract_data_from_envelope
 from aws_lambda_powertools.utilities.validation import envelopes
-from tests.functional.utils import load_event
+from tests.functional.utils import hash_idempotency_key, json_serialize, load_event
 
 TABLE_NAME = "TEST_TABLE"
-
-
-def serialize(data):
-    return json.dumps(data, sort_keys=True, cls=Encoder)
 
 
 @pytest.fixture(scope="module")
@@ -66,12 +60,12 @@ def lambda_response():
 
 @pytest.fixture(scope="module")
 def serialized_lambda_response(lambda_response):
-    return serialize(lambda_response)
+    return json_serialize(lambda_response)
 
 
 @pytest.fixture(scope="module")
 def deserialized_lambda_response(lambda_response):
-    return json.loads(serialize(lambda_response))
+    return json.loads(json_serialize(lambda_response))
 
 
 @pytest.fixture
@@ -150,7 +144,7 @@ def expected_params_put_item_with_validation(hashed_idempotency_key, hashed_vali
 def hashed_idempotency_key(lambda_apigw_event, default_jmespath, lambda_context):
     compiled_jmespath = jmespath.compile(default_jmespath)
     data = compiled_jmespath.search(lambda_apigw_event)
-    return "test-func.lambda_handler#" + hashlib.md5(serialize(data).encode()).hexdigest()
+    return "test-func.lambda_handler#" + hash_idempotency_key(data)
 
 
 @pytest.fixture
@@ -158,12 +152,12 @@ def hashed_idempotency_key_with_envelope(lambda_apigw_event):
     event = extract_data_from_envelope(
         data=lambda_apigw_event, envelope=envelopes.API_GATEWAY_HTTP, jmespath_options={}
     )
-    return "test-func.lambda_handler#" + hashlib.md5(serialize(event).encode()).hexdigest()
+    return "test-func.lambda_handler#" + hash_idempotency_key(event)
 
 
 @pytest.fixture
 def hashed_validation_key(lambda_apigw_event):
-    return hashlib.md5(serialize(lambda_apigw_event["requestContext"]).encode()).hexdigest()
+    return hash_idempotency_key(lambda_apigw_event["requestContext"])
 
 
 @pytest.fixture

--- a/tests/functional/idempotency/test_idempotency.py
+++ b/tests/functional/idempotency/test_idempotency.py
@@ -1061,31 +1061,38 @@ def test_idempotent_function_duplicates(
 
 def test_idempotent_function_dataclasses():
     try:
-        # Scenario _prepare_data should allow for python dataclasses
+        # Scenario _prepare_data should convert a python dataclasses to a dict
         from dataclasses import asdict, dataclass
 
         @dataclass
         class Foo:
             name: str
 
+        expected_result = {"name": "Bar"}
         data = Foo(name="Bar")
         as_dict = _prepare_data(data)
-        assert asdict(data) == as_dict
-        assert as_dict == {"name": "Bar"}
+        assert as_dict == asdict(data)
+        assert as_dict == expected_result
 
     except ModuleNotFoundError:
-        # Python 3.6
-        pass
+        pass  # Python 3.6
 
 
 def test_idempotent_function_pydantic():
-    # Scenario _prepare_data should allow for pydantic
+    # Scenario _prepare_data should convert a pydantic to a dict
     from pydantic import BaseModel
 
     class Foo(BaseModel):
         name: str
 
+    expected_result = {"name": "Bar"}
     data = Foo(name="Bar")
     as_dict = _prepare_data(data)
     assert as_dict == data.dict()
-    assert as_dict == {"name": "Bar"}
+    assert as_dict == expected_result
+
+
+@pytest.mark.parametrize("data", [None, "foo", ["foo"], 1, True, {}])
+def test_idempotent_function_other(data):
+    # All other data types should be left as is
+    assert _prepare_data(data) == data

--- a/tests/functional/idempotency/test_idempotency.py
+++ b/tests/functional/idempotency/test_idempotency.py
@@ -8,6 +8,7 @@ from unittest.mock import MagicMock
 import jmespath
 import pytest
 from botocore import stub
+from pydantic import BaseModel
 
 from aws_lambda_powertools.utilities.data_classes import APIGatewayProxyEventV2, event_source
 from aws_lambda_powertools.utilities.idempotency import DynamoDBPersistenceLayer, IdempotencyConfig
@@ -1080,8 +1081,6 @@ def test_idempotent_function_dataclasses():
 
 def test_idempotent_function_pydantic():
     # Scenario _prepare_data should convert a pydantic to a dict
-    from pydantic import BaseModel
-
     class Foo(BaseModel):
         name: str
 

--- a/tests/functional/utils.py
+++ b/tests/functional/utils.py
@@ -1,7 +1,10 @@
 import base64
+import hashlib
 import json
 from pathlib import Path
 from typing import Any
+
+from aws_lambda_powertools.shared.json_encoder import Encoder
 
 
 def load_event(file_name: str) -> Any:
@@ -15,3 +18,12 @@ def str_to_b64(data: str) -> str:
 
 def b64_to_str(data: str) -> str:
     return base64.b64decode(data.encode()).decode("utf-8")
+
+
+def json_serialize(data):
+    return json.dumps(data, sort_keys=True, cls=Encoder)
+
+
+def hash_idempotency_key(data: Any):
+    """Serialize data to JSON, encode, and hash it for idempotency key"""
+    return hashlib.md5(json_serialize(data).encode()).hexdigest()


### PR DESCRIPTION
**Issue #, if available:**

## Description of changes:

Add support for serialization of python dataclasses, but checking if `__dataclass_fields__` exists and calling `dataclasses.asdict`. This happens early on in the idempotency work flow.

## UX

### Dataclasses support

```python
from dataclasses import dataclass

from aws_lambda_powertools.utilities.idempotency import (
    DynamoDBPersistenceLayer, IdempotencyConfig, idempotent_function)

dynamodb = DynamoDBPersistenceLayer(table_name="idem")
config =  IdempotencyConfig(
    event_key_jmespath="messageId",  # see Choosing a payload subset section
    use_local_cache=True,
)

@dataclass
class OrderItem:
    sku: str
    description: str

@dataclass
class Order:
    item: OrderItem
    order_id: int


@idempotent_function(data_keyword_argument="order", config=config, persistence_store=dynamodb)
def process_order(order: Order):
    return f"processed order {order.order_id}"


order_item = OrderItem(sku="fake", description="sample")
order = Order(item=order_item, order_id="fake-id")

# `order` parameter must be called as a keyword argument to work
process_order(order=order)
```

### Pydantic support

```python
from aws_lambda_powertools.utilities.idempotency import (
    DynamoDBPersistenceLayer, IdempotencyConfig, idempotent_function)
from aws_lambda_powertools.utilities.parser import BaseModel

dynamodb = DynamoDBPersistenceLayer(table_name="idem")
config =  IdempotencyConfig(
    event_key_jmespath="messageId",  # see Choosing a payload subset section
    use_local_cache=True,
)


class OrderItem(BaseModel):
    sku: str
    description: str


class Order(BaseModel):
    item: OrderItem
    order_id: int


@idempotent_function(data_keyword_argument="order", config=config, persistence_store=dynamodb)
def process_order(order: Order):
    return f"processed order {order.order_id}"


order_item = OrderItem(sku="fake", description="sample")
order = Order(item=order_item, order_id="fake-id")

# `order` parameter must be called as a keyword argument to work
process_order(order=order)
```

**Checklist**

<!--- Leave unchecked if your change doesn't seem to apply --> 

* [X] [Meet tenets criteria](https://awslabs.github.io/aws-lambda-powertools-python/#tenets)
* [X] Update tests
* [x] Update docs
* [X] PR title follows [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-python/blob/376ec0a2ac0d2a40e0af5717bef42ff84ca0d1b9/.github/semantic.yml#L2)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
