### PR TITLE
docs: fix syntax errors and line highlights

### DIFF
--- a/docs/core/event_handler/api_gateway.md
+++ b/docs/core/event_handler/api_gateway.md
@@ -298,7 +298,7 @@ You can also nest paths as configured earlier in [our sample infrastructure](#re
     @app.get("/<message>/<name>")
     @tracer.capture_method
     def get_message(message, name):
-        return {"message": f"{message}, {name}}"}
+        return {"message": f"{message}, {name}"}
 
     # You can continue to use other utilities just as before
     @logger.inject_lambda_context(correlation_id_path=correlation_paths.API_GATEWAY_REST)
@@ -461,7 +461,7 @@ def get_hello_you():
 	payload = app.current_event.body
 
 	name = app.current_event.get_query_string_value(name="name", default_value="")
-	return {"message": f"hello {name}}"}
+	return {"message": f"hello {name}"}
 
 def lambda_handler(event, context):
 	return app.resolve(event, context)
@@ -481,7 +481,7 @@ def get_hello_you():
 	headers_as_dict = app.current_event.headers
 	name = app.current_event.get_header_value(name="X-Name", default_value="")
 
-	return {"message": f"hello {name}}"}
+	return {"message": f"hello {name}"}
 
 def lambda_handler(event, context):
 	return app.resolve(event, context)
@@ -768,7 +768,8 @@ You can use the `Response` class to have full control over the response, for exa
 
 === "app.py"
 
-    ```python hl_lines="10-14"
+    ```python hl_lines="11-16"
+    import json
     from aws_lambda_powertools.event_handler.api_gateway import APIGatewayRestResolver, Response
 
     app = APIGatewayRestResolver()
@@ -778,10 +779,11 @@ You can use the `Response` class to have full control over the response, for exa
         payload = json.dumps({"message": "I'm a teapot"})
         custom_headers = {"X-Custom": "X-Value"}
 
-        return Response(status_code=418,
-                        content_type="application/json",
-                        body=payload,
-                        headers=custom_headers
+        return Response(
+            status_code=418,
+            content_type="application/json",
+            body=payload,
+            headers=custom_headers,
         )
 
     def lambda_handler(event, context):
@@ -974,7 +976,7 @@ def lambda_handler(event, context):
 
 You can instruct API Gateway handler to use a custom serializer to best suit your needs, for example take into account Enums when serializing.
 
-```python hl_lines="19-20 24" title="Using a custom JSON serializer for responses"
+```python hl_lines="21-22 26" title="Using a custom JSON serializer for responses"
 import json
 from enum import Enum
 from json import JSONEncoder
@@ -1025,7 +1027,7 @@ Let's assume you have `app.py` as your Lambda function entrypoint and routes in 
 
 	We import **Router** instead of **APIGatewayRestResolver**; syntax wise is exactly the same.
 
-    ```python hl_lines="4 8 12 15 21"
+    ```python hl_lines="5 8 12 15 21"
     import itertools
 	from typing import Dict
 
@@ -1221,7 +1223,7 @@ This sample project contains a Users function with two distinct set of routes, `
 
 === "src/users/main.py"
 
-    ```python hl_lines="9 15-16"
+    ```python hl_lines="8 14-15"
     from typing import Dict
 
     from aws_lambda_powertools import Logger, Tracer
@@ -1356,7 +1358,7 @@ You can test your routes by passing a proxy event request where `path` and `http
     def test_lambda_handler(lambda_context):
         minimal_event = {
             "path": "/hello",
-            "httpMethod": "GET"
+            "httpMethod": "GET",
             "requestContext": {  # correlation ID
                 "requestId": "c6af9ac6-7b61-11e6-9a41-93e8deadbeef"
             }

--- a/docs/core/event_handler/appsync.md
+++ b/docs/core/event_handler/appsync.md
@@ -346,24 +346,24 @@ You can nest `app.resolver()` decorator multiple times when resolving fields wit
 === "nested_mappings.py"
 
     ```python hl_lines="4 8 10-12 18"
-      from aws_lambda_powertools import Logger, Tracer
+    from aws_lambda_powertools import Logger, Tracer
 
-      from aws_lambda_powertools.logging import correlation_paths
-      from aws_lambda_powertools.event_handler import AppSyncResolver
+    from aws_lambda_powertools.logging import correlation_paths
+    from aws_lambda_powertools.event_handler import AppSyncResolver
 
-      tracer = Tracer(service="sample_resolver")
-      logger = Logger(service="sample_resolver")
-      app = AppSyncResolver()
+    tracer = Tracer(service="sample_resolver")
+    logger = Logger(service="sample_resolver")
+    app = AppSyncResolver()
 
-      @app.resolver(field_name="listLocations")
-      @app.resolver(field_name="locations")
-      def get_locations(name: str, description: str = ""):
-          return name + description
+    @app.resolver(field_name="listLocations")
+    @app.resolver(field_name="locations")
+    def get_locations(name: str, description: str = ""):
+        return name + description
 
-      @logger.inject_lambda_context(correlation_id_path=correlation_paths.APPSYNC_RESOLVER)
-      @tracer.capture_lambda_handler
-      def lambda_handler(event, context):
-          return app.resolve(event, context)
+    @logger.inject_lambda_context(correlation_id_path=correlation_paths.APPSYNC_RESOLVER)
+    @tracer.capture_lambda_handler
+    def lambda_handler(event, context):
+        return app.resolve(event, context)
     ```
 
 === "schema.graphql"
@@ -396,7 +396,8 @@ You can nest `app.resolver()` decorator multiple times when resolving fields wit
 
 For Lambda Python3.8+ runtime, this utility supports async functions when you use in conjunction with `asyncio.run`.
 
-```python hl_lines="4 8 10-12 20" title="Resolving GraphQL resolvers async"
+```python hl_lines="5 9 11-13 21" title="Resolving GraphQL resolvers async"
+import asyncio
 from aws_lambda_powertools import Logger, Tracer
 
 from aws_lambda_powertools.logging import correlation_paths
@@ -603,33 +604,34 @@ You can subclass `AppSyncResolverEvent` to bring your own set of methods to hand
 
 === "custom_model.py"
 
-    ```python hl_lines="11-14 19 26"
-      from aws_lambda_powertools import Logger, Tracer
+    ```python hl_lines="12-15 20 27"
+    from aws_lambda_powertools import Logger, Tracer
 
-      from aws_lambda_powertools.logging import correlation_paths
-      from aws_lambda_powertools.event_handler import AppSyncResolver
+    from aws_lambda_powertools.logging import correlation_paths
+    from aws_lambda_powertools.event_handler import AppSyncResolver
+    from aws_lambda_powertools.utilities.data_classes.appsync_resolver_event import AppSyncResolverEvent
 
-      tracer = Tracer(service="sample_resolver")
-      logger = Logger(service="sample_resolver")
-      app = AppSyncResolver()
+    tracer = Tracer(service="sample_resolver")
+    logger = Logger(service="sample_resolver")
+    app = AppSyncResolver()
 
 
-      class MyCustomModel(AppSyncResolverEvent):
-          @property
-          def country_viewer(self) -> str:
-              return self.request_headers.get("cloudfront-viewer-country")
+    class MyCustomModel(AppSyncResolverEvent):
+        @property
+        def country_viewer(self) -> str:
+            return self.request_headers.get("cloudfront-viewer-country")
 
-      @app.resolver(field_name="listLocations")
-      @app.resolver(field_name="locations")
-      def get_locations(name: str, description: str = ""):
-          if app.current_event.country_viewer == "US":
-            ...
-          return name + description
+    @app.resolver(field_name="listLocations")
+    @app.resolver(field_name="locations")
+    def get_locations(name: str, description: str = ""):
+        if app.current_event.country_viewer == "US":
+          ...
+        return name + description
 
-      @logger.inject_lambda_context(correlation_id_path=correlation_paths.APPSYNC_RESOLVER)
-      @tracer.capture_lambda_handler
-      def lambda_handler(event, context):
-          return app.resolve(event, context, data_model=MyCustomModel)
+    @logger.inject_lambda_context(correlation_id_path=correlation_paths.APPSYNC_RESOLVER)
+    @tracer.capture_lambda_handler
+    def lambda_handler(event, context):
+        return app.resolve(event, context, data_model=MyCustomModel)
     ```
 
 === "schema.graphql"
@@ -819,7 +821,6 @@ Here's an example of how you can test your synchronous resolvers:
     ```
 
 And an example for testing asynchronous resolvers. Note that this requires the `pytest-asyncio` package:
-
 
 === "test_async_resolver.py"
 

--- a/docs/tutorial/index.md
+++ b/docs/tutorial/index.md
@@ -822,7 +822,7 @@ Let's expand our application with custom metrics using AWS SDK to see how it wor
     def add_greeting_metric(service: str = "APP"):
         function_name = os.getenv("AWS_LAMBDA_FUNCTION_NAME", "undefined")
         service_dimension = {"Name": "service", "Value": service}
-        function_dimension = {"Name": "function_name": "Value": function_name}
+        function_dimension = {"Name": "function_name", "Value": function_name}
         is_cold_start = True
 
         global cold_start

--- a/docs/utilities/feature_flags.md
+++ b/docs/utilities/feature_flags.md
@@ -453,6 +453,8 @@ By default, we cache configuration retrieved from the Store for 5 seconds for pe
 
 You can override `max_age` parameter when instantiating the store.
 
+=== "app.py"
+
     ```python hl_lines="7"
     from aws_lambda_powertools.utilities.feature_flags import FeatureFlags, AppConfigStore
 
@@ -677,10 +679,12 @@ Parameter | Default | Description
 **logger** | `logging.Logger` | Logger to use for debug.  You can optionally supply an instance of Powertools Logger.
 
 
-```python hl_lines="19-25" title="AppConfigStore sample"
+```python hl_lines="21-27" title="AppConfigStore sample"
 from botocore.config import Config
 
 import jmespath
+
+from aws_lambda_powertools.utilities.feature_flags import AppConfigStore
 
 boto_config = Config(read_timeout=10, retries={"total_max_attempts": 2})
 
@@ -715,9 +719,7 @@ You can unit test your feature flags locally and independently without setting u
 ???+ warning
     This excerpt relies on `pytest` and `pytest-mock` dependencies.
 
-```python hl_lines="9-11" title="Unit testing feature flags"
-from typing import Dict, List, Optional
-
+```python hl_lines="7-9" title="Unit testing feature flags"
 from aws_lambda_powertools.utilities.feature_flags import FeatureFlags, AppConfigStore, RuleAction
 
 


### PR DESCRIPTION
**Issue #, if available:**
- https://github.com/awslabs/aws-lambda-powertools-python/issues/1013

## Description of changes:

- fix line number highlights
- fix missing imports
- fix syntax error
- fix indents
- fix example code rendering

**Checklist**

<!--- Leave unchecked if your change doesn't seem to apply --> 

* [X] [Meet tenets criteria](https://awslabs.github.io/aws-lambda-powertools-python/#tenets)
* [X] Update tests
* [X] Update docs
* [X] PR title follows [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-python/blob/376ec0a2ac0d2a40e0af5717bef42ff84ca0d1b9/.github/semantic.yml#L2)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


-----
[View rendered docs/core/event_handler/api_gateway.md](https://github.com/gyft/aws-lambda-powertools-python/blob/fix-docs/docs/core/event_handler/api_gateway.md)
[View rendered docs/tutorial/index.md](https://github.com/gyft/aws-lambda-powertools-python/blob/fix-docs/docs/tutorial/index.md)