### PR TITLE
feat(logger): clone powertools logger config to any Python logger

### DIFF
--- a/aws_lambda_powertools/logging/utils.py
+++ b/aws_lambda_powertools/logging/utils.py
@@ -1,0 +1,30 @@
+import logging
+from typing import List, Optional, TypeVar
+
+from .logger import Logger
+
+PowertoolsLogger = TypeVar("PowertoolsLogger", bound=Logger)
+
+
+def copy_config_to_registered_loggers(
+    source_logger: PowertoolsLogger, exclude: Optional[List[str]] = None, include: Optional[List[str]] = None
+):
+    root_loggers = [
+        logging.getLogger(name)
+        for name in logging.root.manager.loggerDict
+        if "." not in name and name != source_logger.name
+    ]
+    source_logger.debug(f"Found registered root loggers: {root_loggers}")
+    if include and not exclude:
+        root_loggers = [logger for logger in root_loggers if logger.name in include]
+    elif not include and exclude:
+        root_loggers = [logger for logger in root_loggers if logger.name not in exclude]
+    elif include and exclude:
+        root_loggers = [logger for logger in root_loggers if logger.name in include and logger.name not in exclude]
+
+    source_logger.debug(f"Filtered root loggers: {root_loggers}")
+    for logger in root_loggers:
+        logger.handlers = []
+        logger.setLevel(source_logger.level)
+        for source_handler in source_logger.handlers:
+            logger.addHandler(source_handler)

--- a/aws_lambda_powertools/logging/utils.py
+++ b/aws_lambda_powertools/logging/utils.py
@@ -1,5 +1,5 @@
 import logging
-from typing import List, Optional, TypeVar
+from typing import Callable, List, Optional, TypeVar
 
 from .logger import Logger
 
@@ -7,51 +7,51 @@ PowertoolsLogger = TypeVar("PowertoolsLogger", bound=Logger)
 
 
 def copy_config_to_registered_loggers(
-    source_logger: PowertoolsLogger, exclude: Optional[List[str]] = None, include: Optional[List[str]] = None
+    source_logger: PowertoolsLogger,
+    exclude: Optional[List[str]] = None,
+    include: Optional[List[str]] = None,
 ) -> None:
     """Enable powertools logging for imported libraries.
 
     Attach source logger handlers to external loggers.
     Modify logger level based on source logger attribute.
+    Ensure powertools logger itself is excluded from registered list.
     """
-    registered_loggers = _find_registered_loggers(source_logger, exclude, include)
+
+    if include and not exclude:
+        loggers = include
+        filter_func = _include_registered_loggers_filter
+    elif include and exclude:
+        exclude = [source_logger.name, *exclude]
+        loggers = list(set(include) - set(exclude))
+        filter_func = _include_registered_loggers_filter
+    elif not include and exclude:
+        loggers = [source_logger.name, *exclude]
+        filter_func = _exclude_registered_loggers_filter
+    else:
+        loggers = [source_logger.name]
+        filter_func = _exclude_registered_loggers_filter
+
+    registered_loggers = _find_registered_loggers(source_logger, loggers, filter_func)
     for logger in registered_loggers:
         _configure_logger(source_logger, logger)
 
 
-def _include_registered_loggers_filter(logger_list: List[str]):
-    return [
-        logging.getLogger(name) for name in logging.root.manager.loggerDict if "." not in name and name in logger_list
-    ]
+def _include_registered_loggers_filter(loggers: List[str]):
+    return [logging.getLogger(name) for name in logging.root.manager.loggerDict if "." not in name and name in loggers]
 
 
-def _exclude_registered_loggers_filter(logger_list: List[str]) -> List[logging.Logger]:
+def _exclude_registered_loggers_filter(loggers: List[str]) -> List[logging.Logger]:
     return [
-        logging.getLogger(name)
-        for name in logging.root.manager.loggerDict
-        if "." not in name and name not in logger_list
+        logging.getLogger(name) for name in logging.root.manager.loggerDict if "." not in name and name not in loggers
     ]
 
 
 def _find_registered_loggers(
-    source_logger: PowertoolsLogger, exclude: Optional[List[str]] = None, include: Optional[List[str]] = None
+    source_logger: PowertoolsLogger, loggers: List[str], filter_func: Callable
 ) -> List[logging.Logger]:
