### PR TITLE
docs(batch): snippet typo in custom batch processor

### DIFF
--- a/docs/utilities/batch.md
+++ b/docs/utilities/batch.md
@@ -921,7 +921,7 @@ class MyPartialProcessor(BasePartialProcessor):
 	def _clean(self):
 		# It's called once, *after* closing processing all records (closing the context manager)
 		# Here we're sending, at once, all successful messages to a ddb table
-		with ddb_table.batch_writer() as batch:
+		with self.ddb_table.batch_writer() as batch:
 			for result in self.success_messages:
 				batch.put_item(Item=result)
 


### PR DESCRIPTION
## Description of changes:

Variable `ddb_table` is not defined in the class. Updated with instance variable `self.ddb_table
`
**Checklist**

<!--- Leave unchecked if your change doesn't seem to apply --> 

* [ :white_check_mark:] [Meet tenets criteria](https://awslabs.github.io/aws-lambda-powertools-python/#tenets)
* [ ] Update tests
* [ :white_check_mark:] Update docs
* [ :white_check_mark:] PR title follows [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-python/blob/376ec0a2ac0d2a40e0af5717bef42ff84ca0d1b9/.github/semantic.yml#L2)

## Breaking change checklist

<!--- Ignore if it's not a breaking change -->

**RFC issue #**:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


-----
[View rendered docs/utilities/batch.md](https://github.com/thehananbhat/aws-lambda-powertools-python/blob/patch-1/docs/utilities/batch.md)