### PR TITLE
feat(data_classes): Batch response helper

### DIFF
--- a/aws_lambda_powertools/utilities/data_classes/batch_response.py
+++ b/aws_lambda_powertools/utilities/data_classes/batch_response.py
@@ -1,0 +1,24 @@
+from typing import Dict, List, Optional
+
+
+class BatchResponse:
+    """Batch Response
+
+    Documentation:
+    --------------
+    - https://docs.aws.amazon.com/lambda/latest/dg/with-sqs.html#services-sqs-batchfailurereporting
+    - https://docs.aws.amazon.com/lambda/latest/dg/with-kinesis.html#services-kinesis-batchfailurereporting
+    - https://docs.aws.amazon.com/lambda/latest/dg/with-ddb.html#services-ddb-batchfailurereporting
+    """
+
+    def __init__(self, failed_items: Optional[List[str]] = None) -> None:
+        if failed_items:
+            self._messages = [{"itemIdentifier": item} for item in failed_items]
+        else:
+            self._messages = []
+
+    def add_item(self, identifier: str):
+        self._messages.append({"itemIdentifier": identifier})
+
+    def asdict(self) -> Dict[str, List]:
+        return {"batchItemFailures": self._messages}

--- a/tests/functional/data_classes/test_batch_response.py
+++ b/tests/functional/data_classes/test_batch_response.py
@@ -1,0 +1,18 @@
+from aws_lambda_powertools.utilities.data_classes.batch_response import BatchResponse
+
+
+def test_no_elements():
+    assert BatchResponse().asdict() == {"batchItemFailures": []}
+    assert BatchResponse(None).asdict() == {"batchItemFailures": []}
+
+
+def test_with_elements():
+    assert BatchResponse(["item1", "item2"]).asdict() == {
+        "batchItemFailures": [{"itemIdentifier": "item1"}, {"itemIdentifier": "item2"}]
+    }
+
+
+def test_add_item():
+    response = BatchResponse()
+    response.add_item("item1")
+    assert response.asdict() == {"batchItemFailures": [{"itemIdentifier": "item1"}]}


### PR DESCRIPTION
BatchResponse is a smaller batch response helper

**Issue #, if available:**

## Description of changes:

UX based on the examples:
- https://docs.aws.amazon.com/lambda/latest/dg/with-sqs.html#services-sqs-batchfailurereporting

```python3
from aws_lambda_powertools.utilities.data_classes.batch_response import BatchResponse
from aws_lambda_powertools.utilities.data_classes.event_source import event_source
from aws_lambda_powertools.utilities.data_classes.sqs_event import SQSEvent


@event_source(data_class=SQSEvent)
def handler(event: SQSEvent, context):
    cur_record_sequence_number = ""

    for record in event.records:
        try:
            # Process your record
            cur_record_sequence_number = record.message_id
        except Exception:
            # Return failed record's sequence number
            return BatchResponse([cur_record_sequence_number]).asdict()

    return BatchResponse().asdict()
```

**Checklist**

<!--- Leave unchecked if your change doesn't seem to apply --> 

* [X] [Meet tenets criteria](https://awslabs.github.io/aws-lambda-powertools-python/#tenets)
* [X] Update tests
* [X] Update docs
* [X] PR title follows [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-python/blob/376ec0a2ac0d2a40e0af5717bef42ff84ca0d1b9/.github/semantic.yml#L2)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