-    """Filter root loggers based on provided parameters.
-
-    Ensure powertools logger itself is excluded from final list.
-    """
-    root_loggers = []
-    if include and not exclude:
-        root_loggers = _include_registered_loggers_filter(logger_list=include)
-    elif include and exclude:
-        exclude = [source_logger.name, *exclude]
-        root_loggers = _include_registered_loggers_filter(logger_list=list(set(include) - set(exclude)))
-    elif not include and exclude:
-        exclude = [source_logger.name, *exclude]
-        root_loggers = _exclude_registered_loggers_filter(logger_list=exclude)
-    else:
-        root_loggers = _exclude_registered_loggers_filter(logger_list=[source_logger.name])
-
+    """Filter root loggers based on provided parameters."""
+    root_loggers = filter_func(loggers)
     source_logger.debug(f"Filtered root loggers: {root_loggers}")
     return root_loggers
 

--- a/aws_lambda_powertools/logging/utils.py
+++ b/aws_lambda_powertools/logging/utils.py
@@ -1,54 +1,70 @@
 import logging
-from typing import Callable, List, Optional, TypeVar
+from typing import Callable, List, Optional, Set, Union
 
 from .logger import Logger
 
-PowertoolsLogger = TypeVar("PowertoolsLogger", bound=Logger)
-
 
 def copy_config_to_registered_loggers(
-    source_logger: PowertoolsLogger,
-    exclude: Optional[List[str]] = None,
-    include: Optional[List[str]] = None,
+    source_logger: Logger,
+    log_level: Optional[str] = None,
+    exclude: Optional[Set[str]] = None,
+    include: Optional[Set[str]] = None,
 ) -> None:
-    """Enable powertools logging for imported libraries.
 
-    Attach source logger handlers to external loggers.
-    Modify logger level based on source logger attribute.
-    Ensure powertools logger itself is excluded from registered list.
+    """Copies source Logger level and handler to all registered loggers for consistent formatting.
+
+    Parameters
+    ----------
+    source_logger : Logger
+        Powertools Logger to copy configuration from
+    log_level : str, optional
+        Logging level to set to registered loggers, by default uses source_logger logging level
+    include : Optional[Set[str]], optional
+        List of logger names to include, by default all registered loggers are included
+    exclude : Optional[Set[str]], optional
+        List of logger names to exclude, by default None
     """
 
-    if include and not exclude:
-        loggers = include
-        filter_func = _include_registered_loggers_filter
-    elif include and exclude:
-        exclude = [source_logger.name, *exclude]
-        loggers = list(set(include) - set(exclude))
-        filter_func = _include_registered_loggers_filter
-    elif not include and exclude:
-        loggers = [source_logger.name, *exclude]
-        filter_func = _exclude_registered_loggers_filter
+    level = log_level or source_logger.level
+
+    # Assumptions: Only take parent loggers not children (dot notation rule)
+    # Steps:
+    # 1. Default operation: Include all registered loggers
+    # 2. Only include set? Only add Loggers in the list and ignore all else
+    # 3. Include and exclude set? Add Logger if it’s in include and not in exclude
+    # 4. Only exclude set? Ignore Logger in the excluding list
+
+    # Exclude source logger by default
+    if exclude:
+        exclude.add(source_logger.name)
     else:
-        loggers = [source_logger.name]
+        exclude = set(source_logger.name)
+
+    # Prepare loggers set
+    if include:
+        loggers = include.difference(exclude)
+        filter_func = _include_registered_loggers_filter
+    else:
+        loggers = exclude
         filter_func = _exclude_registered_loggers_filter
 
     registered_loggers = _find_registered_loggers(source_logger, loggers, filter_func)
     for logger in registered_loggers:
-        _configure_logger(source_logger, logger)
+        _configure_logger(source_logger, logger, level)
 
 
-def _include_registered_loggers_filter(loggers: List[str]):
+def _include_registered_loggers_filter(loggers: Set[str]):
     return [logging.getLogger(name) for name in logging.root.manager.loggerDict if "." not in name and name in loggers]
 
 
-def _exclude_registered_loggers_filter(loggers: List[str]) -> List[logging.Logger]:
+def _exclude_registered_loggers_filter(loggers: Set[str]) -> List[logging.Logger]:
     return [
         logging.getLogger(name) for name in logging.root.manager.loggerDict if "." not in name and name not in loggers
     ]
 
 
 def _find_registered_loggers(
-    source_logger: PowertoolsLogger, loggers: List[str], filter_func: Callable
+    source_logger: Logger, loggers: Set[str], filter_func: Callable[[Set[str]], List[logging.Logger]]
 ) -> List[logging.Logger]:
     """Filter root loggers based on provided parameters."""
     root_loggers = filter_func(loggers)
@@ -56,10 +72,10 @@ def _find_registered_loggers(
     return root_loggers
 
 
-def _configure_logger(source_logger: PowertoolsLogger, logger: logging.Logger) -> None:
+def _configure_logger(source_logger: Logger, logger: logging.Logger, level: Union[int, str]) -> None:
     logger.handlers = []
-    logger.setLevel(source_logger.level)
-    source_logger.debug(f"Logger {logger} reconfigured to use logging level {source_logger.level}")
+    logger.setLevel(level)
+    source_logger.debug(f"Logger {logger} reconfigured to use logging level {level}")
     for source_handler in source_logger.handlers:
         logger.addHandler(source_handler)
         source_logger.debug(f"Logger {logger} reconfigured to use {source_handler}")

--- a/aws_lambda_powertools/logging/utils.py
+++ b/aws_lambda_powertools/logging/utils.py
@@ -14,18 +14,18 @@ def copy_config_to_registered_loggers(
     Attach source logger handlers to external loggers.
     Modify logger level based on source logger attribute.
     """
