### PR TITLE
docs(tracer): new ignore_endpoint feature

### DIFF
--- a/docs/core/tracer.md
+++ b/docs/core/tracer.md
@@ -221,6 +221,32 @@ def handler(event, context):
 	raise ValueError("some sensitive info in the stack trace...")
 ```
 
+### Ignoring certain HTTP endpoints
+
+You might have endpoints you don't want requests to be traced, perhaps due to the volume of calls or sensitive URLs.
+
+You can use `ignore_endpoint` method with the hostname and/or URLs you'd like it to be ignored - globs (`*`) are allowed.
+
+```python title="Ignoring certain HTTP endpoints from being traced"
+from aws_lambda_powertools import Tracer
+
+tracer = Tracer()
+# ignore all calls to `ec2.amazon.com`
+tracer.ignore_endpoint(hostname="ec2.amazon.com")
+# ignore calls to `*.sensitive.com/password` and  `*.sensitive.com/credit-card`
+tracer.ignore_endpoint(hostname="*.sensitive.com", urls=["/password", "/credit-card"])
+
+
+def ec2_api_calls():
+    return "suppress_api_responses"
+
+@tracer.capture_lambda_handler
+def handler(event, context):
+    for x in long_list:
+        ec2_api_calls()
+```
+
+
 ### Tracing aiohttp requests
 
 ???+ info


### PR DESCRIPTION
**Issue #, if available:** #910

## Description of changes:

<!--- One or two sentences as a summary of what's being changed -->

Documents new `ignore_endpoint` feature in Tracer.

```python title="Ignoring certain HTTP endpoints from being traced"
from aws_lambda_powertools import Tracer

tracer = Tracer()
# ignore all calls to `ec2.amazon.com`
tracer.ignore_endpoint(hostname="ec2.amazon.com")
# ignore calls to `*.sensitive.com/password` and  `*.sensitive.com/credit-card`
tracer.ignore_endpoint(hostname="*.sensitive.com", urls=["/password", "/credit-card"])


def ec2_api_calls():
    return "suppress_api_responses"

@tracer.capture_lambda_handler
def handler(event, context):
    for x in long_list:
        ec2_api_calls()
```

**Checklist**

<!--- Leave unchecked if your change doesn't seem to apply --> 

* [x] [Meet tenets criteria](https://awslabs.github.io/aws-lambda-powertools-python/#tenets)
* [ ] Update tests
* [x] Update docs
* [x] PR title follows [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-python/blob/376ec0a2ac0d2a40e0af5717bef42ff84ca0d1b9/.github/semantic.yml#L2)

## Breaking change checklist

<!--- Ignore if it's not a breaking change -->

**RFC issue #**:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


-----
[View rendered docs/core/tracer.md](https://github.com/heitorlessa/aws-lambda-powertools-python/blob/docs/tracer-ignore-endpoints/docs/core/tracer.md)