### PR TITLE
fix(metrics): flush upon a single metric 100th data point

### DIFF
--- a/aws_lambda_powertools/metrics/base.py
+++ b/aws_lambda_powertools/metrics/base.py
@@ -127,7 +127,7 @@ class MetricManager:
         logger.debug(f"Adding metric: {name} with {metric}")
         self.metric_set[name] = metric
 
-        if len(self.metric_set) == MAX_METRICS:
+        if len(self.metric_set) == MAX_METRICS or len(metric["Value"]) == MAX_METRICS:
             logger.debug(f"Exceeded maximum of {MAX_METRICS} metrics - Publishing existing metric set")
             metrics = self.serialize_metric_set()
             print(json.dumps(metrics))

--- a/tests/functional/test_metrics.py
+++ b/tests/functional/test_metrics.py
@@ -82,6 +82,11 @@ def a_hundred_metrics() -> List[Dict[str, str]]:
     return [{"name": f"metric_{i}", "unit": "Count", "value": 1} for i in range(100)]
 
 
+@pytest.fixture
+def a_hundred_metric_values() -> List[Dict[str, str]]:
+    return [{"name": "metric", "unit": "Count", "value": i} for i in range(100)]
+
+
 def serialize_metrics(
     metrics: List[Dict], dimensions: List[Dict], namespace: str, metadatas: List[Dict] = None
 ) -> Dict:
@@ -227,6 +232,37 @@ def test_metrics_spillover(monkeypatch, capsys, metric, dimension, namespace, a_
     expected_101th_metric = serialize_single_metric(metric=metric, dimension=dimension, namespace=namespace)
     remove_timestamp(metrics=[serialized_101th_metric, expected_101th_metric])
     assert serialized_101th_metric == expected_101th_metric
+
+
+def test_metric_values_spillover(monkeypatch, capsys, dimension, namespace, a_hundred_metric_values):
+    # GIVEN Metrics is initialized and we have over a hundred metric values to add
+    my_metrics = Metrics(namespace=namespace)
+    my_metrics.add_dimension(**dimension)
+    metric = a_hundred_metric_values[0]
+
+    # WHEN we add 100 metric values
+    for _metric in a_hundred_metric_values:
+        my_metrics.add_metric(**_metric)
+
+    # THEN it should serialize and flush the metric at the 100th value
+    # and clear all metrics and dimensions from memory
+    output = capture_metrics_output(capsys)
+    spillover_values = output[metric["name"]]
+    assert my_metrics.metric_set == {}
+    assert len(spillover_values) == 100
+
+    # GIVEN we add the 101st metric
+    # WHEN we already had a Metric class instance
+    # with an existing dimension set from the previous 100th metric batch
+    my_metrics.add_metric(**metric)
+
+    # THEN serializing the 101st value should
+    # create a new EMF object with a single value in it (101st)
+    # and contain the same dimension we previously added
+    serialized_101st_metric = my_metrics.serialize_metric_set()
+    expected_101st_metric = serialize_single_metric(metric=metric, dimension=dimension, namespace=namespace)
+    remove_timestamp(metrics=[serialized_101st_metric, expected_101st_metric])
+    assert serialized_101st_metric == expected_101st_metric
 
 
 def test_log_metrics_decorator_call_decorated_function(metric, namespace, service):


### PR DESCRIPTION
## Description of changes:

Per the [EMF spec](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch_Embedded_Metric_Format_Specification.html#CloudWatch_Embedded_Metric_Format_Specification_structure_target), metric value arrays must not have more than 100 elements. This PR ensures that metrics are serialized when a single metric collects 100 values in addition to the existing behavior of serializing when 100 metrics are collected.

Note: as far as I can see, this same change needs to be brought to the other Powertools languages as well. I'm not equipped nor have the skill to submit a PR for any language other than Python.

**Checklist**

<!--- Leave unchecked if your change doesn't seem to apply --> 

* [ ] [Meet tenets criteria](https://awslabs.github.io/aws-lambda-powertools-python/#tenets)
* [x] Update tests
* [ ] Update docs
* [x] PR title follows [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-python/blob/376ec0a2ac0d2a40e0af5717bef42ff84ca0d1b9/.github/semantic.yml#L2)

## Breaking change checklist

<!--- Ignore if it's not a breaking change -->

**RFC issue #**:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