-    root_loggers = _find_root_loggers(source_logger, exclude, include)
-    for logger in root_loggers:
+    registered_loggers = _find_registered_loggers(source_logger, exclude, include)
+    for logger in registered_loggers:
         _configure_logger(source_logger, logger)
 
 
-def _include_root_loggers_filter(logger_list: List[str]):
+def _include_registered_loggers_filter(logger_list: List[str]):
     return [
         logging.getLogger(name) for name in logging.root.manager.loggerDict if "." not in name and name in logger_list
     ]
 
 
-def _exclude_root_loggers_filter(logger_list: List[str]) -> List[logging.Logger]:
+def _exclude_registered_loggers_filter(logger_list: List[str]) -> List[logging.Logger]:
     return [
         logging.getLogger(name)
         for name in logging.root.manager.loggerDict
@@ -33,24 +33,24 @@ def _exclude_root_loggers_filter(logger_list: List[str]) -> List[logging.Logger]
     ]
 
 
-def _find_root_loggers(
+def _find_registered_loggers(
     source_logger: PowertoolsLogger, exclude: Optional[List[str]] = None, include: Optional[List[str]] = None
-) -> list[logging.Logger]:
+) -> List[logging.Logger]:
     """Filter root loggers based on provided parameters.
 
     Ensure powertools logger itself is excluded from final list.
     """
     root_loggers = []
     if include and not exclude:
-        root_loggers = _include_root_loggers_filter(logger_list=include)
+        root_loggers = _include_registered_loggers_filter(logger_list=include)
     elif include and exclude:
         exclude = [source_logger.name, *exclude]
-        root_loggers = _include_root_loggers_filter(logger_list=list(set(include) - set(exclude)))
+        root_loggers = _include_registered_loggers_filter(logger_list=list(set(include) - set(exclude)))
     elif not include and exclude:
         exclude = [source_logger.name, *exclude]
