### PR TITLE
docs(event-handler): improve testing section for graphql

### DIFF
--- a/docs/core/event_handler/appsync.md
+++ b/docs/core/event_handler/appsync.md
@@ -780,6 +780,7 @@ Here's an example of how you can test your synchronous resolvers:
 === "test_resolver.py"
 
     ```python
+    import json
     import pytest
     from pathlib import Path
 
@@ -823,6 +824,7 @@ And an example for testing asynchronous resolvers. Note that this requires the `
 === "test_async_resolver.py"
 
     ```python
+    import json
     import pytest
     from pathlib import Path
 

--- a/docs/core/event_handler/appsync.md
+++ b/docs/core/event_handler/appsync.md
@@ -781,13 +781,15 @@ Here's an example of how you can test your synchronous resolvers:
 
     ```python
     import pytest
+    from pathlib import Path
+
     from src.index import app  # import the instance of AppSyncResolver from your code
 
     def test_direct_resolver():
       # Load mock event from a file
-      json_file = "appSyncDirectResolver.json"
-      fh = open(file)
-      mock_event = json.load(fh)
+      json_file_path = Path("appSyncDirectResolver.json")
+      with open(json_file_path) as json_file:
+        mock_event = json.load(json_file)
 
       # Call the implicit handler
       result = app(mock_event, {})
@@ -822,14 +824,16 @@ And an example for testing asynchronous resolvers. Note that this requires the `
 
     ```python
     import pytest
+    from pathlib import Path
+
     from src.index import app  # import the instance of AppSyncResolver from your code
 
     @pytest.mark.asyncio
     async def test_direct_resolver():
       # Load mock event from a file
-      json_file = "appSyncDirectResolver.json"
-      fh = open(file)
-      mock_event = json.load(fh)
+      json_file_path = Path("appSyncDirectResolver.json")
+      with open(json_file_path) as json_file:
+        mock_event = json.load(json_file)
 
       # Call the implicit handler
       result = await app(mock_event, {})

--- a/docs/core/event_handler/appsync.md
+++ b/docs/core/event_handler/appsync.md
@@ -785,7 +785,7 @@ Here's an example of how you can test your synchronous resolvers:
 
     def test_direct_resolver():
       # Load mock event from a file
-      json_file = "../../events/appSyncDirectResolver.json"
+      json_file = "appSyncDirectResolver.json"
       fh = open(file)
       mock_event = json.load(fh)
 
@@ -827,7 +827,7 @@ And an example for testing asynchronous resolvers. Note that this requires the `
     @pytest.mark.asyncio
     async def test_direct_resolver():
       # Load mock event from a file
-      json_file = "../../events/appSyncDirectResolver.json"
+      json_file = "appSyncDirectResolver.json"
       fh = open(file)
       mock_event = json.load(fh)
 

--- a/docs/core/event_handler/appsync.md
+++ b/docs/core/event_handler/appsync.md
@@ -775,27 +775,82 @@ You can test your resolvers by passing a mocked or actual AppSync Lambda event t
 
 You can use either `app.resolve(event, context)` or simply `app(event, context)`.
 
-Here's an example from our internal functional test.
+Here's an example of how you can test your synchronous resolvers:
 
-=== "test_direct_resolver.py"
+=== "test_resolver.py"
 
     ```python
+    import pytest
+    from src.index import app  # import the instance of AppSyncResolver from your code
+
     def test_direct_resolver():
-      # Check whether we can handle an example appsync direct resolver
-      # load_event primarily deserialize the JSON event into a dict
-      mock_event = load_event("appSyncDirectResolver.json")
-
-      app = AppSyncResolver()
-
-      @app.resolver(field_name="createSomething")
-      def create_something(id: str):
-          assert app.lambda_context == {}
-          return id
+      # Load mock event from a file
+      json_file = "../../events/appSyncDirectResolver.json"
+      fh = open(file)
+      mock_event = json.load(fh)
 
       # Call the implicit handler
       result = app(mock_event, {})
 
-      assert result == "my identifier"
+      assert result == "created this value"
+    ```
+
+=== "src/index.py"
+
+    ```python
+
+    from aws_lambda_powertools.event_handler import AppSyncResolver
+
+    app = AppSyncResolver()
+
+    @app.resolver(field_name="createSomething")
+    def create_something():
+        return "created this value"
+
+    ```
+
+=== "appSyncDirectResolver.json"
+
+    ```json
+    --8<-- "tests/events/appSyncDirectResolver.json"
+    ```
+
+And an example for testing asynchronous resolvers. Note that this requires the `pytest-asyncio` package:
+
+
+=== "test_async_resolver.py"
+
+    ```python
+    import pytest
+    from src.index import app  # import the instance of AppSyncResolver from your code
+
+    @pytest.mark.asyncio
+    async def test_direct_resolver():
+      # Load mock event from a file
+      json_file = "../../events/appSyncDirectResolver.json"
+      fh = open(file)
+      mock_event = json.load(fh)
+
+      # Call the implicit handler
+      result = await app(mock_event, {})
+
+      assert result == "created this value"
+    ```
+
+=== "src/index.py"
+
+    ```python
+    import asyncio
+
+    from aws_lambda_powertools.event_handler import AppSyncResolver
+
+    app = AppSyncResolver()
+
+    @app.resolver(field_name="createSomething")
+    async def create_something_async():
+        await asyncio.sleep(1)  # Do async stuff
+        return "created this value"
+
     ```
 
 === "appSyncDirectResolver.json"


### PR DESCRIPTION
**Issue #, if available:** #857

## Description of changes:

Small improvements to "Testing Your Code" section in of graphql event handlers doc. Made example more relevant to a real application rather than borrowing our own example test, and added an example for async tests.

**Checklist**

<!--- Leave unchecked if your change doesn't seem to apply --> 

* [X] [Meet tenets criteria](https://awslabs.github.io/aws-lambda-powertools-python/#tenets)
* [ ] Update tests
* [X] Update docs
* [X] PR title follows [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-python/blob/376ec0a2ac0d2a40e0af5717bef42ff84ca0d1b9/.github/semantic.yml#L2)

## Breaking change checklist

<!--- Ignore if it's not a breaking change -->

**RFC issue #**:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


-----
[View rendered docs/core/event_handler/appsync.md](https://github.com/awslabs/aws-lambda-powertools-python/blob/docs/async_testing_example/docs/core/event_handler/appsync.md)