### PR TITLE
docs(plugin): add mermaid to create diagram as code

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -77,9 +77,13 @@ markdown_extensions:
   - attr_list
   - pymdownx.emoji
   - pymdownx.inlinehilite
-  - pymdownx.superfences
+  - pymdownx.superfences:
+      custom_fences:
+        - name: mermaid
+          class: mermaid
+          format: !!python/name:pymdownx.superfences.fence_code_format
 
-copyright: Copyright &copy; 2021 Amazon Web Services
+copyright: Copyright &copy; 2022 Amazon Web Services
 
 plugins:
   - git-revision-date
@@ -95,3 +99,4 @@ extra:
   version:
     provider: mike
     default: latest
+


### PR DESCRIPTION
**Issue #, if available:** N/A but discussed directly with maintainers

## Description of changes:

This PR adds [the plugin](https://squidfunk.github.io/mkdocs-material/reference/diagrams/) that allows to use mermaid diagrams in the MKDocs documentation as discussed internally.

<img width="735" alt="image" src="https://user-images.githubusercontent.com/7353869/157209926-7b1e3688-2647-4b8c-bf9a-940b92e5f94e.png">

**Note**: the diagram above is provided only as an aid for review, it is not part of the actual commit.

Additionally I also updated the year in copyright notice that is in the footer of the docs to the correct year (it was still 2021).

**Checklist**

<!--- Leave unchecked if your change doesn't seem to apply --> 

* [x] [Meet tenets criteria](https://awslabs.github.io/aws-lambda-powertools-python/#tenets)
* [ ] Update tests
* [x] Update docs
* [x] PR title follows [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-python/blob/376ec0a2ac0d2a40e0af5717bef42ff84ca0d1b9/.github/semantic.yml#L2)

## Breaking change checklist

<!--- Ignore if it's not a breaking change -->

**RFC issue #**:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
