### PR TITLE
fix(logger): exclude source_logger in copy_config_to_registered_loggers

### DIFF
--- a/aws_lambda_powertools/logging/utils.py
+++ b/aws_lambda_powertools/logging/utils.py
@@ -38,7 +38,7 @@ def copy_config_to_registered_loggers(
     if exclude:
         exclude.add(source_logger.name)
     else:
-        exclude = set(source_logger.name)
+        exclude = {source_logger.name}
 
     # Prepare loggers set
     if include:

--- a/tests/functional/test_logger_utils.py
+++ b/tests/functional/test_logger_utils.py
@@ -188,7 +188,7 @@ def test_copy_config_to_ext_loggers_should_not_break_append_keys(stdout, logger,
     # GIVEN powertools logger initialized
     powertools_logger = Logger(service=service_name(), level=log_level.INFO.value, stream=stdout)
 
-    # WHEN configuration copied from powertools logger to ALL external loggers two times
+    # WHEN configuration copied from powertools logger to ALL external loggers
     utils.copy_config_to_registered_loggers(source_logger=powertools_logger)
 
     # THEN append_keys should not raise an exception

--- a/tests/functional/test_logger_utils.py
+++ b/tests/functional/test_logger_utils.py
@@ -182,3 +182,14 @@ def test_copy_config_to_ext_loggers_custom_log_level(stdout, logger, log_level):
     assert logger.level == log_level.WARNING.value
     assert log["message"] == msg
     assert log["level"] == log_level.WARNING.name
+
+
+def test_copy_config_to_ext_loggers_should_not_break_append_keys(stdout, logger, log_level):
+    # GIVEN powertools logger initialized
+    powertools_logger = Logger(service=service_name(), level=log_level.INFO.value, stream=stdout)
+
+    # WHEN configuration copied from powertools logger to ALL external loggers two times
+    utils.copy_config_to_registered_loggers(source_logger=powertools_logger)
+
+    # THEN append_keys should not raise an exception
+    powertools_logger.append_keys(key="value")


### PR DESCRIPTION
#999 

## Description of changes:

The source_logger was not added correctly to the exclusions.

**Checklist**

* [x] [Meet tenets criteria](https://awslabs.github.io/aws-lambda-powertools-python/#tenets)
* [x] Update tests
* [ ] Update docs
* [x] PR title follows [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-python/blob/376ec0a2ac0d2a40e0af5717bef42ff84ca0d1b9/.github/semantic.yml#L2)

## Breaking change checklist

<!--- Ignore if it's not a breaking change -->

**RFC issue #**:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
