### PR TITLE
fix(logger): ensure state is cleared for custom formatters

### DIFF
--- a/aws_lambda_powertools/logging/formatter.py
+++ b/aws_lambda_powertools/logging/formatter.py
@@ -45,6 +45,7 @@ class BasePowertoolsFormatter(logging.Formatter, metaclass=ABCMeta):
     def remove_keys(self, keys: Iterable[str]):
         raise NotImplementedError()
 
+    @abstractmethod
     def clear_state(self):
         """Removes any previously added logging keys"""
         raise NotImplementedError()

--- a/aws_lambda_powertools/logging/formatter.py
+++ b/aws_lambda_powertools/logging/formatter.py
@@ -45,6 +45,10 @@ class BasePowertoolsFormatter(logging.Formatter, metaclass=ABCMeta):
     def remove_keys(self, keys: Iterable[str]):
         raise NotImplementedError()
 
+    def clear_state(self):
+        """Removes any previously added logging keys"""
+        raise NotImplementedError()
+
 
 class LambdaPowertoolsFormatter(BasePowertoolsFormatter):
     """AWS Lambda Powertools Logging formatter.
@@ -179,6 +183,9 @@ class LambdaPowertoolsFormatter(BasePowertoolsFormatter):
     def remove_keys(self, keys: Iterable[str]):
         for key in keys:
             self.log_format.pop(key, None)
+
+    def clear_state(self):
+        self.log_format = dict.fromkeys(self.log_record_order)
 
     @staticmethod
     def _build_default_keys():

--- a/aws_lambda_powertools/logging/logger.py
+++ b/aws_lambda_powertools/logging/logger.py
@@ -450,9 +450,6 @@ class Logger(logging.Logger):  # lgtm [py/missing-call-to-init]
         caller_frame = frame.f_back.f_back.f_back
         return caller_frame.f_globals["__name__"]
 
-    def _reset_logger_state(self):
-        self.registered_formatter.clear_state()
-
 
 def set_package_logger(
     level: Union[str, int] = logging.DEBUG,

--- a/aws_lambda_powertools/logging/logger.py
+++ b/aws_lambda_powertools/logging/logger.py
@@ -386,28 +386,25 @@ class Logger(logging.Logger):  # lgtm [py/missing-call-to-init]
             append keys provided to logger formatter, by default False
         """
         # There are 3 operational modes for this method
-        ## 1. Append new keys to the current logger formatter; deprecated in favour of append_keys
-        ## 2. Register a Powertools Formatter for the first time
+        ## 1. Register a Powertools Formatter for the first time
+        ## 2. Append new keys to the current logger formatter; deprecated in favour of append_keys
         ## 3. Add new keys and discard existing to the registered formatter
 
-        if append:
-            # Maintenance: Add deprecation warning for major version
-            return self.append_keys(**keys)
-
+        # Mode 1
         log_keys = {**self._default_log_keys, **keys}
-
-        # Behaviour 2
         is_logger_preconfigured = getattr(self._logger, "init", False)
         if not is_logger_preconfigured:
             formatter = self.logger_formatter or LambdaPowertoolsFormatter(**log_keys)  # type: ignore
             return self.registered_handler.setFormatter(formatter)
 
-        # Behaviour 3
-        try:
-            self.registered_formatter.clear_state()
-            self.registered_formatter.append_keys(**log_keys)
-        except (AttributeError, NotImplementedError):
-            logger.warning(f"Formatter {self.registered_formatter} doesn't implement clear_state method; ignoring...")
+        # Mode 2 (legacy)
+        if append:
+            # Maintenance: Add deprecation warning for major version
+            return self.append_keys(**keys)
+
+        # Mode 3
+        self.registered_formatter.clear_state()
+        self.registered_formatter.append_keys(**log_keys)
 
     def set_correlation_id(self, value: Optional[str]):
         """Sets the correlation_id in the logging json

--- a/tests/functional/test_logger.py
+++ b/tests/functional/test_logger.py
@@ -525,6 +525,9 @@ def test_logger_custom_formatter(stdout, service_name, lambda_context):
             for key in keys:
                 self.custom_format.pop(key, None)
 
+        def clear_state(self):
+            self.custom_format.clear()
+
         def format(self, record: logging.LogRecord) -> str:  # noqa: A003
             return json.dumps(
                 {


### PR DESCRIPTION
**Issue #, if available:** #1042

## Description of changes:

This ensures custom logger formatters receive Lambda context keys and their state can be cleared upon each invocation when using `clear_state`. This PR also takes into account those using `log_record_order` with custom formatters, if the state is ever cleared.

The reason we use an `abstractmethod` is to ensure all functionalities (as docs suggested) will work for the ~1% of customers creating highly customized loggers that can work in more than Lambda environments. We initially thought in having warnings but given this is a bug behavior and the extreme edge case, it makes it worthwhile to enforce it early and improve documentation on use cases for `LambdaPowertoolsFormatter` (common, no change required) vs `BasePowertoolsFormatter` (edge case).

<!--- One or two sentences as a summary of what's being changed -->

**Checklist**

<!--- Leave unchecked if your change doesn't seem to apply --> 

* [x] [Meet tenets criteria](https://awslabs.github.io/aws-lambda-powertools-python/#tenets)
* [x] Update tests
* [ ] Update docs
* [x] PR title follows [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-python/blob/376ec0a2ac0d2a40e0af5717bef42ff84ca0d1b9/.github/semantic.yml#L2)

## Breaking change checklist

<!--- Ignore if it's not a breaking change -->

**RFC issue #**:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
