### PR TITLE
fix(apigateway): remove indentation in debug_mode

### DIFF
--- a/aws_lambda_powertools/event_handler/api_gateway.py
+++ b/aws_lambda_powertools/event_handler/api_gateway.py
@@ -446,10 +446,6 @@ class ApiGatewayResolver(BaseRouter):
         # Allow for a custom serializer or a concise json serialization
         self._serializer = serializer or partial(json.dumps, separators=(",", ":"), cls=Encoder)
 
-        if self._debug:
-            # Always does a pretty print when in debug mode
-            self._serializer = partial(json.dumps, indent=4, cls=Encoder)
-
     def route(
         self,
         rule: str,
@@ -496,7 +492,7 @@ class ApiGatewayResolver(BaseRouter):
             Returns the dict response
         """
         if self._debug:
-            print(self._json_dump(event))
+            print(self._json_dump(event), end="")
         BaseRouter.current_event = self._to_proxy_event(event)
         BaseRouter.lambda_context = context
         return self._resolve().build(self.current_event, self._cors)

--- a/docs/core/event_handler/api_gateway.md
+++ b/docs/core/event_handler/api_gateway.md
@@ -940,6 +940,8 @@ This will enable full tracebacks errors in the response, print request and respo
 ???+ danger
     This might reveal sensitive information in your logs and relax CORS restrictions, use it sparingly.
 
+    It's best to use for local development only!
+
 ```python hl_lines="3" title="Enabling debug mode"
 from aws_lambda_powertools.event_handler.api_gateway import ApiGatewayResolver
 

--- a/tests/functional/event_handler/test_api_gateway.py
+++ b/tests/functional/event_handler/test_api_gateway.py
@@ -32,6 +32,12 @@ from aws_lambda_powertools.utilities.data_classes import ALBEvent, APIGatewayPro
 from tests.functional.utils import load_event
 
 
+@pytest.fixture
+def json_dump():
+    # our serializers reduce length to save on costs; fixture to replicate separators
+    return lambda obj: json.dumps(obj, separators=(",", ":"))
+
+
 def read_media(file_name: str) -> bytes:
     path = Path(str(Path(__file__).parent.parent.parent.parent) + "/docs/media/" + file_name)
     return path.read_bytes()
@@ -506,12 +512,9 @@ def test_custom_preflight_response():
     assert headers["Access-Control-Allow-Methods"] == "CUSTOM"
 
 
-def test_service_error_responses():
+def test_service_error_responses(json_dump):
     # SCENARIO handling different kind of service errors being raised
     app = ApiGatewayResolver(cors=CORSConfig())
-
-    def json_dump(obj):
-        return json.dumps(obj, separators=(",", ":"))
 
     # GIVEN an BadRequestError
     @app.get(rule="/bad-request-error", cors=False)
@@ -641,7 +644,7 @@ def test_debug_mode_environment_variable(monkeypatch):
     assert app._debug
 
 
-def test_debug_json_formatting():
+def test_debug_json_formatting(json_dump):
     # GIVEN debug is True
     app = ApiGatewayResolver(debug=True)
     response = {"message": "Foo"}
@@ -654,7 +657,7 @@ def test_debug_json_formatting():
     result = app({"path": "/foo", "httpMethod": "GET"}, None)
 
     # THEN return a pretty print json in the body
-    assert result["body"] == json.dumps(response, indent=4)
+    assert result["body"] == json_dump(response)
 
 
 def test_debug_print_event(capsys):


### PR DESCRIPTION
**Issue #, if available:** #972

## Description of changes:

<!--- One or two sentences as a summary of what's being changed -->

This PR removes additional indentation when using `debug_mode`. While effective for local development it creates additional log events for CloudWatch Logs incurring additional charges; this breaks our tenets hence we revert.

**Before**

![image](https://user-images.githubusercontent.com/3340292/151830448-f739fe81-9d39-4448-8a6d-379d4f241b9b.png)

**After**

![image](https://user-images.githubusercontent.com/3340292/151830501-8f146911-1d32-4e58-8db5-809721114333.png)


**Checklist**

<!--- Leave unchecked if your change doesn't seem to apply --> 

* [ ] [Meet tenets criteria](https://awslabs.github.io/aws-lambda-powertools-python/#tenets)
* [ ] Update tests
* [ ] Update docs
* [ ] PR title follows [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-python/blob/376ec0a2ac0d2a40e0af5717bef42ff84ca0d1b9/.github/semantic.yml#L2)

## Breaking change checklist

<!--- Ignore if it's not a breaking change -->

**RFC issue #**:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


-----
[View rendered docs/core/event_handler/api_gateway.md](https://github.com/heitorlessa/aws-lambda-powertools-python/blob/fix/event-handler-debug-mode/docs/core/event_handler/api_gateway.md)