### PR TITLE
feat(tracer): ignore tracing for certain hostname(s) or url(s)

### DIFF
--- a/aws_lambda_powertools/tracing/tracer.py
+++ b/aws_lambda_powertools/tracing/tracer.py
@@ -5,7 +5,7 @@ import inspect
 import logging
 import numbers
 import os
-from typing import Any, Callable, Dict, Optional, Sequence, Union, cast, overload
+from typing import Any, Callable, Dict, List, Optional, Sequence, Union, cast, overload
 
 from ..shared import constants
 from ..shared.functions import resolve_env_var_choice, resolve_truthy_env_var_choice
@@ -758,7 +758,7 @@ class Tracer:
         # Due to Lazy Import, we need to activate `core` attrib via import
         # we also need to include `patch`, `patch_all` methods
         # to ensure patch calls are done via the provider
-        from aws_xray_sdk.core import xray_recorder
+        from aws_xray_sdk.core import xray_recorder  # type: ignore
 
         provider = xray_recorder
         provider.patch = aws_xray_sdk.core.patch
@@ -778,3 +778,23 @@ class Tracer:
 
     def _is_xray_provider(self):
         return "aws_xray_sdk" in self.provider.__module__
+
+    @staticmethod
+    def ignore_endpoint(hostname: Optional[str] = None, urls: Optional[List[str]] = None):
+        """If you want to ignore certain httplib requests you can do so based on the hostname or URL that is being
+        requested.
+
+        Documentation
+        --------------
+        - https://github.com/aws/aws-xray-sdk-python#ignoring-httplib-requests
+
+        Parameters
+        ----------
+        hostname : Optional, str
+            The hostname is matched using the Python fnmatch library which does Unix glob style matching.
+        urls: Optional, List[str]
+            List of urls to ignore. Example `tracer.ignore_endpoint(urls=["/ignored-url"])`
+        """
+        from aws_xray_sdk.ext.httplib import add_ignored  # type: ignore
+
+        add_ignored(hostname=hostname, urls=urls)

--- a/aws_lambda_powertools/tracing/tracer.py
+++ b/aws_lambda_powertools/tracing/tracer.py
@@ -779,10 +779,11 @@ class Tracer:
     def _is_xray_provider(self):
         return "aws_xray_sdk" in self.provider.__module__
 
-    @staticmethod
-    def ignore_endpoint(hostname: Optional[str] = None, urls: Optional[List[str]] = None):
+    def ignore_endpoint(self, hostname: Optional[str] = None, urls: Optional[List[str]] = None):
         """If you want to ignore certain httplib requests you can do so based on the hostname or URL that is being
         requested.
+
+        > NOTE: If the provider is not xray, nothing will be added to ignore list
 
         Documentation
         --------------
@@ -795,6 +796,9 @@ class Tracer:
         urls: Optional, List[str]
             List of urls to ignore. Example `tracer.ignore_endpoint(urls=["/ignored-url"])`
         """
+        if not self._is_xray_provider():
+            return
+
         from aws_xray_sdk.ext.httplib import add_ignored  # type: ignore
 
         add_ignored(hostname=hostname, urls=urls)

--- a/tests/unit/test_tracing.py
+++ b/tests/unit/test_tracing.py
@@ -628,3 +628,9 @@ def test_tracer_lambda_handler_do_not_add_service_annotation_when_missing(
     # THEN
     assert in_subsegment_mock.put_annotation.call_count == 1
     assert in_subsegment_mock.put_annotation.call_args == mocker.call(key="ColdStart", value=True)
+
+
+def test_ignore_endpoints(provider_stub, in_subsegment_mock):
+    provider = provider_stub(in_subsegment=in_subsegment_mock.in_subsegment)
+    tracer = Tracer(provider=provider)
+    tracer.ignore_endpoint(hostname="https://foo.com/", urls=["/bar", "/ignored"])


### PR DESCRIPTION
**Issue #, if available:**
- https://github.com/awslabs/aws-lambda-powertools-roadmap/issues/35

## Description of changes:

```python3
from aws_lambda_powertools import Tracer

tracer = Tracer()
# ignore all calls to `ec2.amazon.com`
tracer.ignore_endpoint(hostname="ec2.amazon.com") 
# ignore calls to `*.sensitive.com/password` and  `*.sensitive.com/credit-card`
tracer.ignore_endpoint(hostname="*.sensitive.com", urls=["/password", "/credit-card"]) 


def ec2_api_calls():
    return "suppress_api_responses"

@tracer.capture_lambda_handler
def handler(event, context):
    for x in long_list:
        ec2_api_calls()
```

**Checklist**

<!--- Leave unchecked if your change doesn't seem to apply --> 

* [x] [Meet tenets criteria](https://awslabs.github.io/aws-lambda-powertools-python/#tenets)
* [x] Update tests
* [x] Update docs
* [x] PR title follows [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-python/blob/376ec0a2ac0d2a40e0af5717bef42ff84ca0d1b9/.github/semantic.yml#L2)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
