### PR TITLE
fix(logger): clear_state regression on absent standard keys

### DIFF
--- a/aws_lambda_powertools/logging/formatter.py
+++ b/aws_lambda_powertools/logging/formatter.py
@@ -187,6 +187,7 @@ class LambdaPowertoolsFormatter(BasePowertoolsFormatter):
 
     def clear_state(self):
         self.log_format = dict.fromkeys(self.log_record_order)
+        self.log_format.update(**self._build_default_keys())
 
     @staticmethod
     def _build_default_keys():

--- a/tests/functional/test_logger.py
+++ b/tests/functional/test_logger.py
@@ -675,10 +675,12 @@ def test_clear_state_keeps_standard_keys(lambda_context, stdout, service_name):
 
     # THEN all standard keys should be available as usual
     handler({}, lambda_context)
+    handler({}, lambda_context)
 
-    log = capture_logging_output(stdout)
+    first_log, second_log = capture_multiple_logging_statements_output(stdout)
     for key in standard_keys:
-        assert key in log
+        assert key in first_log
+        assert key in second_log
 
 
 def test_clear_state_keeps_exception_keys(lambda_context, stdout, service_name):

--- a/tests/functional/test_logger.py
+++ b/tests/functional/test_logger.py
@@ -663,6 +663,42 @@ def test_clear_state_on_inject_lambda_context(lambda_context, stdout, service_na
     assert "my_key" not in second_log
 
 
+def test_clear_state_keeps_standard_keys(lambda_context, stdout, service_name):
+    # GIVEN
+    logger = Logger(service=service_name, stream=stdout)
+    standard_keys = ["level", "location", "message", "timestamp", "service"]
+
+    # WHEN clear_state is set
+    @logger.inject_lambda_context(clear_state=True)
+    def handler(event, context):
+        logger.info("Foo")
+
+    # THEN all standard keys should be available as usual
+    handler({}, lambda_context)
+
+    log = capture_logging_output(stdout)
+    for key in standard_keys:
+        assert key in log
+
+
+def test_clear_state_keeps_exception_keys(lambda_context, stdout, service_name):
+    # GIVEN
+    logger = Logger(service=service_name, stream=stdout)
+
+    # WHEN clear_state is set and an exception was logged
+    @logger.inject_lambda_context(clear_state=True)
+    def handler(event, context):
+        try:
+            raise ValueError("something went wrong")
+        except Exception:
+            logger.exception("Received an exception")
+
+    # THEN we expect a "exception_name" to be "ValueError"
+    handler({}, lambda_context)
+    log = capture_logging_output(stdout)
+    assert "ValueError" == log["exception_name"]
+
+
 def test_inject_lambda_context_allows_handler_with_kwargs(lambda_context, stdout, service_name):
     # GIVEN
     logger = Logger(service=service_name, stream=stdout)


### PR DESCRIPTION
**Issue #, if available:** #1084 #1087

## Description of changes:

<!--- One or two sentences as a summary of what's being changed -->

When using `clear_state=True`, standard logging keys like `level, location, timestamp` are no longer being preserved. This is a regression introduced in 1.25.3, when fixing custom formatters for clear_state behaviour. Our tests weren't robust enough for clear_state - this PR adds additional tests to cover gaps we had.

Issue was that when `clear_state=True` was used, the default keys (level, location, timestamp) weren't being re-added as part of a new `clear_state` method for LambdaPowertoolsFormatter implemented in 1.25.3, hence the regression.

```
{
            "level": "%(levelname)s",
            "location": "%(funcName)s:%(lineno)d",
            "timestamp": "%(asctime)s",
}
```

**Checklist**

<!--- Leave unchecked if your change doesn't seem to apply --> 

* [x] [Meet tenets criteria](https://awslabs.github.io/aws-lambda-powertools-python/#tenets)
* [x] Update tests
* [ ] Update docs
* [x] PR title follows [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-python/blob/376ec0a2ac0d2a40e0af5717bef42ff84ca0d1b9/.github/semantic.yml#L2)

## Breaking change checklist

<!--- Ignore if it's not a breaking change -->

**RFC issue #**:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
