### PR TITLE
fix(event_handler): docs snippets, high-level import CorsConfig

### DIFF
--- a/aws_lambda_powertools/event_handler/__init__.py
+++ b/aws_lambda_powertools/event_handler/__init__.py
@@ -2,7 +2,14 @@
 Event handler decorators for common Lambda events
 """
 
-from .api_gateway import ALBResolver, APIGatewayHttpResolver, ApiGatewayResolver, APIGatewayRestResolver
+from .api_gateway import ALBResolver, APIGatewayHttpResolver, ApiGatewayResolver, APIGatewayRestResolver, CORSConfig
 from .appsync import AppSyncResolver
 
-__all__ = ["AppSyncResolver", "APIGatewayRestResolver", "APIGatewayHttpResolver", "ALBResolver", "ApiGatewayResolver"]
+__all__ = [
+    "AppSyncResolver",
+    "APIGatewayRestResolver",
+    "APIGatewayHttpResolver",
+    "ALBResolver",
+    "ApiGatewayResolver",
+    "CORSConfig",
+]

--- a/docs/core/event_handler/api_gateway.md
+++ b/docs/core/event_handler/api_gateway.md
@@ -537,7 +537,7 @@ You can use **`exception_handler`** decorator with any Python exception. This al
 from aws_lambda_powertools import Logger, Tracer
 from aws_lambda_powertools.logging import correlation_paths
 from aws_lambda_powertools.event_handler import content_types
-from aws_lambda_powertools.event_handler import APIGatewayRestResolver, Response
+from aws_lambda_powertools.event_handler.api_gateway import APIGatewayRestResolver, Response
 
 tracer = Tracer()
 logger = Logger()

--- a/docs/core/event_handler/api_gateway.md
+++ b/docs/core/event_handler/api_gateway.md
@@ -685,7 +685,7 @@ This will ensure that CORS headers are always returned as part of the response w
     ```python hl_lines="9 11"
     from aws_lambda_powertools import Logger, Tracer
     from aws_lambda_powertools.logging import correlation_paths
-    from aws_lambda_powertools.event_handler import APIGatewayRestResolver, CORSConfig
+    from aws_lambda_powertools.event_handler.api_gateway import APIGatewayRestResolver, CORSConfig
 
     tracer = Tracer()
     logger = Logger()


### PR DESCRIPTION
**Issue #, if available:**

- #1018
- Related to #1004

## Description of changes:

Changes:
- Fix import statements for `CORSConfig` and `Response` in docs (for current versions) 
- Add CORSConfig to __init__.py for ease of use (to allow for this shortcut in future versions) 

**Checklist**

* [X] [Meet tenets criteria](https://awslabs.github.io/aws-lambda-powertools-python/#tenets)
* [X] Update tests
* [X] Update docs
* [X] PR title follows [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-python/blob/376ec0a2ac0d2a40e0af5717bef42ff84ca0d1b9/.github/semantic.yml#L2)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
