### PR TITLE
docs(batch): snippet typo on batch processed messages iteration

### DIFF
--- a/docs/utilities/batch.md
+++ b/docs/utilities/batch.md
@@ -824,11 +824,10 @@ def lambda_handler(event, context: LambdaContext):
 	with processor(records=batch, handler=record_handler):
 		processed_messages: List[Union[SuccessResponse, FailureResponse]] = processor.process()
 
-	for messages in processed_messages:
-		for message in messages:
-			status: Union[Literal["success"], Literal["fail"]] = message[0]
-			result: Any = message[1]
-			record: SQSRecord = message[2]
+	for message in processed_messages:
+        status: Union[Literal["success"], Literal["fail"]] = message[0]
+        result: Any = message[1]
+        record: SQSRecord = message[2]
 
 
 	return processor.response()


### PR DESCRIPTION
**Issue #, if available:**

## Description of changes:

This is a small change to the documentation, fixing an extra iteration over processed_messages in batch processor.

**Checklist**

<!--- Leave unchecked if your change doesn't seem to apply --> 

* [X] [Meet tenets criteria](https://awslabs.github.io/aws-lambda-powertools-python/#tenets)
* [X] Update tests
* [X] Update docs
* [X PR title follows [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-python/blob/376ec0a2ac0d2a40e0af5717bef42ff84ca0d1b9/.github/semantic.yml#L2)

## Breaking change checklist

<!--- Ignore if it's not a breaking change -->

**RFC issue #**:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


-----
[View rendered docs/utilities/batch.md](https://github.com/j2clerck/aws-lambda-powertools-python/blob/develop/docs/utilities/batch.md)