### PR TITLE
docs(parser): APIGatewayProxyEvent to APIGatewayProxyEventModel

### DIFF
--- a/docs/utilities/parser.md
+++ b/docs/utilities/parser.md
@@ -146,20 +146,20 @@ def my_function():
 
 Parser comes with the following built-in models:
 
-| Model name                 | Description                                                        |
-| -------------------------- | ------------------------------------------------------------------ |
-| **DynamoDBStreamModel**    | Lambda Event Source payload for Amazon DynamoDB Streams            |
-| **EventBridgeModel**       | Lambda Event Source payload for Amazon EventBridge                 |
-| **SqsModel**               | Lambda Event Source payload for Amazon SQS                         |
-| **AlbModel**               | Lambda Event Source payload for Amazon Application Load Balancer   |
-| **CloudwatchLogsModel**    | Lambda Event Source payload for Amazon CloudWatch Logs             |
-| **S3Model**                | Lambda Event Source payload for Amazon S3                          |
-| **S3ObjectLambdaEvent**    | Lambda Event Source payload for Amazon S3 Object Lambda            |
-| **KinesisDataStreamModel** | Lambda Event Source payload for Amazon Kinesis Data Streams        |
-| **SesModel**               | Lambda Event Source payload for Amazon Simple Email Service        |
-| **SnsModel**               | Lambda Event Source payload for Amazon Simple Notification Service |
-| **APIGatewayProxyEvent**   | Lambda Event Source payload for Amazon API Gateway                 |
-| **APIGatewayProxyEventV2Model**  | Lambda Event Source payload for Amazon API Gateway v2 payload |
+| Model name                       | Description                                                        |
+| ---------------------------------| ------------------------------------------------------------------ |
+| **DynamoDBStreamModel**          | Lambda Event Source payload for Amazon DynamoDB Streams            |
+| **EventBridgeModel**             | Lambda Event Source payload for Amazon EventBridge                 |
+| **SqsModel**                     | Lambda Event Source payload for Amazon SQS                         |
+| **AlbModel**                     | Lambda Event Source payload for Amazon Application Load Balancer   |
+| **CloudwatchLogsModel**          | Lambda Event Source payload for Amazon CloudWatch Logs             |
+| **S3Model**                      | Lambda Event Source payload for Amazon S3                          |
+| **S3ObjectLambdaEvent**          | Lambda Event Source payload for Amazon S3 Object Lambda            |
+| **KinesisDataStreamModel**       | Lambda Event Source payload for Amazon Kinesis Data Streams        |
+| **SesModel**                     | Lambda Event Source payload for Amazon Simple Email Service        |
+| **SnsModel**                     | Lambda Event Source payload for Amazon Simple Notification Service |
+| **APIGatewayProxyEventModel**    | Lambda Event Source payload for Amazon API Gateway                 |
+| **APIGatewayProxyEventV2Model**  | Lambda Event Source payload for Amazon API Gateway v2 payload      |
 
 ### extending built-in models
 

--- a/docs/utilities/parser.md
+++ b/docs/utilities/parser.md
@@ -146,20 +146,20 @@ def my_function():
 
 Parser comes with the following built-in models:
 
-| Model name                       | Description                                                        |
-| ---------------------------------| ------------------------------------------------------------------ |
-| **DynamoDBStreamModel**          | Lambda Event Source payload for Amazon DynamoDB Streams            |
-| **EventBridgeModel**             | Lambda Event Source payload for Amazon EventBridge                 |
-| **SqsModel**                     | Lambda Event Source payload for Amazon SQS                         |
-| **AlbModel**                     | Lambda Event Source payload for Amazon Application Load Balancer   |
-| **CloudwatchLogsModel**          | Lambda Event Source payload for Amazon CloudWatch Logs             |
-| **S3Model**                      | Lambda Event Source payload for Amazon S3                          |
-| **S3ObjectLambdaEvent**          | Lambda Event Source payload for Amazon S3 Object Lambda            |
-| **KinesisDataStreamModel**       | Lambda Event Source payload for Amazon Kinesis Data Streams        |
-| **SesModel**                     | Lambda Event Source payload for Amazon Simple Email Service        |
-| **SnsModel**                     | Lambda Event Source payload for Amazon Simple Notification Service |
-| **APIGatewayProxyEventModel**    | Lambda Event Source payload for Amazon API Gateway                 |
-| **APIGatewayProxyEventV2Model**  | Lambda Event Source payload for Amazon API Gateway v2 payload      |
+| Model name                        | Description                                                        |
+| --------------------------------- | ------------------------------------------------------------------ |
+| **DynamoDBStreamModel**           | Lambda Event Source payload for Amazon DynamoDB Streams            |
+| **EventBridgeModel**              | Lambda Event Source payload for Amazon EventBridge                 |
+| **SqsModel**                      | Lambda Event Source payload for Amazon SQS                         |
+| **AlbModel**                      | Lambda Event Source payload for Amazon Application Load Balancer   |
+| **CloudwatchLogsModel**           | Lambda Event Source payload for Amazon CloudWatch Logs             |
+| **S3Model**                       | Lambda Event Source payload for Amazon S3                          |
+| **S3ObjectLambdaEvent**           | Lambda Event Source payload for Amazon S3 Object Lambda            |
+| **KinesisDataStreamModel**        | Lambda Event Source payload for Amazon Kinesis Data Streams        |
+| **SesModel**                      | Lambda Event Source payload for Amazon Simple Email Service        |
+| **SnsModel**                      | Lambda Event Source payload for Amazon Simple Notification Service |
+| **APIGatewayProxyEventModel**     | Lambda Event Source payload for Amazon API Gateway                 |
+| **APIGatewayProxyEventV2Model**   | Lambda Event Source payload for Amazon API Gateway v2 payload      |
 
 ### extending built-in models
 


### PR DESCRIPTION
## Description of changes:

Fix the built-in model that is responsible for parsing events of API Gateway Proxy v1 to Lambda. Someone write that the built-in model is [`aws_lambda_powertools.utilities.data_classes.APIGatewayProxyEvent`](https://github.com/awslabs/aws-lambda-powertools-python/blob/22f8b9a7f47a2a4682c6f3f03536ac848ae7dc0d/aws_lambda_powertools/utilities/data_classes/api_gateway_proxy_event.py#L73), but, in fact, the right model for parsing using `event_parser` is [`aws_lambda_powertools.utilities.parser.models.APIGatewayProxyEventModel`](https://github.com/awslabs/aws-lambda-powertools-python/blob/22f8b9a7f47a2a4682c6f3f03536ac848ae7dc0d/aws_lambda_powertools/utilities/parser/models/apigw.py#L79).

When we try to use the wrong one (`APIGatewayProxyEvent`) in `event_parser`, it results in an error since it does not inherits `BaseModel` from `pydantic`.

**Checklist**

<!--- Leave unchecked if your change doesn't seem to apply --> 

* [x] [Meet tenets criteria](https://awslabs.github.io/aws-lambda-powertools-python/#tenets)
* [ ] Update tests
* [x] Update docs
* [x] PR title follows [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-python/blob/376ec0a2ac0d2a40e0af5717bef42ff84ca0d1b9/.github/semantic.yml#L2)

## Breaking change checklist

<!--- Ignore if it's not a breaking change -->

**RFC issue #**:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


-----
[View rendered docs/utilities/parser.md](https://github.com/darnley/aws-lambda-powertools-python/blob/patch-1/docs/utilities/parser.md) 