### PR TITLE
fix(apigateway): support @app.not_found() syntax & housekeeping

### DIFF
--- a/aws_lambda_powertools/event_handler/api_gateway.py
+++ b/aws_lambda_powertools/event_handler/api_gateway.py
@@ -579,7 +579,7 @@ class ApiGatewayResolver(BaseRouter):
     @staticmethod
     def _path_starts_with(path: str, prefix: str):
         """Returns true if the `path` starts with a prefix plus a `/`"""
-        if not isinstance(prefix, str) or len(prefix) == 0:
+        if not isinstance(prefix, str) or prefix == "":
             return False
 
         return path.startswith(prefix + "/")
@@ -633,7 +633,9 @@ class ApiGatewayResolver(BaseRouter):
 
             raise
 
-    def not_found(self, func: Callable):
+    def not_found(self, func: Optional[Callable] = None):
+        if func is None:
+            return self.exception_handler(NotFoundError)
         return self.exception_handler(NotFoundError)(func)
 
     def exception_handler(self, exc_class: Type[Exception]):

--- a/aws_lambda_powertools/shared/functions.py
+++ b/aws_lambda_powertools/shared/functions.py
@@ -1,7 +1,7 @@
 from typing import Any, Optional, Union
 
 
-def _strtobool(value: str) -> bool:
+def strtobool(value: str) -> bool:
     """Convert a string representation of truth to True or False.
 
     True values are 'y', 'yes', 't', 'true', 'on', and '1'; false values
@@ -35,7 +35,7 @@ def resolve_truthy_env_var_choice(env: str, choice: Optional[bool] = None) -> bo
     choice : str
         resolved choice as either bool or environment value
     """
-    return choice if choice is not None else _strtobool(env)
+    return choice if choice is not None else strtobool(env)
 
 
 def resolve_env_var_choice(env: Any, choice: Optional[Any] = None) -> Union[bool, Any]:

--- a/aws_lambda_powertools/shared/functions.py
+++ b/aws_lambda_powertools/shared/functions.py
@@ -1,13 +1,21 @@
 from typing import Any, Optional, Union
 
 
-def strtobool(value: str) -> bool:
+def _strtobool(value: str) -> bool:
+    """Convert a string representation of truth to True or False.
+
+    True values are 'y', 'yes', 't', 'true', 'on', and '1'; false values
+    are 'n', 'no', 'f', 'false', 'off', and '0'.  Raises ValueError if
+    'value' is anything else.
+
+    > note:: Copied from distutils.util.
+    """
     value = value.lower()
     if value in ("y", "yes", "t", "true", "on", "1"):
         return True
     if value in ("n", "no", "f", "false", "off", "0"):
         return False
-    raise ValueError(f"invalid truth value '{value}'")
+    raise ValueError(f"invalid truth value {value!r}")
 
 
 def resolve_truthy_env_var_choice(env: str, choice: Optional[bool] = None) -> bool:
@@ -27,7 +35,7 @@ def resolve_truthy_env_var_choice(env: str, choice: Optional[bool] = None) -> bo
     choice : str
         resolved choice as either bool or environment value
     """
-    return choice if choice is not None else strtobool(env)
+    return choice if choice is not None else _strtobool(env)
 
 
 def resolve_env_var_choice(env: Any, choice: Optional[Any] = None) -> Union[bool, Any]:

--- a/aws_lambda_powertools/shared/functions.py
+++ b/aws_lambda_powertools/shared/functions.py
@@ -1,14 +1,13 @@
 from typing import Any, Optional, Union
 
 
-def strtobool(value):
+def strtobool(value: str) -> bool:
     value = value.lower()
     if value in ("y", "yes", "t", "true", "on", "1"):
-        return 1
-    elif value in ("n", "no", "f", "false", "off", "0"):
-        return 0
-    else:
-        raise ValueError("invalid truth value %r" % (value,))
+        return True
+    if value in ("n", "no", "f", "false", "off", "0"):
+        return False
+    raise ValueError(f"invalid truth value '{value}'")
 
 
 def resolve_truthy_env_var_choice(env: str, choice: Optional[bool] = None) -> bool:

--- a/aws_lambda_powertools/utilities/data_classes/cognito_user_pool_event.py
+++ b/aws_lambda_powertools/utilities/data_classes/cognito_user_pool_event.py
@@ -687,7 +687,7 @@ class CreateAuthChallengeTriggerEventRequest(DictWrapper):
     @property
     def client_metadata(self) -> Optional[Dict[str, str]]:
         """One or more key-value pairs that you can provide as custom input to the Lambda function that you
