### PR TITLE
fix(data-classes): docstring typos and clean up

### DIFF
--- a/aws_lambda_powertools/event_handler/api_gateway.py
+++ b/aws_lambda_powertools/event_handler/api_gateway.py
@@ -101,7 +101,7 @@ class CORSConfig:
             only be used during development.
         allow_headers: Optional[List[str]]
             The list of additional allowed headers. This list is added to list of
-            built in allowed headers: `Authorization`, `Content-Type`, `X-Amz-Date`,
+            built-in allowed headers: `Authorization`, `Content-Type`, `X-Amz-Date`,
             `X-Api-Key`, `X-Amz-Security-Token`.
         expose_headers: Optional[List[str]]
             A list of values to return for the Access-Control-Expose-Headers

--- a/aws_lambda_powertools/utilities/data_classes/api_gateway_authorizer_event.py
+++ b/aws_lambda_powertools/utilities/data_classes/api_gateway_authorizer_event.py
@@ -440,8 +440,7 @@ class APIGatewayAuthorizerResponse:
         if not self._resource_pattern.match(resource):
             raise ValueError(f"Invalid resource path: {resource}. Path should match {self.path_regex}")
 
-        if resource.startswith("/"):
-            resource = resource[1:]
+        resource = self._removeprefix(resource, "/")
 
         resource_arn = APIGatewayRouteArn(
             self.region, self.aws_account_id, self.api_id, self.stage, http_method, resource
@@ -453,6 +452,14 @@ class APIGatewayAuthorizerResponse:
             self._allow_routes.append(route)
         else:  # deny
             self._deny_routes.append(route)
+
+    @staticmethod
+    def _removeprefix(value: str, prefix: str) -> str:
+        """Remove matching prefix from value. To be replaced with builtin `removeprefix`"""
+        length = len(prefix)
+        if value[:length] == prefix:
+            return value[length:]
+        return value
 
     @staticmethod
     def _get_empty_statement(effect: str) -> Dict[str, Any]:

--- a/aws_lambda_powertools/utilities/data_classes/api_gateway_authorizer_event.py
+++ b/aws_lambda_powertools/utilities/data_classes/api_gateway_authorizer_event.py
@@ -32,7 +32,7 @@ class APIGatewayRouteArn:
 
     @property
     def arn(self) -> str:
-        """Build an arn from it's parts
+        """Build an arn from its parts
         eg: arn:aws:execute-api:us-east-1:123456789012:abcdef123/test/GET/request"""
         return (
             f"arn:{self.partition}:execute-api:{self.region}:{self.aws_account_id}:{self.api_id}/{self.stage}/"
@@ -168,7 +168,7 @@ class APIGatewayAuthorizerRequestEvent(DictWrapper):
         default_value: str, optional
             Default value if no value was found by name
         case_sensitive: bool
-            Whether to use a case sensitive look up
+            Whether to use a case-sensitive look up
         Returns
         -------
         str, optional
@@ -270,7 +270,7 @@ class APIGatewayAuthorizerEventV2(DictWrapper):
         default_value: str, optional
             Default value if no value was found by name
         case_sensitive: bool
-            Whether to use a case sensitive look up
+            Whether to use a case-sensitive look up
         Returns
         -------
         str, optional
@@ -440,7 +440,7 @@ class APIGatewayAuthorizerResponse:
         if not self._resource_pattern.match(resource):
             raise ValueError(f"Invalid resource path: {resource}. Path should match {self.path_regex}")
 
-        if resource[:1] == "/":
+        if resource.startswith("/"):
             resource = resource[1:]
 
         resource_arn = APIGatewayRouteArn(

--- a/aws_lambda_powertools/utilities/data_classes/api_gateway_authorizer_event.py
+++ b/aws_lambda_powertools/utilities/data_classes/api_gateway_authorizer_event.py
@@ -455,7 +455,7 @@ class APIGatewayAuthorizerResponse:
 
     @staticmethod
     def _removeprefix(value: str, prefix: str) -> str:
-        """Remove matching prefix from value. To be replaced with builtin `removeprefix`"""
+        """Remove matching prefix from value. To be replaced with built-in `removeprefix`"""
         length = len(prefix)
         if value[:length] == prefix:
             return value[length:]

--- a/aws_lambda_powertools/utilities/data_classes/api_gateway_authorizer_event.py
+++ b/aws_lambda_powertools/utilities/data_classes/api_gateway_authorizer_event.py
@@ -28,7 +28,8 @@ class APIGatewayRouteArn:
         self.api_id = api_id
         self.stage = stage
         self.http_method = http_method
-        self.resource = resource
+        # Remove matching "/" from `resource`.
+        self.resource = resource.lstrip("/")
 
     @property
     def arn(self) -> str:
@@ -36,15 +37,8 @@ class APIGatewayRouteArn:
         eg: arn:aws:execute-api:us-east-1:123456789012:abcdef123/test/GET/request"""
         return (
             f"arn:{self.partition}:execute-api:{self.region}:{self.aws_account_id}:{self.api_id}/{self.stage}/"
-            f"{self.http_method}/{self._resource}"
+            f"{self.http_method}/{self.resource}"
         )
-
-    @property
-    def _resource(self) -> str:
-        """Remove matching "/" from `resource`. To be replaced with built-in `removeprefix`"""
-        if self.resource.startswith("/"):
-            return self.resource[1:]
-        return self.resource
 
 
 def parse_api_gateway_arn(arn: str) -> APIGatewayRouteArn:

--- a/aws_lambda_powertools/utilities/data_classes/appsync_resolver_event.py
+++ b/aws_lambda_powertools/utilities/data_classes/appsync_resolver_event.py
@@ -27,7 +27,7 @@ class AppSyncIdentityIAM(DictWrapper):
 
     @property
     def username(self) -> str:
-        """The user name of the authenticated user. IAM user principal"""
+        """The username of the authenticated user. IAM user principal"""
         return self["username"]
 
     @property
@@ -72,7 +72,7 @@ class AppSyncIdentityCognito(DictWrapper):
 
     @property
     def username(self) -> str:
-        """The user name of the authenticated user."""
+        """The username of the authenticated user."""
         return self["username"]
 
     @property
@@ -172,7 +172,7 @@ class AppSyncResolverEvent(DictWrapper):
     def identity(self) -> Union[None, AppSyncIdentityIAM, AppSyncIdentityCognito]:
         """An object that contains information about the caller.
 
-        Depending of the type of identify found:
+        Depending on the type of identify found:
 
         - API_KEY authorization - returns None
         - AWS_IAM authorization - returns AppSyncIdentityIAM
@@ -223,7 +223,7 @@ class AppSyncResolverEvent(DictWrapper):
         default_value: str, optional
             Default value if no value was found by name
         case_sensitive: bool
-            Whether to use a case sensitive look up
+            Whether to use a case-sensitive look up
         Returns
         -------
         str, optional

--- a/aws_lambda_powertools/utilities/data_classes/cognito_user_pool_event.py
+++ b/aws_lambda_powertools/utilities/data_classes/cognito_user_pool_event.py
@@ -195,7 +195,7 @@ class UserMigrationTriggerEventResponse(DictWrapper):
     @final_user_status.setter
     def final_user_status(self, value: str):
         """During sign-in, this attribute can be set to CONFIRMED, or not set, to auto-confirm your users and
-        allow them to sign-in with their previous passwords. This is the simplest experience for the user.
+        allow them to sign in with their previous passwords. This is the simplest experience for the user.
 
         If this attribute is set to RESET_REQUIRED, the user is required to change his or her password immediately
         after migration at the time of sign-in, and your client app needs to handle the PasswordResetRequiredException
@@ -333,7 +333,7 @@ class CustomMessageTriggerEvent(BaseTriggerEvent):
        verification code automatically to the user. Cannot be used for other attributes.
     - `CustomMessage_VerifyUserAttribute`  This trigger sends a verification code to the user when they manually
        request it for a new email or phone number.
-    - `CustomMessage_Authentication` To send MFA code during authentication.
+    - `CustomMessage_Authentication` To send MFA codes during authentication.
 
     Documentation:
     --------------
@@ -590,7 +590,7 @@ class DefineAuthChallengeTriggerEventRequest(DictWrapper):
     @property
     def user_not_found(self) -> Optional[bool]:
         """A Boolean that is populated when PreventUserExistenceErrors is set to ENABLED for your user pool client.
-        A value of true means that the user id (user name, email address, etc.) did not match any existing users."""
+        A value of true means that the user id (username, email address, etc.) did not match any existing users."""
         return self["request"].get("userNotFound")
 
     @property
@@ -601,7 +601,7 @@ class DefineAuthChallengeTriggerEventRequest(DictWrapper):
     @property
     def client_metadata(self) -> Optional[Dict[str, str]]:
         """One or more key-value pairs that you can provide as custom input to the Lambda function that you specify
-        for the define auth challenge trigger."""
+        for the defined auth challenge trigger."""
         return self["request"].get("clientMetadata")
 
 
@@ -687,7 +687,7 @@ class CreateAuthChallengeTriggerEventRequest(DictWrapper):
     @property
     def client_metadata(self) -> Optional[Dict[str, str]]:
         """One or more key-value pairs that you can provide as custom input to the Lambda function that you
-        specify for the create auth challenge trigger."""
+        specify for the creation auth challenge trigger."""
         return self["request"].get("clientMetadata")
 
 
@@ -699,7 +699,7 @@ class CreateAuthChallengeTriggerEventResponse(DictWrapper):
     @public_challenge_parameters.setter
     def public_challenge_parameters(self, value: Dict[str, str]):
         """One or more key-value pairs for the client app to use in the challenge to be presented to the user.
-        This parameter should contain all of the necessary information to accurately present the challenge to
+        This parameter should contain all the necessary information to accurately present the challenge to
         the user."""
         self["response"]["publicChallengeParameters"] = value
 
@@ -709,8 +709,8 @@ class CreateAuthChallengeTriggerEventResponse(DictWrapper):
 
     @private_challenge_parameters.setter
     def private_challenge_parameters(self, value: Dict[str, str]):
-        """This parameter is only used by the Verify Auth Challenge Response Lambda trigger.
-        This parameter should contain all of the information that is required to validate the user's
+        """This parameter is only used by the "Verify Auth Challenge" Response Lambda trigger.
+        This parameter should contain all the information that is required to validate the user's
         response to the challenge. In other words, the publicChallengeParameters parameter contains the
         question that is presented to the user and privateChallengeParameters contains the valid answers
         for the question."""
@@ -730,7 +730,7 @@ class CreateAuthChallengeTriggerEvent(BaseTriggerEvent):
     """Create Auth Challenge Lambda Trigger
 
     Amazon Cognito invokes this trigger after Define Auth Challenge if a custom challenge has been
-    specified as part of the Define Auth Challenge trigger.
+    specified as part of the "Define Auth Challenge" trigger.
     It creates a custom authentication flow.
 
     Notes:
@@ -775,7 +775,7 @@ class VerifyAuthChallengeResponseTriggerEventRequest(DictWrapper):
     @property
     def client_metadata(self) -> Optional[Dict[str, str]]:
         """One or more key-value pairs that you can provide as custom input to the Lambda function that
-        you specify for the verify auth challenge trigger."""
+        you specify for the "Verify Auth Challenge" trigger."""
         return self["request"].get("clientMetadata")
 
     @property

--- a/aws_lambda_powertools/utilities/data_classes/dynamo_db_stream_event.py
+++ b/aws_lambda_powertools/utilities/data_classes/dynamo_db_stream_event.py
@@ -231,7 +231,7 @@ class DynamoDBRecord(DictWrapper):
 
     @property
     def dynamodb(self) -> Optional[StreamRecord]:
-        """The main body of the stream record, containing all of the DynamoDB-specific fields."""
+        """The main body of the stream record, containing all the DynamoDB-specific fields."""
         stream_record = self.get("dynamodb")
         return None if stream_record is None else StreamRecord(stream_record)
 

--- a/aws_lambda_powertools/utilities/data_classes/s3_object_event.py
+++ b/aws_lambda_powertools/utilities/data_classes/s3_object_event.py
@@ -82,7 +82,7 @@ class S3ObjectUserRequest(DictWrapper):
         default_value: str, optional
             Default value if no value was found by name
         case_sensitive: bool
-            Whether to use a case sensitive look up
+            Whether to use a case-sensitive look up
         Returns
         -------
         str, optional
@@ -128,7 +128,7 @@ class S3ObjectSessionAttributes(DictWrapper):
     @property
     def mfa_authenticated(self) -> str:
         """The value is true if the root user or IAM user whose credentials were used for the request also was
-        authenticated with an MFA device; otherwise, false.."""
+        authenticated with an MFA device; otherwise, false."""
         return self["mfaAuthenticated"]
 
 

--- a/aws_lambda_powertools/utilities/data_classes/sqs_event.py
+++ b/aws_lambda_powertools/utilities/data_classes/sqs_event.py
@@ -76,7 +76,7 @@ class SQSMessageAttribute(DictWrapper):
 
 class SQSMessageAttributes(Dict[str, SQSMessageAttribute]):
     def __getitem__(self, key: str) -> Optional[SQSMessageAttribute]:  # type: ignore
-        item = super(SQSMessageAttributes, self).get(key)
+        item = super().get(key)
         return None if item is None else SQSMessageAttribute(item)  # type: ignore
 
 


### PR DESCRIPTION
**Issue #, if available:**

It's been a while since i scanned through the data classes for typos and improvements.

## Description of changes:

Changes:
- Use correct wording: `built-in`, `its`, `sign in`, `all the` and `case-sensitive`
- Modern use of `super()`
- Use `resource.lstrip("/")` instead of `resource[:1] == "/"` for readability to remove leading "/" that isn't allowed when constructing an authorizer response object

**Checklist**

<!--- Leave unchecked if your change doesn't seem to apply --> 

* [X] [Meet tenets criteria](https://awslabs.github.io/aws-lambda-powertools-python/#tenets)
* [X] Update tests
* [X] Update docs
* [X] PR title follows [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-python/blob/376ec0a2ac0d2a40e0af5717bef42ff84ca0d1b9/.github/semantic.yml#L2)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
