### PR TITLE
docs(batch): fix typo in context manager keyword

### DIFF
--- a/docs/utilities/batch.md
+++ b/docs/utilities/batch.md
@@ -285,7 +285,7 @@ Processing batches from SQS works in four stages:
     @tracer.capture_lambda_handler
     def lambda_handler(event, context: LambdaContext):
         batch = event["Records"]
-        with processor(records=batch, processor=processor):
+        with processor(records=batch, handler=record_handler):
             processed_messages = processor.process() # kick off processing, return list[tuple]
 
         return processor.response()
@@ -413,7 +413,7 @@ Processing batches from Kinesis works in four stages:
     @tracer.capture_lambda_handler
     def lambda_handler(event, context: LambdaContext):
         batch = event["Records"]
-        with processor(records=batch, processor=processor):
+        with processor(records=batch, handler=record_handler):
             processed_messages = processor.process() # kick off processing, return list[tuple]
 
         return processor.response()
@@ -549,7 +549,7 @@ Processing batches from Kinesis works in four stages:
     @tracer.capture_lambda_handler
     def lambda_handler(event, context: LambdaContext):
         batch = event["Records"]
-        with processor(records=batch, processor=processor):
+        with processor(records=batch, handler=record_handler):
             processed_messages = processor.process() # kick off processing, return list[tuple]
 
         return processor.response()
@@ -821,7 +821,7 @@ def record_handler(record: SQSRecord):
 @tracer.capture_lambda_handler
 def lambda_handler(event, context: LambdaContext):
 	batch = event["Records"]
-	with processor(records=batch, processor=processor):
+	with processor(records=batch, handler=record_handler):
 		processed_messages: List[Union[SuccessResponse, FailureResponse]] = processor.process()
 
 	for messages in processed_messages:


### PR DESCRIPTION
**Issue #, if available:** Notified via Powertools Slack by KimL (thank you!!)

## Description of changes:

<!--- One or two sentences as a summary of what's being changed -->

**Checklist**

<!--- Leave unchecked if your change doesn't seem to apply --> 

* [ ] [Meet tenets criteria](https://awslabs.github.io/aws-lambda-powertools-python/#tenets)
* [ ] Update tests
* [ ] Update docs
* [ ] PR title follows [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-python/blob/376ec0a2ac0d2a40e0af5717bef42ff84ca0d1b9/.github/semantic.yml#L2)

## Breaking change checklist

<!--- Ignore if it's not a breaking change -->

**RFC issue #**:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


-----
[View rendered docs/utilities/batch.md](https://github.com/heitorlessa/aws-lambda-powertools-python/blob/docs/batch-example-typo/docs/utilities/batch.md)