### PR TITLE
fix(logger): clear_state should keep custom key formats

### DIFF
--- a/aws_lambda_powertools/logging/formatter.py
+++ b/aws_lambda_powertools/logging/formatter.py
@@ -127,8 +127,8 @@ class LambdaPowertoolsFormatter(BasePowertoolsFormatter):
 
         super(LambdaPowertoolsFormatter, self).__init__(datefmt=self.datefmt)
 
-        keys_combined = {**self._build_default_keys(), **kwargs}
-        self.log_format.update(**keys_combined)
+        self.keys_combined = {**self._build_default_keys(), **kwargs}
+        self.log_format.update(**self.keys_combined)
 
     def serialize(self, log: Dict) -> str:
         """Serialize structured log dict to JSON str"""
@@ -187,7 +187,7 @@ class LambdaPowertoolsFormatter(BasePowertoolsFormatter):
 
     def clear_state(self):
         self.log_format = dict.fromkeys(self.log_record_order)
-        self.log_format.update(**self._build_default_keys())
+        self.log_format.update(**self.keys_combined)
 
     @staticmethod
     def _build_default_keys():

--- a/tests/functional/test_logger.py
+++ b/tests/functional/test_logger.py
@@ -685,9 +685,8 @@ def test_clear_state_keeps_standard_keys(lambda_context, stdout, service_name):
 
 def test_clear_state_keeps_custom_keys(lambda_context, stdout, service_name):
     # GIVEN
-    date_format = "%Y"
-    location_format = "%(module)s:%(funcName)s:%(lineno)d"
-    logger = Logger(service=service_name, stream=stdout, location=location_format, datefmt=date_format)
+    location_format = "%(module)s.%(funcName)s:clear_state"
+    logger = Logger(service=service_name, stream=stdout, location=location_format, custom_key="foo")
 
     # WHEN clear_state is set
     @logger.inject_lambda_context(clear_state=True)
@@ -699,11 +698,9 @@ def test_clear_state_keeps_custom_keys(lambda_context, stdout, service_name):
     handler({}, lambda_context)
 
     first_log, second_log = capture_multiple_logging_statements_output(stdout)
-
-    assert re.fullmatch("[0-9]{4}", first_log["timestamp"])
-    assert re.fullmatch("[0-9]{4}", second_log["timestamp"])
-    assert re.fullmatch(".+:.+:[0-9]+", first_log["location"])
-    assert re.fullmatch(".+:.+:[0-9]+", second_log["location"])
+    for log in (first_log, second_log):
+        assert "foo" == log["custom_key"]
+        assert "test_logger.handler:clear_state" == log["location"]
 
 
 def test_clear_state_keeps_exception_keys(lambda_context, stdout, service_name):


### PR DESCRIPTION
**Issue #, if available:** #1084

## Description of changes:

When using `clear_state=True`, overriden formats for standard logging keys like `location` and `timestamp` was being overriden with the default formats.  Overriding the formats are explained in the docs like this:

```python
from aws_lambda_powertools import Logger

date_format = "%m/%d/%Y %I:%M:%S %p"
location_format = "[%(funcName)s] %(module)s"

# override location and timestamp format
logger = Logger(service="payment", location=location_format, datefmt=date_format)
```

Issue was that when `clear_state=True` was used, the default keys were reset to their defaults (by the fix implemented in #1088). This fix saves the formatting keys on instantiation and uses those instead when `clear_state` is called.

<!--- One or two sentences as a summary of what's being changed -->

**Checklist**

<!--- Leave unchecked if your change doesn't seem to apply --> 

* [x] [Meet tenets criteria](https://awslabs.github.io/aws-lambda-powertools-python/#tenets)
* [x] Update tests
* [ ] Update docs
* [x] PR title follows [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-python/blob/376ec0a2ac0d2a40e0af5717bef42ff84ca0d1b9/.github/semantic.yml#L2)

## Breaking change checklist

<!--- Ignore if it's not a breaking change -->

**RFC issue #**:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