-        root_loggers = _exclude_root_loggers_filter(logger_list=exclude)
+        root_loggers = _exclude_registered_loggers_filter(logger_list=exclude)
     else:
-        root_loggers = _exclude_root_loggers_filter(logger_list=[source_logger.name])
+        root_loggers = _exclude_registered_loggers_filter(logger_list=[source_logger.name])
 
     source_logger.debug(f"Filtered root loggers: {root_loggers}")
     return root_loggers

--- a/aws_lambda_powertools/logging/utils.py
+++ b/aws_lambda_powertools/logging/utils.py
@@ -8,23 +8,58 @@ PowertoolsLogger = TypeVar("PowertoolsLogger", bound=Logger)
 
 def copy_config_to_registered_loggers(
     source_logger: PowertoolsLogger, exclude: Optional[List[str]] = None, include: Optional[List[str]] = None
-):
-    root_loggers = [
+) -> None:
+    """Enable powertools logging for imported libraries.
+
+    Attach source logger handlers to external loggers.
+    Modify logger level based on source logger attribute.
+    """
+    root_loggers = _find_root_loggers(source_logger, exclude, include)
+    for logger in root_loggers:
+        _configure_logger(source_logger, logger)
+
+
+def _include_root_loggers_filter(logger_list: List[str]):
+    return [
+        logging.getLogger(name) for name in logging.root.manager.loggerDict if "." not in name and name in logger_list
+    ]
+
+
+def _exclude_root_loggers_filter(logger_list: List[str]) -> List[logging.Logger]:
+    return [
         logging.getLogger(name)
         for name in logging.root.manager.loggerDict
-        if "." not in name and name != source_logger.name
+        if "." not in name and name not in logger_list
     ]
-    source_logger.debug(f"Found registered root loggers: {root_loggers}")
+
+
+def _find_root_loggers(
+    source_logger: PowertoolsLogger, exclude: Optional[List[str]] = None, include: Optional[List[str]] = None
+) -> list[logging.Logger]:
+    """Filter root loggers based on provided parameters.
+
+    Ensure powertools logger itself is excluded from final list.
+    """
+    root_loggers = []
     if include and not exclude:
-        root_loggers = [logger for logger in root_loggers if logger.name in include]
-    elif not include and exclude:
-        root_loggers = [logger for logger in root_loggers if logger.name not in exclude]
+        root_loggers = _include_root_loggers_filter(logger_list=include)
     elif include and exclude:
-        root_loggers = [logger for logger in root_loggers if logger.name in include and logger.name not in exclude]
+        exclude = [source_logger.name, *exclude]
+        root_loggers = _include_root_loggers_filter(logger_list=list(set(include) - set(exclude)))
+    elif not include and exclude:
+        exclude = [source_logger.name, *exclude]
+        root_loggers = _exclude_root_loggers_filter(logger_list=exclude)
+    else:
+        root_loggers = _exclude_root_loggers_filter(logger_list=[source_logger.name])
 
     source_logger.debug(f"Filtered root loggers: {root_loggers}")
-    for logger in root_loggers:
-        logger.handlers = []
-        logger.setLevel(source_logger.level)
-        for source_handler in source_logger.handlers:
-            logger.addHandler(source_handler)
+    return root_loggers
+
+
+def _configure_logger(source_logger: PowertoolsLogger, logger: logging.Logger) -> None:
+    logger.handlers = []
+    logger.setLevel(source_logger.level)
+    source_logger.debug(f"Logger {logger} reconfigured to use logging level {source_logger.level}")
+    for source_handler in source_logger.handlers:
+        logger.addHandler(source_handler)
+        source_logger.debug(f"Logger {logger} reconfigured to use {source_handler}")

--- a/docs/core/logger.md
+++ b/docs/core/logger.md
@@ -1067,20 +1067,18 @@ for the given name and level to the logging module. By default, this logs all bo
 You can copy the Logger setup to all or sub-sets of registered external loggers. Use the `copy_config_to_registered_logger` method to do this. By default all registered loggers will be modified. You can change this behaviour by providing `include` and `exclude` attributes. You can also provide optional `log_level` attribute external loggers will be configured with.
 
 
