### PR TITLE
fix: bump mkdocs-material to latest to avoid breaking documentation builds

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -573,7 +573,7 @@ mkdocs = ">=0.17"
 
 [[package]]
 name = "mkdocs-material"
-version = "8.2.4"
+version = "8.2.6"
 description = "A Material Design theme for MkDocs"
 category = "dev"
 optional = false
@@ -1353,8 +1353,8 @@ mkdocs-git-revision-date-plugin = [
     {file = "mkdocs_git_revision_date_plugin-0.3.1-py3-none-any.whl", hash = "sha256:8ae50b45eb75d07b150a69726041860801615aae5f4adbd6b1cf4d51abaa03d5"},
 ]
 mkdocs-material = [
-    {file = "mkdocs-material-8.2.4.tar.gz", hash = "sha256:3c350a03e2f7288874f0a9cf5aacfbbb8721cc7d4e389b53169180ee2187223e"},
-    {file = "mkdocs_material-8.2.4-py2.py3-none-any.whl", hash = "sha256:7aa9ed562f68c8592dad3f568378c98a2350398445dbf46de373585b3cd9080e"},
+    {file = "mkdocs-material-8.2.6.tar.gz", hash = "sha256:be76ba3e0c0d4482159fc2c00d060dbf22cfb29f25276ebd0db9a0eaf6a18712"},
+    {file = "mkdocs_material-8.2.6-py2.py3-none-any.whl", hash = "sha256:b30b4cfe5b0a74cccf2c75b7127c22cd8d816e6260c9a8708c3baf08c59e6714"},
 ]
 mkdocs-material-extensions = [
     {file = "mkdocs-material-extensions-1.0.3.tar.gz", hash = "sha256:bfd24dfdef7b41c312ede42648f9eb83476ea168ec163b613f9abd12bbfddba2"},


### PR DESCRIPTION
**Issue #, if available:**

## Description of changes:

`mkdocs-material` just released a new version ([8.2.7](https://github.com/squidfunk/mkdocs-material/releases/tag/8.2.7)) in response to a deprecation notice of a dependency (`jinja2` - see [issue from mkdocs-material repo](https://github.com/mkdocs/mkdocs/issues/2794)) that was breaking builds ([example from Powertools for TS repo](https://github.com/awslabs/aws-lambda-powertools-typescript/actions/runs/2034859221)).

Although this repo hasn't encountered the issue yet, it will most likely experience failed docs builds due to the issue above, this is a preemptive fix to avoid that.

**Checklist**

<!--- Leave unchecked if your change doesn't seem to apply --> 

* [x] [Meet tenets criteria](https://awslabs.github.io/aws-lambda-powertools-python/#tenets)
* [ ] Update tests
* [ ] Update docs
* [x] PR title follows [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-python/blob/376ec0a2ac0d2a40e0af5717bef42ff84ca0d1b9/.github/semantic.yml#L2)

## Breaking change checklist

<!--- Ignore if it's not a breaking change -->

**RFC issue #**:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
