### PR TITLE
fix(idempotency): pass by value on idem key to guard inadvert mutations

### DIFF
--- a/aws_lambda_powertools/utilities/idempotency/base.py
+++ b/aws_lambda_powertools/utilities/idempotency/base.py
@@ -1,5 +1,6 @@
 import logging
 from typing import Any, Callable, Dict, Optional, Tuple
+from copy import deepcopy
 
 from aws_lambda_powertools.utilities.idempotency.config import IdempotencyConfig
 from aws_lambda_powertools.utilities.idempotency.exceptions import (
@@ -69,7 +70,7 @@ class IdempotencyHandler:
             Function keyword arguments
         """
         self.function = function
-        self.data = _prepare_data(function_payload)
+        self.data = deepcopy(_prepare_data(function_payload))
         self.fn_args = function_args
         self.fn_kwargs = function_kwargs
 

--- a/tests/functional/idempotency/conftest.py
+++ b/tests/functional/idempotency/conftest.py
@@ -14,7 +14,8 @@ from aws_lambda_powertools.utilities.idempotency import DynamoDBPersistenceLayer
 from aws_lambda_powertools.utilities.idempotency.idempotency import IdempotencyConfig
 from aws_lambda_powertools.utilities.jmespath_utils import extract_data_from_envelope
 from aws_lambda_powertools.utilities.validation import envelopes
-from tests.functional.utils import hash_idempotency_key, json_serialize, load_event
+from tests.functional.idempotency.utils import hash_idempotency_key
+from tests.functional.utils import json_serialize, load_event
 
 TABLE_NAME = "TEST_TABLE"
 

--- a/tests/functional/idempotency/test_idempotency.py
+++ b/tests/functional/idempotency/test_idempotency.py
@@ -22,7 +22,12 @@ from aws_lambda_powertools.utilities.idempotency.exceptions import (
 from aws_lambda_powertools.utilities.idempotency.idempotency import idempotent, idempotent_function
 from aws_lambda_powertools.utilities.idempotency.persistence.base import BasePersistenceLayer, DataRecord
 from aws_lambda_powertools.utilities.validation import envelopes, validator
-from tests.functional.utils import hash_idempotency_key, json_serialize, load_event
+from tests.functional.idempotency.utils import (
+    build_idempotency_put_item_stub,
+    build_idempotency_update_item_stub,
+    hash_idempotency_key,
+)
+from tests.functional.utils import json_serialize, load_event
 
 TABLE_NAME = "TEST_TABLE"
 
@@ -274,36 +279,36 @@ def test_idempotent_lambda_first_execution_cached(
     stubber.assert_no_pending_responses()
     stubber.deactivate()
 
-@pytest.mark.parametrize("idempotency_config", [{"use_local_cache": False}, {"use_local_cache": True}], indirect=True)
+
+@pytest.mark.parametrize("idempotency_config", [{"use_local_cache": True, "event_key_jmespath": "body"}], indirect=True)
 def test_idempotent_lambda_first_execution_event_mutation(
     idempotency_config: IdempotencyConfig,
     persistence_store: DynamoDBPersistenceLayer,
     lambda_apigw_event,
-    expected_params_update_item,
-    expected_params_put_item,
     lambda_response,
-    serialized_lambda_response,
-    deserialized_lambda_response,
-    hashed_idempotency_key,
     lambda_context,
 ):
     """
-    Test idempotent decorator where lambda_handler mutates the event
+    Test idempotent decorator where lambda_handler mutates the event.
+    Ensures we're passing data by value, not reference.
     """
-
+    event = copy.deepcopy(lambda_apigw_event)
     stubber = stub.Stubber(persistence_store.table.meta.client)
     ddb_response = {}
-
-    stubber.add_response("put_item", ddb_response, expected_params_put_item)
-    stubber.add_response("update_item", ddb_response, expected_params_update_item)
+    stubber.add_response("put_item", ddb_response, build_idempotency_put_item_stub(data=event["body"]))
+    stubber.add_response(
+        "update_item",
+        ddb_response,
+        build_idempotency_update_item_stub(data=event["body"], handler_response=lambda_response),
+    )
     stubber.activate()
 
     @idempotent(config=idempotency_config, persistence_store=persistence_store)
     def lambda_handler(event, context):
-        event.popitem()
+        event.pop("body")  # remove exact key we're using for idempotency
         return lambda_response
 
-    lambda_handler(lambda_apigw_event, lambda_context)
+    lambda_handler(event, lambda_context)
 
     stubber.assert_no_pending_responses()
     stubber.deactivate()

--- a/tests/functional/idempotency/utils.py
+++ b/tests/functional/idempotency/utils.py
@@ -1,0 +1,45 @@
+import hashlib
+from typing import Any, Dict
+
+from botocore import stub
+
+from tests.functional.utils import json_serialize
+
+
+def hash_idempotency_key(data: Any):
+    """Serialize data to JSON, encode, and hash it for idempotency key"""
+    return hashlib.md5(json_serialize(data).encode()).hexdigest()
+
+
+def build_idempotency_put_item_stub(
+    data: Dict, function_name: str = "test-func", handler_name: str = "lambda_handler"
+) -> Dict:
+    idempotency_key_hash = f"{function_name}.{handler_name}#{hash_idempotency_key(data)}"
+    return {
+        "ConditionExpression": "attribute_not_exists(#id) OR #now < :now",
+        "ExpressionAttributeNames": {"#id": "id", "#now": "expiration"},
+        "ExpressionAttributeValues": {":now": stub.ANY},
+        "Item": {"expiration": stub.ANY, "id": idempotency_key_hash, "status": "INPROGRESS"},
+        "TableName": "TEST_TABLE",
+    }
+
+
+def build_idempotency_update_item_stub(
+    data: Dict,
+    handler_response: Dict,
+    function_name: str = "test-func",
+    handler_name: str = "lambda_handler",
+) -> Dict:
+    idempotency_key_hash = f"{function_name}.{handler_name}#{hash_idempotency_key(data)}"
+    serialized_lambda_response = json_serialize(handler_response)
+    return {
+        "ExpressionAttributeNames": {"#expiry": "expiration", "#response_data": "data", "#status": "status"},
+        "ExpressionAttributeValues": {
+            ":expiry": stub.ANY,
+            ":response_data": serialized_lambda_response,
+            ":status": "COMPLETED",
+        },
+        "Key": {"id": idempotency_key_hash},
+        "TableName": "TEST_TABLE",
+        "UpdateExpression": "SET #response_data = :response_data, " "#expiry = :expiry, #status = :status",
+    }

--- a/tests/functional/utils.py
+++ b/tests/functional/utils.py
@@ -1,5 +1,4 @@
 import base64
-import hashlib
 import json
 from pathlib import Path
 from typing import Any
@@ -22,8 +21,3 @@ def b64_to_str(data: str) -> str:
 
 def json_serialize(data):
     return json.dumps(data, sort_keys=True, cls=Encoder)
-
-
-def hash_idempotency_key(data: Any):
-    """Serialize data to JSON, encode, and hash it for idempotency key"""
-    return hashlib.md5(json_serialize(data).encode()).hexdigest()


### PR DESCRIPTION
This protects against functions that inadvertently change the incoming event data

## Description of changes:

Switch to using a deep copy of data. Without this, we've seen two documents written for one function invocation that (inadvertently) mutated the event data:

* An _initial_ document with a hashed idempotency key _based on the original payload_ that will be stuck in INPROGRESS and has no return data
* A _second_ document with a hashed idempotency key _based on the mutated payload_ with status COMPLETED and the correct return value

Happy to add a test if there is an appetite for this change.

**Checklist**

* [ ] [Meet tenets criteria](https://awslabs.github.io/aws-lambda-powertools-python/#tenets)
* [x] Update tests
* [ ] Update docs
* [x] PR title follows [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-python/blob/376ec0a2ac0d2a40e0af5717bef42ff84ca0d1b9/.github/semantic.yml#L2)