-=== "structured_logging_external_loggers"
-    ```python hl_lines="10"
-    import logging
+```python hl_lines="10" title="Cloning Logger config to all other registered standard loggers"
+import logging
 
-    from aws_lambda_powertools import Logger
-    from aws_lambda_powertools.logging import utils
+from aws_lambda_powertools import Logger
+from aws_lambda_powertools.logging import utils
 
-    logger = Logger()
+logger = Logger()
 
-    external_logger = logging.logger()
+external_logger = logging.logger()
 
-    utils.copy_config_to_registered_loggers(source_logger=logger)
-    external_logger.info("test message")
-    ```
+utils.copy_config_to_registered_loggers(source_logger=logger)
+external_logger.info("test message")
 
 **What's the difference between `append_keys` and `extra`?**
 

--- a/docs/core/logger.md
+++ b/docs/core/logger.md
@@ -1062,6 +1062,26 @@ for the given name and level to the logging module. By default, this logs all bo
         return response.get("Buckets", [])
     ```
 
+**How can I enable powertools logging for imported libraries?**
+
+You can copy the Logger setup to all or sub-sets of registered external loggers. Use the `copy_config_to_registered_logger` method to do this. By default all registered loggers will be modified. You can change this behaviour by providing `include` and `exclude` attributes. You can also provide optional `log_level` attribute external loggers will be configured with.
+
+
+=== "structured_logging_external_loggers"
+    ```python hl_lines="10"
+    import logging
+
+    from aws_lambda_powertools import Logger
+    from aws_lambda_powertools.logging import utils
+
+    logger = Logger()
+
+    external_logger = logging.logger()
+
+    utils.copy_config_to_registered_loggers(source_logger=logger)
+    external_logger.info("test message")
+    ```
+
 **What's the difference between `append_keys` and `extra`?**
 
 Keys added with `append_keys` will persist across multiple log messages while keys added via `extra` will only be available in a given log message operation.

--- a/tests/functional/test_logger_utils.py
+++ b/tests/functional/test_logger_utils.py
@@ -25,15 +25,6 @@ def log_level():
     return LogLevel
 
 
-def capture_logging_output(stdout):
-    return json.loads(stdout.getvalue().strip())
-
-
-def service_name():
-    chars = string.ascii_letters + string.digits
-    return "".join(random.SystemRandom().choice(chars) for _ in range(15))
-
-
 @pytest.fixture
 def logger(stdout, log_level):
     def _logger():
@@ -44,30 +35,43 @@ def logger(stdout, log_level):
     return _logger
 
 
+def capture_logging_output(stdout):
+    return json.loads(stdout.getvalue().strip())
+
+
+def capture_multiple_logging_statements_output(stdout):
+    return [json.loads(line.strip()) for line in stdout.getvalue().split("\n") if line]
+
+
+def service_name():
+    chars = string.ascii_letters + string.digits
+    return "".join(random.SystemRandom().choice(chars) for _ in range(15))
+
+
 def test_copy_config_to_ext_loggers(stdout, logger, log_level):
 
     msg = "test message"
 
     # GIVEN a external logger and powertools logger initialized
-    logger = logger()
-    logger_initial_handlers = logger.handlers.copy()
-    logger_initial_level = logger.level
+    logger_1 = logger()
+    logger_2 = logger()
+
     powertools_logger = Logger(service=service_name(), level=log_level.INFO.value, stream=stdout)
 
     # WHEN configuration copied from powertools logger to ALL external loggers AND our external logger used
     utils.copy_config_to_registered_loggers(source_logger=powertools_logger)
-    logger.info(msg)
-    log = capture_logging_output(stdout)
+    logger_1.info(msg)
+    logger_2.info(msg)
+    logs = capture_multiple_logging_statements_output(stdout)
 
     # THEN
