### PR TITLE
fix(middleware_factory): ret type annotation for handler dec

### DIFF
--- a/aws_lambda_powertools/middleware_factory/factory.py
+++ b/aws_lambda_powertools/middleware_factory/factory.py
@@ -1,18 +1,64 @@
 import functools
 import inspect
 import logging
+import sys
 import os
-from typing import Callable, Optional
+from typing import Any, Callable, Dict, Optional, Union, cast, overload
+
+if sys.version_info >= (3, 8):
+    from typing import Protocol
+else:
+    from typing_extensions import Protocol
 
 from ..shared import constants
 from ..shared.functions import resolve_truthy_env_var_choice
 from ..tracing import Tracer
+from ..utilities.typing import LambdaContext
 from .exceptions import MiddlewareInvalidArgumentError
 
 logger = logging.getLogger(__name__)
 
+# context: Any to avoid forcing users to type it as context: LambdaContext
+_Handler = Callable[[Any, LambdaContext], Any]
+_RawHandlerDecorator = Callable[[_Handler], _Handler]
 
-def lambda_handler_decorator(decorator: Optional[Callable] = None, trace_execution: Optional[bool] = None):
+
+class _FactoryDecorator(Protocol):
+    # it'd be better for this to be using ParamSpec (available from 3.10)
+    def __call__(
+        self, handler: _Handler, event: Dict[str, Any], context: LambdaContext, **kwargs: Any
+    ) -> _RawHandlerDecorator:
+        ...
+
+
+class _HandlerDecorator(Protocol):
+    @overload
+    def __call__(self, decorator: _Handler) -> _Handler:
+        ...
+
+    @overload
+    def __call__(self, decorator: None = None, **kwargs: Any) -> _RawHandlerDecorator:
+        ...
+
+    def __call__(self, decorator: Optional[_Handler] = None, **kwargs: Any) -> Union[_Handler, _RawHandlerDecorator]:
+        ...
+
+
+@overload
+def lambda_handler_decorator(decorator: _FactoryDecorator) -> _HandlerDecorator:
+    ...
+
+
+@overload
+def lambda_handler_decorator(
+    decorator: None = None, trace_execution: Optional[bool] = None
+) -> Callable[[_FactoryDecorator], _HandlerDecorator]:
+    ...
+
+
+def lambda_handler_decorator(
+    decorator: Optional[_FactoryDecorator] = None, trace_execution: Optional[bool] = None
+) -> Union[_HandlerDecorator, Callable[[_FactoryDecorator], _HandlerDecorator]]:
     """Decorator factory for decorating Lambda handlers.
 
     You can use lambda_handler_decorator to create your own middlewares,
@@ -103,19 +149,25 @@ def lambda_handler_decorator(decorator: Optional[Callable] = None, trace_executi
     """
 
     if decorator is None:
-        return functools.partial(lambda_handler_decorator, trace_execution=trace_execution)
+        return cast(
+            Callable[[_FactoryDecorator], _HandlerDecorator],
+            functools.partial(lambda_handler_decorator, trace_execution=trace_execution),
+        )
 
     trace_execution = resolve_truthy_env_var_choice(
         env=os.getenv(constants.MIDDLEWARE_FACTORY_TRACE_ENV, "false"), choice=trace_execution
     )
 
     @functools.wraps(decorator)
-    def final_decorator(func: Optional[Callable] = None, **kwargs):
+    def final_decorator(
+        func: Optional[_RawHandlerDecorator] = None, **kwargs: Any
+    ) -> Union[_Handler, _RawHandlerDecorator]:
         # If called with kwargs return new func with kwargs
         if func is None:
             return functools.partial(final_decorator, **kwargs)
 
         if not inspect.isfunction(func):
