### PR TITLE
docs(parameters): add testing your code section

### DIFF
--- a/docs/utilities/parameters.md
+++ b/docs/utilities/parameters.md
@@ -524,17 +524,16 @@ to patch the `parameters.get_parameter` method:
 
 === "tests.py"
 	```python
-	from src.index import handler
+	from src import index
 
 	def test_handler(monkeypatch):
 
 		def mockreturn(name):
 			return "mock_value"
 
-		monkeypatch.setattr(parameters, "get_parameter", mockreturn)
-		return_val = handler({}, {})
+		monkeypatch.setattr(index.parameters, "get_parameter", mockreturn)
+		return_val = index.handler({}, {})
 		assert return_val.get('message') == 'mock_value'
-
 	```
 
 === "src/index.py"
@@ -553,18 +552,18 @@ If we need to use this pattern across multiple tests, we can avoid repetition by
 	```python
 	import pytest
 
-	from src.index import handler
+	from src import index
 
 	@pytest.fixture
 	def mock_parameter_response(monkeypatch):
 		def mockreturn(name):
 			return "mock_value"
 
-    	monkeypatch.setattr(parameters, "get_parameter", mockreturn)
+    	monkeypatch.setattr(index.parameters, "get_parameter", mockreturn)
 
 	# Pass our fixture as an argument to all tests where we want to mock the get_parameter response
 	def test_handler(mock_parameter_response):
-		return_val = handler({}, {})
+		return_val = index.handler({}, {})
 		assert return_val.get('message') == 'mock_value'
 
 	```
@@ -577,13 +576,14 @@ object named `get_parameter_mock`.
 === "tests.py"
 	```python
 	from unittest.mock import patch
+	from src import index
 
 	# Replaces "aws_lambda_powertools.utilities.parameters.get_parameter" with a Mock object
 	@patch("aws_lambda_powertools.utilities.parameters.get_parameter")
 	def test_handler(get_parameter_mock):
 		get_parameter_mock.return_value = 'mock_value'
 
-		return_val = handler({}, {})
+		return_val = index.handler({}, {})
 		get_parameter_mock.assert_called_with("my-parameter-name")
 		assert return_val.get('message') == 'mock_value'
 


### PR DESCRIPTION
**Issue #, if available:** #1009

## Description of changes:

Add "Testing your code" section to the documentation for parameters utility.

**Checklist**

<!--- Leave unchecked if your change doesn't seem to apply --> 

* [ ] [Meet tenets criteria](https://awslabs.github.io/aws-lambda-powertools-python/#tenets)
* [ ] Update tests
* [x] Update docs
* [ ] PR title follows [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-python/blob/376ec0a2ac0d2a40e0af5717bef42ff84ca0d1b9/.github/semantic.yml#L2)

## Breaking change checklist

<!--- Ignore if it's not a breaking change -->

**RFC issue #**:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


-----
[View rendered docs/utilities/parameters.md](https://github.com/awslabs/aws-lambda-powertools-python/blob/docs/testing_parameters/docs/utilities/parameters.md)