### PR TITLE
feat(logger): log_event support event data classes (e.g. S3Event)

### DIFF
--- a/aws_lambda_powertools/logging/logger.py
+++ b/aws_lambda_powertools/logging/logger.py
@@ -349,7 +349,7 @@ class Logger(logging.Logger):  # lgtm [py/missing-call-to-init]
 
             if log_event:
                 logger.debug("Event received")
-                self.info(event)
+                self.info(getattr(event, "raw_event", event))
 
             return lambda_handler(event, context)
 


### PR DESCRIPTION
**Issue #, if available:**

closes #947

## Description of changes:

```python3
@event_source(data_class=S3Event)
@log.inject_lambda_context(log_event=True)
def lambda_handler(event: S3Event, context: LambdaContext):
   ...
```

Changes:
- Add dict data from raw_event when available

**Checklist**

<!--- Leave unchecked if your change doesn't seem to apply --> 

* [X] [Meet tenets criteria](https://awslabs.github.io/aws-lambda-powertools-python/#tenets)
* [X] Update tests
* [X] Update docs
* [X] PR title follows [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-python/blob/376ec0a2ac0d2a40e0af5717bef42ff84ca0d1b9/.github/semantic.yml#L2)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