-    assert not logger_initial_handlers
-    assert logger_initial_level == log_level.NOTSET.value
-    assert len(logger.handlers) == 1
-    assert type(logger.handlers[0]) is logging.StreamHandler
-    assert type(logger.handlers[0].formatter) is formatter.LambdaPowertoolsFormatter
-    assert logger.level == log_level.INFO.value
-    assert log["message"] == msg
-    assert log["level"] == log_level.INFO.name
+    for index, logger in enumerate([logger_1, logger_2]):
+        assert len(logger.handlers) == 1
+        assert type(logger.handlers[0]) is logging.StreamHandler
+        assert type(logger.handlers[0].formatter) is formatter.LambdaPowertoolsFormatter
+        assert logger.level == log_level.INFO.value
+        assert logs[index]["message"] == msg
+        assert logs[index]["level"] == log_level.INFO.name
 
 
 def test_copy_config_to_ext_loggers_include(stdout, logger, log_level):
@@ -134,6 +138,7 @@ def test_copy_config_to_ext_loggers_include_exclude(stdout, logger, log_level):
     )
     logger_2.info(msg)
     log = capture_logging_output(stdout)
+
     # THEN
     assert not logger_1.handlers
     assert len(logger_2.handlers) == 1
@@ -142,3 +147,20 @@ def test_copy_config_to_ext_loggers_include_exclude(stdout, logger, log_level):
     assert logger_2.level == log_level.INFO.value
     assert log["message"] == msg
     assert log["level"] == log_level.INFO.name
+
+
+def test_copy_config_to_ext_loggers_clean_old_handlers(stdout, logger, log_level):
+
+    # GIVEN a external logger with handler and powertools logger initialized
+    logger = logger()
+    handler = logging.FileHandler("logfile")
+    logger.addHandler(handler)
+    powertools_logger = Logger(service=service_name(), level=log_level.INFO.value, stream=stdout)
+
+    # WHEN configuration copied from powertools logger to ALL external loggers AND our external logger used
+    utils.copy_config_to_registered_loggers(source_logger=powertools_logger)
+
+    # THEN
+    assert len(logger.handlers) == 1
+    assert type(logger.handlers[0]) is logging.StreamHandler
+    assert type(logger.handlers[0].formatter) is formatter.LambdaPowertoolsFormatter

