### PR TITLE
fix(logger): Ensure external loggers doesn't propagate logs

### DIFF
--- a/aws_lambda_powertools/logging/utils.py
+++ b/aws_lambda_powertools/logging/utils.py
@@ -3,6 +3,8 @@ from typing import Callable, List, Optional, Set, Union
 
 from .logger import Logger
 
+PACKAGE_LOGGER = "aws_lambda_powertools"
+
 
 def copy_config_to_registered_loggers(
     source_logger: Logger,
@@ -24,7 +26,6 @@ def copy_config_to_registered_loggers(
     exclude : Optional[Set[str]], optional
         List of logger names to exclude, by default None
     """
-    package_logger = logging.getLogger("aws_lambda_powertools")
     level = log_level or source_logger.level
 
     # Assumptions: Only take parent loggers not children (dot notation rule)
@@ -36,9 +37,9 @@ def copy_config_to_registered_loggers(
 
     # Exclude source and powertools package logger by default
     if exclude:
-        exclude.update(source_logger.name, package_logger.name)
+        exclude.update(source_logger.name, PACKAGE_LOGGER)
     else:
-        exclude = {source_logger.name, package_logger.name}
+        exclude = {source_logger.name, PACKAGE_LOGGER}
 
     # Prepare loggers set
     if include:

--- a/aws_lambda_powertools/logging/utils.py
+++ b/aws_lambda_powertools/logging/utils.py
@@ -38,7 +38,7 @@ def copy_config_to_registered_loggers(
     # Exclude source and powertools package logger by default
     # If source logger is a child ensure we exclude parent logger to not break child logger
     # from receiving/pushing updates to keys being added/removed
-    source_logger_name = source_logger.name.split(".")[0] if source_logger.child else source_logger.name
+    source_logger_name = source_logger.name.split(".")[0]
 
     if exclude:
         exclude.update(source_logger_name, PACKAGE_LOGGER)

--- a/aws_lambda_powertools/logging/utils.py
+++ b/aws_lambda_powertools/logging/utils.py
@@ -36,10 +36,14 @@ def copy_config_to_registered_loggers(
     # 4. Only exclude set? Ignore Logger in the excluding list
 
     # Exclude source and powertools package logger by default
+    # If source logger is a child ensure we exclude parent logger to not break child logger
+    # from receiving/pushing updates to keys being added/removed
+    source_logger_name = source_logger.name.split(".")[0] if source_logger.child else source_logger.name
+
     if exclude:
-        exclude.update(source_logger.name, PACKAGE_LOGGER)
+        exclude.update(source_logger_name, PACKAGE_LOGGER)
     else:
-        exclude = {source_logger.name, PACKAGE_LOGGER}
+        exclude = {source_logger_name, PACKAGE_LOGGER}
 
     # Prepare loggers set
     if include:

--- a/aws_lambda_powertools/logging/utils.py
+++ b/aws_lambda_powertools/logging/utils.py
@@ -75,7 +75,7 @@ def _find_registered_loggers(
 def _configure_logger(source_logger: Logger, logger: logging.Logger, level: Union[int, str]) -> None:
     logger.handlers = []
     logger.setLevel(level)
-    logger.propagate = False
+    logger.propagate = False  # ensure we don't propagate logs to existing loggers, #1073
     source_logger.debug(f"Logger {logger} reconfigured to use logging level {level}")
     for source_handler in source_logger.handlers:
         logger.addHandler(source_handler)

--- a/tests/functional/test_logger_utils.py
+++ b/tests/functional/test_logger_utils.py
@@ -6,7 +6,6 @@ import string
 from enum import Enum
 
 import pytest
-from pytest_mock import MockerFixture
 
 from aws_lambda_powertools import Logger
 from aws_lambda_powertools.logging import formatter, utils
@@ -45,6 +44,7 @@ def capture_multiple_logging_statements_output(stdout):
     return [json.loads(line.strip()) for line in stdout.getvalue().split("\n") if line]
 
 
+@pytest.fixture
 def service_name():
     chars = string.ascii_letters + string.digits
     return "".join(random.SystemRandom().choice(chars) for _ in range(15))

--- a/tests/functional/test_logger_utils.py
+++ b/tests/functional/test_logger_utils.py
@@ -44,7 +44,6 @@ def capture_multiple_logging_statements_output(stdout):
     return [json.loads(line.strip()) for line in stdout.getvalue().split("\n") if line]
 
 
-@pytest.fixture
 def service_name():
     chars = string.ascii_letters + string.digits
     return "".join(random.SystemRandom().choice(chars) for _ in range(15))

--- a/tests/functional/test_logger_utils.py
+++ b/tests/functional/test_logger_utils.py
@@ -195,35 +195,6 @@ def test_copy_config_to_ext_loggers_should_not_break_append_keys(stdout, log_lev
     powertools_logger.append_keys(key="value")
 
 
-def test_copy_config_to_ext_loggers_child_loggers_append_before_work(stdout):
-    # GIVEN powertools logger AND  child initialized AND
-
-    # GIVEN Loggers are initialized
-    # create child logger before parent to mimick
-    # importing logger from another module/file
-    # as loggers are created in global scope
-    service = service_name()
-    child = Logger(stream=stdout, service=service, child=True)
-    parent = Logger(stream=stdout, service=service)
-
-    # WHEN a child Logger adds an additional key AND parent logger adds additional key
-    child.structure_logs(append=True, customer_id="value")
-    parent.structure_logs(append=True, user_id="value")
-    # WHEN configuration copied from powertools logger
-    # AND powertools logger and child logger used
-    utils.copy_config_to_registered_loggers(source_logger=parent)
-    parent.warning("Logger message")
-    child.warning("Child logger message")
-
-    # THEN payment_id key added to both powertools logger and child logger
-    parent_log, child_log = capture_multiple_logging_statements_output(stdout)
-    assert "customer_id" in parent_log
-    assert "customer_id" in child_log
-    assert "user_id" in parent_log
-    assert "user_id" in child_log
-    assert child.parent.name == service
-
-
 def test_copy_config_to_ext_loggers_child_loggers_append_after_works(stdout):
     # GIVEN powertools logger AND  child initialized AND
 

--- a/tests/functional/test_logger_utils.py
+++ b/tests/functional/test_logger_utils.py
@@ -195,37 +195,6 @@ def test_copy_config_to_ext_loggers_should_not_break_append_keys(stdout, log_lev
     powertools_logger.append_keys(key="value")
 
 
-def test_copy_child_config_to_ext_loggers_should_not_break_append_keys(stdout):
-    # GIVEN powertools logger AND  child initialized AND
-
-    # GIVEN Loggers are initialized
-    # create child logger before parent to mimick
-    # importing logger from another module/file
-    # as loggers are created in global scope
-    service = service_name()
-    child = Logger(stream=stdout, service=service, child=True)
-    parent = Logger(stream=stdout, service=service)
-
-    # WHEN a child Logger adds an additional key AND child logger adds additional key
-    # AND configuration copied from powertools child logger
-    # AND powertools logger and child logger used
-    child.structure_logs(append=True, customer_id="value")
-    parent.structure_logs(append=True, user_id="value")
-    utils.copy_config_to_registered_loggers(source_logger=child)
-    parent.warning("Logger message")
-    child.warning("Child logger message")
-
-    # THEN both custom keys should be propagated bi-directionally in parent and child loggers
-    # as parent logger won't be touched when config is being copied
-    parent_log, child_log = capture_multiple_logging_statements_output(stdout)
-    assert "customer_id" in parent_log
-    assert "customer_id" in child_log
-    assert "user_id" in parent_log
-    assert "user_id" in child_log
-    assert "Child Logger message" not in parent_log
-    assert child.parent.name == service
-
-
 def test_copy_config_to_parent_loggers_only(stdout):
     # GIVEN Powertools Logger and Child Logger are initialized
     # and Powertools Logger config is copied over

--- a/tests/functional/test_logger_utils.py
+++ b/tests/functional/test_logger_utils.py
@@ -260,7 +260,7 @@ def test_copy_config_to_ext_loggers_no_duplicate_logs(stdout, logger, log_level)
     handler = logging.StreamHandler(stdout)
     formatter = logging.Formatter('{"message": "%(message)s"}')
     handler.setFormatter(formatter)
-    root_logger.handlers = [handler]
+    root_logger.addHandler(handler)
 
     logger = logger()
 
@@ -275,5 +275,5 @@ def test_copy_config_to_ext_loggers_no_duplicate_logs(stdout, logger, log_level)
 
     # THEN no root logger logs AND log is not duplicated
     logs = capture_multiple_logging_statements_output(stdout)
-    assert not {"message": msg} in logs
+    assert {"message": msg} not in logs
     assert sum(msg in log.values() for log in logs) == 1


### PR DESCRIPTION
**Issue #, if available:**

https://github.com/awslabs/aws-lambda-powertools-python/issues/1073

## Description of changes:

Ensure external loggers doesn't propagate logs to root logger by disabling Propagate attribute. Previously event was emitted in external logger ( with powertools handler) and in root handler IF propagation was set to True. This change ensure log is only emitted by external logger handler.

Also, during debugging noticed that we don't exclude `aws_lambda_powertools`  from handler modification since this is root powertools package we might treat it as internal package and skip applying powertools logger handler. @heitorlessa  please correct me if I'm wrong here 

**Checklist**

<!--- Leave unchecked if your change doesn't seem to apply --> 

* [x] [Meet tenets criteria](https://awslabs.github.io/aws-lambda-powertools-python/#tenets)
* [x] Update tests
* [ ] Update docs
* [x] PR title follows [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-python/blob/376ec0a2ac0d2a40e0af5717bef42ff84ca0d1b9/.github/semantic.yml#L2)

## Breaking change checklist

<!--- Ignore if it's not a breaking change -->

**RFC issue #**:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
