### PR TITLE
fix(data-classes): underscore support in api gateway authorizer resource name

### DIFF
--- a/aws_lambda_powertools/utilities/data_classes/api_gateway_authorizer_event.py
+++ b/aws_lambda_powertools/utilities/data_classes/api_gateway_authorizer_event.py
@@ -356,7 +356,7 @@ class APIGatewayAuthorizerResponse:
     - https://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-lambda-authorizer-output.html
     """
 
-    path_regex = r"^[/.a-zA-Z0-9-\*]+$"
+    path_regex = r"^[/.a-zA-Z0-9-_\*]+$"
     """The regular expression used to validate resource paths for the policy"""
 
     def __init__(

--- a/tests/functional/data_classes/test_api_gateway_authorizer.py
+++ b/tests/functional/data_classes/test_api_gateway_authorizer.py
@@ -24,14 +24,14 @@ def test_authorizer_response_no_statement(builder: APIGatewayAuthorizerResponse)
 
 def test_authorizer_response_invalid_verb(builder: APIGatewayAuthorizerResponse):
     with pytest.raises(ValueError, match="Invalid HTTP verb: 'INVALID'"):
-        # GIVEN a invalid http_method
+        # GIVEN an invalid http_method
         # WHEN calling deny_method
         builder.deny_route(http_method="INVALID", resource="foo")
 
 
 def test_authorizer_response_invalid_resource(builder: APIGatewayAuthorizerResponse):
     with pytest.raises(ValueError, match="Invalid resource path: \$."):  # noqa: W605
-        # GIVEN a invalid resource path "$"
+        # GIVEN an invalid resource path "$"
         # WHEN calling deny_method
         builder.deny_route(http_method=HttpVerb.GET.value, resource="$")
 
@@ -177,4 +177,21 @@ def test_deny_all():
         "Action": "execute-api:Invoke",
         "Effect": "Deny",
         "Resource": ["*"],
+    }
+
+
+def test_authorizer_response_allow_route_with_underscore(builder: APIGatewayAuthorizerResponse):
+    builder.allow_route(http_method="GET", resource="/has_underscore")
+    assert builder.asdict() == {
+        "principalId": "foo",
+        "policyDocument": {
+            "Version": "2012-10-17",
+            "Statement": [
+                {
+                    "Action": "execute-api:Invoke",
+                    "Effect": "Allow",
+                    "Resource": ["arn:aws:execute-api:us-west-1:123456789:fantom/dev/GET/has_underscore"],
+                }
+            ],
+        },
     }


### PR DESCRIPTION

**Issue #, if available:**

## Description of changes:

When building a authorizer response we should allow for underscores in the resource

**Checklist**

<!--- Leave unchecked if your change doesn't seem to apply --> 

* [X] [Meet tenets criteria](https://awslabs.github.io/aws-lambda-powertools-python/#tenets)
* [X] Update tests
* [X] Update docs
* [X] PR title follows [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-python/blob/376ec0a2ac0d2a40e0af5717bef42ff84ca0d1b9/.github/semantic.yml#L2)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