--- a/tests/functional/test_logger_utils.py
+++ b/tests/functional/test_logger_utils.py
@@ -1,0 +1,144 @@
+import io
+import json
+import logging
+import random
+import string
+from enum import Enum
+
+import pytest
+
+from aws_lambda_powertools import Logger
+from aws_lambda_powertools.logging import formatter, utils
+
+
+@pytest.fixture
+def stdout():
+    return io.StringIO()
+
+
+@pytest.fixture
+def log_level():
+    class LogLevel(Enum):
+        NOTSET = 0
+        INFO = 20
+
+    return LogLevel
+
+
+def capture_logging_output(stdout):
+    return json.loads(stdout.getvalue().strip())
+
+
+def service_name():
+    chars = string.ascii_letters + string.digits
+    return "".join(random.SystemRandom().choice(chars) for _ in range(15))
+
+
+@pytest.fixture
+def logger(stdout, log_level):
+    def _logger():
+        logging.basicConfig(stream=stdout, level=log_level.NOTSET.value)
+        logger = logging.getLogger(name=service_name())
+        return logger
+
+    return _logger
+
+
+def test_copy_config_to_ext_loggers(stdout, logger, log_level):
+
+    msg = "test message"
+
+    # GIVEN a external logger and powertools logger initialized
+    logger = logger()
+    logger_initial_handlers = logger.handlers.copy()
+    logger_initial_level = logger.level
+    powertools_logger = Logger(service=service_name(), level=log_level.INFO.value, stream=stdout)
+
+    # WHEN configuration copied from powertools logger to ALL external loggers AND our external logger used
+    utils.copy_config_to_registered_loggers(source_logger=powertools_logger)
+    logger.info(msg)
+    log = capture_logging_output(stdout)
+
+    # THEN
+    assert not logger_initial_handlers
+    assert logger_initial_level == log_level.NOTSET.value
+    assert len(logger.handlers) == 1
+    assert type(logger.handlers[0]) is logging.StreamHandler
+    assert type(logger.handlers[0].formatter) is formatter.LambdaPowertoolsFormatter
+    assert logger.level == log_level.INFO.value
+    assert log["message"] == msg
+    assert log["level"] == log_level.INFO.name
+
+
+def test_copy_config_to_ext_loggers_include(stdout, logger, log_level):
+
+    msg = "test message"
+
+    # GIVEN a external logger and powertools logger initialized
+    logger = logger()
+    powertools_logger = Logger(service=service_name(), level=log_level.INFO.value, stream=stdout)
+
+    # WHEN configuration copied from powertools logger to ALL external loggers AND our external logger used
+    utils.copy_config_to_registered_loggers(source_logger=powertools_logger, include=[logger.name])
+    logger.info(msg)
+    log = capture_logging_output(stdout)
+
+    # THEN
+    assert len(logger.handlers) == 1
+    assert type(logger.handlers[0]) is logging.StreamHandler
+    assert type(logger.handlers[0].formatter) is formatter.LambdaPowertoolsFormatter
+    assert logger.level == log_level.INFO.value
+    assert log["message"] == msg
+    assert log["level"] == log_level.INFO.name
+
+
+def test_copy_config_to_ext_loggers_wrong_include(stdout, logger, log_level):
+
+    # GIVEN a external logger and powertools logger initialized
+    logger = logger()
+    powertools_logger = Logger(service=service_name(), level=log_level.INFO.value, stream=stdout)
+
+    # WHEN configuration copied from powertools logger to ALL external loggers AND our external logger used
+    utils.copy_config_to_registered_loggers(source_logger=powertools_logger, include=["non-existing-logger"])
+
+    # THEN
+    assert not logger.handlers
+
+
+def test_copy_config_to_ext_loggers_exclude(stdout, logger, log_level):
+
+    # GIVEN a external logger and powertools logger initialized
+    logger = logger()
+    powertools_logger = Logger(service=service_name(), level=log_level.INFO.value, stream=stdout)
+
+    # WHEN configuration copied from powertools logger to ALL external loggers AND our external logger used
+    utils.copy_config_to_registered_loggers(source_logger=powertools_logger, exclude=[logger.name])
+
+    # THEN
+    assert not logger.handlers
+
+
+def test_copy_config_to_ext_loggers_include_exclude(stdout, logger, log_level):
+
+    msg = "test message"
+
+    # GIVEN a external logger and powertools logger initialized
+    logger_1 = logger()
+    logger_2 = logger()
+
+    powertools_logger = Logger(service=service_name(), level=log_level.INFO.value, stream=stdout)
+
+    # WHEN configuration copied from powertools logger to ALL external loggers AND our external logger used
+    utils.copy_config_to_registered_loggers(
+        source_logger=powertools_logger, include=[logger_1.name, logger_2.name], exclude=[logger_1.name]
+    )
+    logger_2.info(msg)
+    log = capture_logging_output(stdout)
+    # THEN
+    assert not logger_1.handlers
+    assert len(logger_2.handlers) == 1
+    assert type(logger_2.handlers[0]) is logging.StreamHandler
+    assert type(logger_2.handlers[0].formatter) is formatter.LambdaPowertoolsFormatter
+    assert logger_2.level == log_level.INFO.value
+    assert log["message"] == msg
+    assert log["level"] == log_level.INFO.name


### PR DESCRIPTION
**Issue #, if available: https://github.com/awslabs/aws-lambda-powertools-roadmap/issues/40 
## Description of changes:

This feature allows customers to clone Powertools Logger configuration like level & handler to any registered Python loggers - exclusion, inclusion-only are also supported.

* [x] [Meet tenets criteria](https://awslabs.github.io/aws-lambda-powertools-python/#tenets)
* [x] Update tests
* [x] Update docs
* [x] PR title follows [conventional commit semantics]

## Breaking change checklist

<!--- Ignore if it's not a breaking change -->

**RFC issue #**:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
