### PR TITLE
fix(feature_flags): fix max_age type so mypy will not fail on strict …

### DIFF
--- a/aws_lambda_powertools/utilities/feature_flags/appconfig.py
+++ b/aws_lambda_powertools/utilities/feature_flags/appconfig.py
@@ -13,6 +13,8 @@ from .exceptions import ConfigurationStoreError, StoreClientError
 
 TRANSFORM_TYPE = "json"
 
+MAX_AGE_DEFAULT_SECONDS = 5
+
 
 class AppConfigStore(StoreProvider):
     def __init__(
@@ -53,7 +55,7 @@ class AppConfigStore(StoreProvider):
         self.environment = environment
         self.application = application
         self.name = name
-        self.cache_seconds = 5 if max_age is None else max_age
+        self.cache_seconds = MAX_AGE_DEFAULT_SECONDS if max_age is None else max_age
         self.config = sdk_config
         self.envelope = envelope
         self.jmespath_options = jmespath_options

--- a/aws_lambda_powertools/utilities/feature_flags/appconfig.py
+++ b/aws_lambda_powertools/utilities/feature_flags/appconfig.py
@@ -20,7 +20,7 @@ class AppConfigStore(StoreProvider):
         environment: str,
         application: str,
         name: str,
-        max_age: int = 5,
+        max_age: Optional[int] = None,
         sdk_config: Optional[Config] = None,
         envelope: Optional[str] = "",
         jmespath_options: Optional[Dict] = None,
@@ -36,8 +36,9 @@ class AppConfigStore(StoreProvider):
             AppConfig application name, e.g. 'powertools'
         name: str
             AppConfig configuration name e.g. `my_conf`
-        max_age: int
-            cache expiration time in seconds, or how often to call AppConfig to fetch latest configuration
+        max_age: Optional[int]
+            cache expiration time in seconds, or how often to call AppConfig to fetch latest configuration.
+            Defaults to 5 seconds.
         sdk_config: Optional[Config]
             Botocore Config object to pass during client initialization
         envelope : Optional[str]
@@ -52,7 +53,7 @@ class AppConfigStore(StoreProvider):
         self.environment = environment
         self.application = application
         self.name = name
-        self.cache_seconds = max_age
+        self.cache_seconds = 5 if max_age is None else max_age
         self.config = sdk_config
         self.envelope = envelope
         self.jmespath_options = jmespath_options


### PR DESCRIPTION
In feature flags AppConfigStore, the max_age param is defined as optional with a default value but the type hint does not have optional. This caused me errors when enabling strict mypy configuration.