### PR TITLE
docs(logger): fix code block syntax in FAQ

### DIFF
--- a/docs/core/logger.md
+++ b/docs/core/logger.md
@@ -1083,6 +1083,7 @@ external_logger = logging.logger()
 
 utils.copy_config_to_registered_loggers(source_logger=logger)
 external_logger.info("test message")
+```
 
 **What's the difference between `append_keys` and `extra`?**
 


### PR DESCRIPTION
Fix closure of python code block

## Description of changes:

Tiny change in the docs to fix a missing block closure in the markdown

**Checklist**

<!--- Leave unchecked if your change doesn't seem to apply --> 

* [x] [Meet tenets criteria](https://awslabs.github.io/aws-lambda-powertools-python/#tenets)
* [ ] Update tests. N/A
* [x] Update docs
* [x] PR title follows [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-python/blob/376ec0a2ac0d2a40e0af5717bef42ff84ca0d1b9/.github/semantic.yml#L2)

## Breaking change checklist

<!--- Ignore if it's not a breaking change -->

**RFC issue #**:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


-----
[View rendered docs/core/logger.md](https://github.com/mozz100/aws-lambda-powertools-python/blob/patch-1/docs/core/logger.md)