+            assert decorator is not None
             # @custom_middleware(True) vs @custom_middleware(log_event=True)
             raise MiddlewareInvalidArgumentError(
                 f"Only keyword arguments is supported for middlewares: {decorator.__qualname__} received {func}"  # type: ignore # noqa: E501
@@ -138,4 +190,4 @@ def lambda_handler_decorator(decorator: Optional[Callable] = None, trace_executi
 
         return wrapper
 
-    return final_decorator
+    return cast(_HandlerDecorator, final_decorator)

--- a/aws_lambda_powertools/middleware_factory/factory.py
+++ b/aws_lambda_powertools/middleware_factory/factory.py
@@ -12,7 +12,7 @@ from .exceptions import MiddlewareInvalidArgumentError
 logger = logging.getLogger(__name__)
 
 
-# giving this an accurate return type is hard
+# Maintenance: we can't yet provide an accurate return type without ParamSpec etc. see #1066
 def lambda_handler_decorator(decorator: Optional[Callable] = None, trace_execution: Optional[bool] = None) -> Callable:
     """Decorator factory for decorating Lambda handlers.
 


### PR DESCRIPTION
**Issue #, if available:** #1060 

## Description of changes:

This is two versions of typing `lambda_handler_decorator` more accurately for #1060, to ensure that middleware using it have a type. They end up with type `Callable[..., Any]` but that's better than nothing.

The first commit 937e6fe tries to be more accurate via overloads and protocols, but it doesn't work as written, and I cannot quite work out why. The errors below demonstrate the issues. It's potentially resolvable with 3.10's `ParamSpec` (I'm not sure `typing_extensions` depended upon for 3.8 and 3.8?):

<details><summary>Errors</summary>

```
aws_lambda_powertools/utilities/validation/validator.py:12:2: error: No overload variant of "lambda_handler_decorator" matches argument type "Callable[[Callable[..., Any], Union[Dict[Any, Any], str], Any, Optional[Dict[Any, Any]], Optional[Dict[Any, Any]], Optional[Dict[Any, Any]], Optional[Dict[Any, Any]], str, Optional[Dict[Any, Any]]], Any]"  [call-overload]
aws_lambda_powertools/utilities/validation/validator.py:12:2: note: Possible overload variants:
aws_lambda_powertools/utilities/validation/validator.py:12:2: note:     def lambda_handler_decorator(decorator: _FactoryDecorator) -> _HandlerDecorator
aws_lambda_powertools/utilities/validation/validator.py:12:2: note:     def lambda_handler_decorator(decorator: None = ..., trace_execution: Optional[bool] = ...) -> Callable[[_FactoryDecorator], _HandlerDecorator]
aws_lambda_powertools/utilities/parser/parser.py:14:2: error: No overload variant of "lambda_handler_decorator" matches argument type "Callable[[Callable[[Any, LambdaContext], EventParserReturnType], Dict[str, Any], LambdaContext, Type[Model], Optional[Type[Envelope]]], EventParserReturnType]"  [call-overload]
aws_lambda_powertools/utilities/parser/parser.py:14:2: note: Possible overload variants:
aws_lambda_powertools/utilities/parser/parser.py:14:2: note:     def lambda_handler_decorator(decorator: _FactoryDecorator) -> _HandlerDecorator
aws_lambda_powertools/utilities/parser/parser.py:14:2: note:     def lambda_handler_decorator(decorator: None = ..., trace_execution: Optional[bool] = ...) -> Callable[[_FactoryDecorator], _HandlerDecorator]
aws_lambda_powertools/utilities/idempotency/idempotency.py:20:2: error: No overload variant of "lambda_handler_decorator" matches argument type "Callable[[Callable[[Any, LambdaContext], Any], Dict[str, Any], LambdaContext, BasePersistenceLayer, Optional[IdempotencyConfig], KwArg(Any)], Any]"  [call-overload]
aws_lambda_powertools/utilities/idempotency/idempotency.py:20:2: note: Possible overload variants:
aws_lambda_powertools/utilities/idempotency/idempotency.py:20:2: note:     def lambda_handler_decorator(decorator: _FactoryDecorator) -> _HandlerDecorator
aws_lambda_powertools/utilities/idempotency/idempotency.py:20:2: note:     def lambda_handler_decorator(decorator: None = ..., trace_execution: Optional[bool] = ...) -> Callable[[_FactoryDecorator], _HandlerDecorator]
aws_lambda_powertools/utilities/data_classes/event_source.py:8:2: error: No overload variant of "lambda_handler_decorator" matches argument type "Callable[[Callable[[Any, LambdaContext], Any], Dict[str, Any], LambdaContext, Type[DictWrapper]], Any]"  [call-overload]
aws_lambda_powertools/utilities/data_classes/event_source.py:8:2: note: Possible overload variants:
aws_lambda_powertools/utilities/data_classes/event_source.py:8:2: note:     def lambda_handler_decorator(decorator: _FactoryDecorator) -> _HandlerDecorator
aws_lambda_powertools/utilities/data_classes/event_source.py:8:2: note:     def lambda_handler_decorator(decorator: None = ..., trace_execution: Optional[bool] = ...) -> Callable[[_FactoryDecorator], _HandlerDecorator]
aws_lambda_powertools/utilities/batch/base.py:156:2: error: No overload variant of "lambda_handler_decorator" matches argument type "Callable[[Callable[..., Any], Dict[Any, Any], Dict[Any, Any], Callable[..., Any], BasePartialProcessor], Any]"  [call-overload]
aws_lambda_powertools/utilities/batch/base.py:156:2: note: Possible overload variants:
aws_lambda_powertools/utilities/batch/base.py:156:2: note:     def lambda_handler_decorator(decorator: _FactoryDecorator) -> _HandlerDecorator
aws_lambda_powertools/utilities/batch/base.py:156:2: note:     def lambda_handler_decorator(decorator: None = ..., trace_execution: Optional[bool] = ...) -> Callable[[_FactoryDecorator], _HandlerDecorator]
aws_lambda_powertools/utilities/batch/sqs.py:179:2: error: No overload variant of "lambda_handler_decorator" matches argument type "Callable[[Callable[..., Any], Dict[Any, Any], Dict[Any, Any], Callable[..., Any], Optional[Any], bool, Optional[Any]], Any]"  [call-overload]
aws_lambda_powertools/utilities/batch/sqs.py:179:2: note: Possible overload variants:
aws_lambda_powertools/utilities/batch/sqs.py:179:2: note:     def lambda_handler_decorator(decorator: _FactoryDecorator) -> _HandlerDecorator
aws_lambda_powertools/utilities/batch/sqs.py:179:2: note:     def lambda_handler_decorator(decorator: None = ..., trace_execution: Optional[bool] = ...) -> Callable[[_FactoryDecorator], _HandlerDecorator]
```

</details>

**Checklist**

<!--- Leave unchecked if your change doesn't seem to apply --> 

* [x] [Meet tenets criteria](https://awslabs.github.io/aws-lambda-powertools-python/#tenets)
* [x] Update tests
* [x] Update docs
* [x] PR title follows [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-python/blob/376ec0a2ac0d2a40e0af5717bef42ff84ca0d1b9/.github/semantic.yml#L2)

## Breaking change checklist

<!--- Ignore if it's not a breaking change -->

**RFC issue #**:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
