### PR TITLE
fix(event-sources): handle dynamodb null type as none, not bool

### DIFF
--- a/aws_lambda_powertools/utilities/data_classes/dynamo_db_stream_event.py
+++ b/aws_lambda_powertools/utilities/data_classes/dynamo_db_stream_event.py
@@ -106,14 +106,13 @@ class AttributeValue(DictWrapper):
         return self.get("NS")
 
     @property
-    def null_value(self) -> Optional[bool]:
+    def null_value(self) -> None:
         """An attribute of type Null.
 
         Example:
             >>> {"NULL": True}
         """
-        item = self.get("NULL")
-        return None if item is None else bool(item)
+        return None
 
     @property
     def s_value(self) -> Optional[str]:

--- a/tests/functional/test_data_classes.py
+++ b/tests/functional/test_data_classes.py
@@ -544,7 +544,17 @@ def test_dynamo_attribute_value_null_value():
     attribute_value = AttributeValue(example_attribute_value)
 
     assert attribute_value.get_type == AttributeValueType.Null
+    assert attribute_value.null_value is None
     assert attribute_value.null_value == attribute_value.get_value
+
+
+def test_dynamo_attribute_value_null_value_invalid():
+    example_attribute_value = {"NULL": False}
+
+    attribute_value = AttributeValue(example_attribute_value)
+
+    assert attribute_value.get_type == AttributeValueType.Null
+    assert attribute_value.null_value is None
 
 
 def test_dynamo_attribute_value_s_value():

--- a/tests/functional/test_data_classes.py
+++ b/tests/functional/test_data_classes.py
@@ -548,15 +548,6 @@ def test_dynamo_attribute_value_null_value():
     assert attribute_value.null_value == attribute_value.get_value
 
 
-def test_dynamo_attribute_value_null_value_invalid():
-    example_attribute_value = {"NULL": False}
-
-    attribute_value = AttributeValue(example_attribute_value)
-
-    assert attribute_value.get_type == AttributeValueType.Null
-    assert attribute_value.null_value is None
-
-
 def test_dynamo_attribute_value_s_value():
     example_attribute_value = {"S": "Hello"}
 


### PR DESCRIPTION
**Issue #, if available:**
- #928

## Description of changes:

Return for `None` for null types:

Example: 

```json5
{
  "Records": [
    {
      ...
      "dynamodb": {
        "OldImage": {
          ...
          "Message": {
            "S": "New item!"
          },
          "Id": {
            "N": "101"
          }
        },
        "Keys": {
          "Id": {
            "N": "101"
          }
        },
        "NewImage": {
          ...
          "Message": {
            "NULL": true
          },
          "Id": {
            "N": "101"
          }
        },
      }
    }
  ]
}
```

Below `null_value` and `get_value` would have returned `True`, and now they return None.

```python3
from aws_lambda_powertools.utilities.data_classes import event_source
from aws_lambda_powertools.utilities.data_classes.dynamo_db_stream_event import (
    DynamoDBStreamEvent,
)

@event_source(data_class=DynamoDBStreamEvent)
def handler(event: DynamoDBStreamEvent, context):
    record = next(event.records)
    message_value = record.dynamodb.new_image.get("message")

    # get_value would be the preferred way to get the underlying value regardless of type
    assert message_value.get_value is None

    # Otherwise when you want to use `null_value` you should first change against `get_type`
    if message_value.get_type == AttributeValueType.Null:
        assert message_value.null_value is None
```

**Checklist**

<!--- Leave unchecked if your change doesn't seem to apply --> 

* [X] [Meet tenets criteria](https://awslabs.github.io/aws-lambda-powertools-python/#tenets)
* [X] Update tests
* [X] Update docs
* [X] PR title follows [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-python/blob/376ec0a2ac0d2a40e0af5717bef42ff84ca0d1b9/.github/semantic.yml#L2)

## Breaking change checklist

Before `null_value` was returning a boolean,  `True` when `NULL` value was set to `true` and `False` when `NULL` value was not set (or was `False`)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
