### PR TITLE
docs(install): instructions to reduce pydantic package size

### DIFF
--- a/docs/utilities/parser.md
+++ b/docs/utilities/parser.md
@@ -15,7 +15,7 @@ This utility provides data parsing and deep validation using [Pydantic](https://
 
 ???+ warning
 
-    This will increase the compressed package size by approximately 25MB due to the Pydantic dependency.
+    This will increase the compressed package size by >10MB due to the Pydantic dependency.
 
     To reduce the impact on the package size at the expense of 30%-50% of its performance [Pydantic can also be
     installed without binary files](https://pydantic-docs.helpmanual.io/install/#performance-vs-package-size-trade-off):

--- a/docs/utilities/parser.md
+++ b/docs/utilities/parser.md
@@ -14,7 +14,13 @@ This utility provides data parsing and deep validation using [Pydantic](https://
 **Extra dependency**
 
 ???+ warning
-    This will increase the overall package size by approximately 75MB due to Pydantic dependency.
+
+    This will increase the compressed package size by approximately 25MB due to the Pydantic dependency.
+
+    To reduce the impact on the package size at the expense of 30%-50% of its performance [Pydantic can also be
+    installed without binary files](https://pydantic-docs.helpmanual.io/install/#performance-vs-package-size-trade-off):
+
+    `SKIP_CYTHON=1 pip install --no-binary pydantic aws-lambda-powertools[pydantic]`
 
 Install parser's extra dependencies using **`pip install aws-lambda-powertools[pydantic]`**.
 


### PR DESCRIPTION
Issue, if available: #1078

Pydantic can be installed without binary files. This significantly
reduces the additional size it adds to the compressed Lambda packages
(down to 2MB from 25MB) at the expense of 30%-50% of its performance.

While at it I also updated the amount of megabyte Pydantic adds to the
package, as it wasn't clear if the stated number referred to compressed
or uncompressed package size and I couldn't reproduce the 75MB either
way.

**Checklist**

* [ ] [Meet tenets criteria](https://awslabs.github.io/aws-lambda-powertools-python/#tenets)
* [ ] Update tests
* [x] Update docs
* [x] PR title follows [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-python/blob/376ec0a2ac0d2a40e0af5717bef42ff84ca0d1b9/.github/semantic.yml#L2)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


-----
[View rendered docs/utilities/parser.md](https://github.com/yomagroup/aws-lambda-powertools-python/blob/docs-pydantic-without-binary-files/docs/utilities/parser.md)