### PR TITLE
fix(lambda-authorizer): Propertly parse resource path

### DIFF
--- a/aws_lambda_powertools/utilities/data_classes/api_gateway_authorizer_event.py
+++ b/aws_lambda_powertools/utilities/data_classes/api_gateway_authorizer_event.py
@@ -60,7 +60,7 @@ def parse_api_gateway_arn(arn: str) -> APIGatewayRouteArn:
         api_id=api_gateway_arn_parts[0],
         stage=api_gateway_arn_parts[1],
         http_method=api_gateway_arn_parts[2],
-        resource=api_gateway_arn_parts[3] if len(api_gateway_arn_parts) == 4 else "",
+        resource="/".join(api_gateway_arn_parts[3:]) if len(api_gateway_arn_parts) >= 4 else "",
     )
 
 

--- a/tests/functional/data_classes/test_api_gateway_authorizer.py
+++ b/tests/functional/data_classes/test_api_gateway_authorizer.py
@@ -3,6 +3,7 @@ import pytest
 from aws_lambda_powertools.utilities.data_classes.api_gateway_authorizer_event import (
     DENY_ALL_RESPONSE,
     APIGatewayAuthorizerResponse,
+    APIGatewayAuthorizerTokenEvent,
     HttpVerb,
 )
 
@@ -195,3 +196,26 @@ def test_authorizer_response_allow_route_with_underscore(builder: APIGatewayAuth
             ],
         },
     }
+
+
+def test_parse_api_gateway_arn_with_resource():
+    mock_event = {
+        "type": "TOKEN",
+        "authorizationToken": "allow",
+        "methodArn": "arn:aws:execute-api:us-west-2:123456789012:ymy8tbxw7b/*/GET/foo/bar",
+    }
+    event = APIGatewayAuthorizerTokenEvent(mock_event)
+    event_arn = event.parsed_arn
+    assert "foo/bar" == event_arn.resource
+
+    authorizer_policy = APIGatewayAuthorizerResponse(
+        principal_id="fooPrinciple",
+        region=event_arn.region,
+        aws_account_id=event_arn.aws_account_id,
+        api_id=event_arn.api_id,
+        stage=event_arn.stage,
+    )
+    authorizer_policy.allow_route(http_method=event_arn.http_method, resource=event_arn.resource)
+    response = authorizer_policy.asdict()
+
+    assert mock_event["methodArn"] == response["policyDocument"]["Statement"][0]["Resource"][0]


### PR DESCRIPTION
**Issue #, if available:**

- 1047

## Description of changes:

Correctly parse method arn to include the full resource path ie: `arn:aws:execute-api:us-west-2:123456789012:ymy8tbxw7b/*/GET/foo/bar`

**Checklist**

<!--- Leave unchecked if your change doesn't seem to apply --> 

* [X] [Meet tenets criteria](https://awslabs.github.io/aws-lambda-powertools-python/#tenets)
* [X] Update tests
* [X] Update docs
* [X] PR title follows [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-python/blob/376ec0a2ac0d2a40e0af5717bef42ff84ca0d1b9/.github/semantic.yml#L2)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
