### PR TITLE
fix(logger-utils): regression on exclude set leading to no formatter

### DIFF
--- a/aws_lambda_powertools/logging/utils.py
+++ b/aws_lambda_powertools/logging/utils.py
@@ -41,7 +41,7 @@ def copy_config_to_registered_loggers(
     source_logger_name = source_logger.name.split(".")[0]
 
     if exclude:
-        exclude.update(source_logger_name, PACKAGE_LOGGER)
+        exclude.update([source_logger_name, PACKAGE_LOGGER])
     else:
         exclude = {source_logger_name, PACKAGE_LOGGER}
 

--- a/tests/functional/test_logger_utils.py
+++ b/tests/functional/test_logger_utils.py
@@ -217,6 +217,28 @@ def test_copy_config_to_parent_loggers_only(stdout):
     assert child.parent.name == service
 
 
+def test_copy_config_to_parent_loggers_only_with_exclude(stdout):
+    # GIVEN Powertools Logger and Child Logger are initialized
+    # and Powertools Logger config is copied over with exclude set
+    service = service_name()
+    child = Logger(stream=stdout, service=service, child=True)
+    parent = Logger(stream=stdout, service=service)
+    utils.copy_config_to_registered_loggers(source_logger=parent, exclude={"test"})
+
+    # WHEN either parent or child logger append keys
+    child.append_keys(customer_id="value")
+    parent.append_keys(user_id="value")
+    parent.info("Logger message")
+    child.info("Child logger message")
+
+    # THEN both custom keys should be propagated bi-directionally in parent and child loggers
+    # as child logger won't be touched when config is being copied
+    parent_log, child_log = capture_multiple_logging_statements_output(stdout)
+    assert "customer_id" in parent_log, child_log
+    assert "user_id" in parent_log, child_log
+    assert child.parent.name == service
+
+
 def test_copy_config_to_ext_loggers_no_duplicate_logs(stdout, logger, log_level):
     # GIVEN an root logger, external logger and powertools logger initialized
 


### PR DESCRIPTION
**Issue #, if available:**

https://github.com/awslabs/aws-lambda-powertools-python/issues/1073

## Description of changes:

Ensure proper loggers are excluded from config propagation

**Checklist**

<!--- Leave unchecked if your change doesn't seem to apply --> 

* [x] [Meet tenets criteria](https://awslabs.github.io/aws-lambda-powertools-python/#tenets)
* [x] Update tests
* [ ] Update docs
* [x] PR title follows [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-python/blob/376ec0a2ac0d2a40e0af5717bef42ff84ca0d1b9/.github/semantic.yml#L2)

## Breaking change checklist

<!--- Ignore if it's not a breaking change -->

**RFC issue #**:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