-        specify for the create auth challenge trigger.."""
+        specify for the create auth challenge trigger."""
         return self["request"].get("clientMetadata")
 
 

--- a/aws_lambda_powertools/utilities/data_classes/common.py
+++ b/aws_lambda_powertools/utilities/data_classes/common.py
@@ -38,7 +38,7 @@ def get_header_value(
     name_lower = name.lower()
 
     return next(
-        # Iterate over the dict and do a case insensitive key comparison
+        # Iterate over the dict and do a case-insensitive key comparison
         (value for key, value in headers.items() if key.lower() == name_lower),
         # Default value is returned if no matches was found
         default_value,
@@ -116,7 +116,7 @@ class BaseProxyEvent(DictWrapper):
         default_value: str, optional
             Default value if no value was found by name
         case_sensitive: bool
-            Whether to use a case sensitive look up
+            Whether to use a case-sensitive look up
         Returns
         -------
         str, optional

--- a/aws_lambda_powertools/utilities/idempotency/exceptions.py
+++ b/aws_lambda_powertools/utilities/idempotency/exceptions.py
@@ -47,5 +47,5 @@ class IdempotencyPersistenceLayerError(Exception):
 
 class IdempotencyKeyError(Exception):
     """
-    Payload does not contain a idempotent key
+    Payload does not contain an idempotent key
     """

--- a/aws_lambda_powertools/utilities/idempotency/idempotency.py
+++ b/aws_lambda_powertools/utilities/idempotency/idempotency.py
@@ -7,7 +7,7 @@ import os
 from typing import Any, Callable, Dict, Optional, cast
 
 from aws_lambda_powertools.middleware_factory import lambda_handler_decorator
-from aws_lambda_powertools.shared.constants import IDEMPOTENCY_DISABLED_ENV
+from aws_lambda_powertools.shared import constants
 from aws_lambda_powertools.shared.types import AnyCallableT
 from aws_lambda_powertools.utilities.idempotency.base import IdempotencyHandler
 from aws_lambda_powertools.utilities.idempotency.config import IdempotencyConfig
@@ -58,7 +58,7 @@ def idempotent(
         >>>     return {"StatusCode": 200}
     """
 
-    if os.getenv(IDEMPOTENCY_DISABLED_ENV):
+    if os.getenv(constants.IDEMPOTENCY_DISABLED_ENV):
         return handler(event, context)
 
     config = config or IdempotencyConfig()
@@ -127,7 +127,7 @@ def idempotent_function(
 
     @functools.wraps(function)
     def decorate(*args, **kwargs):
-        if os.getenv(IDEMPOTENCY_DISABLED_ENV):
+        if os.getenv(constants.IDEMPOTENCY_DISABLED_ENV):
             return function(*args, **kwargs)
 
         payload = kwargs.get(data_keyword_argument)

--- a/tests/functional/event_handler/test_api_gateway.py
+++ b/tests/functional/event_handler/test_api_gateway.py
@@ -1142,10 +1142,26 @@ def test_exception_handler_not_found():
         return Response(status_code=404, content_type=content_types.TEXT_PLAIN, body="I am a teapot!")
 
     # WHEN calling the event handler
-    # AND not route is found
+    # AND no route is found
     result = app(LOAD_GW_EVENT, {})
 
     # THEN call the exception_handler
     assert result["statusCode"] == 404
     assert result["headers"]["Content-Type"] == content_types.TEXT_PLAIN
     assert result["body"] == "I am a teapot!"
+
+
+def test_exception_handler_not_found_alt():
+    # GIVEN a resolver with `@app.not_found()`
+    app = ApiGatewayResolver()
+
+    @app.not_found()
+    def handle_not_found(_) -> Response:
+        return Response(status_code=404, content_type=content_types.APPLICATION_JSON, body="{}")
+
+    # WHEN calling the event handler
+    # AND no route is found
+    result = app(LOAD_GW_EVENT, {})
+
+    # THEN call the @app.not_found() function
+    assert result["statusCode"] == 404

--- a/tests/functional/idempotency/conftest.py
+++ b/tests/functional/idempotency/conftest.py
@@ -166,6 +166,11 @@ def persistence_store(config):
 
 
 @pytest.fixture
+def persistence_store_compound(config):
+    return DynamoDBPersistenceLayer(table_name=TABLE_NAME, boto_config=config, key_attr="id", sort_key_attr="sk")
+
+
+@pytest.fixture
 def idempotency_config(config, request, default_jmespath):
     return IdempotencyConfig(
         event_key_jmespath=request.param.get("event_key_jmespath") or default_jmespath,

--- a/tests/functional/test_shared_functions.py
+++ b/tests/functional/test_shared_functions.py
@@ -1,4 +1,6 @@
-from aws_lambda_powertools.shared.functions import resolve_env_var_choice, resolve_truthy_env_var_choice
+import pytest
+
+from aws_lambda_powertools.shared.functions import resolve_env_var_choice, resolve_truthy_env_var_choice, strtobool
 
 
 def test_resolve_env_var_choice_explicit_wins_over_env_var():
@@ -9,3 +11,19 @@ def test_resolve_env_var_choice_explicit_wins_over_env_var():
 def test_resolve_env_var_choice_env_wins_over_absent_explicit():
     assert resolve_truthy_env_var_choice(env="true") == 1
     assert resolve_env_var_choice(env="something") == "something"
+
+
+@pytest.mark.parametrize("true_value", ["y", "yes", "t", "true", "on", "1"])
+def test_strtobool_true(true_value):
+    assert strtobool(true_value)
+
+
+@pytest.mark.parametrize("false_value", ["n", "no", "f", "false", "off", "0"])
+def test_strtobool_false(false_value):
+    assert strtobool(false_value) is False
+
+
+def test_strtobool_value_error():
+    with pytest.raises(ValueError) as exp:
+        strtobool("fail")
+    assert str(exp.value) == "invalid truth value 'fail'"

--- a/tests/functional/test_shared_functions.py
+++ b/tests/functional/test_shared_functions.py
@@ -1,6 +1,6 @@
 import pytest
 
-from aws_lambda_powertools.shared.functions import _strtobool, resolve_env_var_choice, resolve_truthy_env_var_choice
+from aws_lambda_powertools.shared.functions import resolve_env_var_choice, resolve_truthy_env_var_choice, strtobool
 
 
 def test_resolve_env_var_choice_explicit_wins_over_env_var():
@@ -15,15 +15,15 @@ def test_resolve_env_var_choice_env_wins_over_absent_explicit():
 
 @pytest.mark.parametrize("true_value", ["y", "yes", "t", "true", "on", "1"])
 def test_strtobool_true(true_value):
-    assert _strtobool(true_value)
+    assert strtobool(true_value)
 
 
 @pytest.mark.parametrize("false_value", ["n", "no", "f", "false", "off", "0"])
 def test_strtobool_false(false_value):
-    assert _strtobool(false_value) is False
+    assert strtobool(false_value) is False
 
 
 def test_strtobool_value_error():
     with pytest.raises(ValueError) as exp:
-        _strtobool("fail")
+        strtobool("fail")
     assert str(exp.value) == "invalid truth value 'fail'"

--- a/tests/functional/test_shared_functions.py
+++ b/tests/functional/test_shared_functions.py
@@ -1,6 +1,6 @@
 import pytest
 
-from aws_lambda_powertools.shared.functions import resolve_env_var_choice, resolve_truthy_env_var_choice, strtobool
+from aws_lambda_powertools.shared.functions import _strtobool, resolve_env_var_choice, resolve_truthy_env_var_choice
 
 
 def test_resolve_env_var_choice_explicit_wins_over_env_var():
@@ -15,15 +15,15 @@ def test_resolve_env_var_choice_env_wins_over_absent_explicit():
 
 @pytest.mark.parametrize("true_value", ["y", "yes", "t", "true", "on", "1"])
 def test_strtobool_true(true_value):
-    assert strtobool(true_value)
+    assert _strtobool(true_value)
 
 
 @pytest.mark.parametrize("false_value", ["n", "no", "f", "false", "off", "0"])
 def test_strtobool_false(false_value):
-    assert strtobool(false_value) is False
+    assert _strtobool(false_value) is False
 
 
 def test_strtobool_value_error():
     with pytest.raises(ValueError) as exp:
-        strtobool("fail")
+        _strtobool("fail")
     assert str(exp.value) == "invalid truth value 'fail'"


### PR DESCRIPTION
**Issue #, if available:**

- https://github.com/awslabs/aws-lambda-powertools-roadmap/issues/65

## Description of changes:

Changes:
- Allow for `@app.not_found()` decorator
- Add docstrings and typing to `strtobool`
- Add code coverage for  `strtobool`
- Minor docstring typos
- Add test for DynamoDBPersistenceLayer with a `sort_key_attr`

**Checklist**

<!--- Leave unchecked if your change doesn't seem to apply --> 

* [X] [Meet tenets criteria](https://awslabs.github.io/aws-lambda-powertools-python/#tenets)
* [X] Update tests
* [X] Update docs
* [X] PR title follows [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-python/blob/376ec0a2ac0d2a40e0af5717bef42ff84ca0d1b9/.github/semantic.yml#L2)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
