### PR TITLE
feat(middleware_factory): support router

### DIFF
--- a/aws_lambda_powertools/middleware_factory/factory.py
+++ b/aws_lambda_powertools/middleware_factory/factory.py
@@ -122,9 +122,9 @@ def lambda_handler_decorator(decorator: Optional[Callable] = None, trace_executi
             )
 
         @functools.wraps(func)
-        def wrapper(event, context):
+        def wrapper(**kwargs_wrapper):
             try:
-                middleware = functools.partial(decorator, func, event, context, **kwargs)
+                middleware = functools.partial(decorator, func, **(kwargs_wrapper | kwargs))
                 if trace_execution:
                     tracer = Tracer(auto_patch=False)
                     with tracer.provider.in_subsegment(name=f"## {decorator.__qualname__}"):


### PR DESCRIPTION
**Issue #, if available:**
#953 

## Description of changes:
The changes needed for `lambda_handler_decorator` to support routers are only to modify the arguments of the inner wrapper and its invocation, so I modified it to accept arbitrary arguments.

Due to the difference in signature (and function name), it may be preferable to instead move this to a clone named `router_decorator` instead of modifying the original `lambda_handler_decorator`.  If you would like me to do so, let me know and I can make the change.

**Checklist**

<!--- Leave unchecked if your change doesn't seem to apply --> 

* [ ] [Meet tenets criteria](https://awslabs.github.io/aws-lambda-powertools-python/#tenets)
* [ ] Update tests
* [ ] Update docs
* [x] PR title follows [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-python/blob/376ec0a2ac0d2a40e0af5717bef42ff84ca0d1b9/.github/semantic.yml#L2)

## Breaking change checklist
There may be potential issues with positional arguments if we reuse the same decorator.

**RFC issue #**:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
