### PR TITLE
fix(api_gateway): allow whitespace in routes' path parameter

### DIFF
--- a/aws_lambda_powertools/event_handler/api_gateway.py
+++ b/aws_lambda_powertools/event_handler/api_gateway.py
@@ -26,7 +26,7 @@ logger = logging.getLogger(__name__)
 _DYNAMIC_ROUTE_PATTERN = r"(<\w+>)"
 _SAFE_URI = "-._~()'!*:@,;"  # https://www.ietf.org/rfc/rfc3986.txt
 # API GW/ALB decode non-safe URI chars; we must support them too
-_UNSAFE_URI = "%<>\[\]{}|^"  # noqa: W605
+_UNSAFE_URI = "%<> \[\]{}|^"  # noqa: W605
 _NAMED_GROUP_BOUNDARY_PATTERN = fr"(?P\1[{_SAFE_URI}{_UNSAFE_URI}\\w]+)"
 
 

--- a/tests/functional/event_handler/test_api_gateway.py
+++ b/tests/functional/event_handler/test_api_gateway.py
@@ -688,12 +688,12 @@ def test_similar_dynamic_routes():
     # r'^/accounts/(?P<account_id>\\w+\\b)$' # noqa: E800
     @app.get("/accounts/<account_id>")
     def get_account(account_id: str):
-        assert account_id == "single_account"
+        assert account_id in ("single_account", "single account")
 
     # r'^/accounts/(?P<account_id>\\w+\\b)/source_networks$' # noqa: E800
     @app.get("/accounts/<account_id>/source_networks")
     def get_account_networks(account_id: str):
-        assert account_id == "nested_account"
+        assert account_id in ("nested_account", "nested account")
 
     # r'^/accounts/(?P<account_id>\\w+\\b)/source_networks/(?P<network_id>\\w+\\b)$' # noqa: E800
     @app.get("/accounts/<account_id>/source_networks/<network_id>")
@@ -706,8 +706,16 @@ def test_similar_dynamic_routes():
     event["path"] = "/accounts/single_account"
     app.resolve(event, None)
 
+    event["resource"] = "/accounts/{account_id}"
+    event["path"] = "/accounts/single account"
+    app.resolve(event, None)
+
     event["resource"] = "/accounts/{account_id}/source_networks"
     event["path"] = "/accounts/nested_account/source_networks"
+    app.resolve(event, None)
+
+    event["resource"] = "/accounts/{account_id}/source_networks"
+    event["path"] = "/accounts/nested account/source_networks"
     app.resolve(event, None)
 
     event["resource"] = "/accounts/{account_id}/source_networks/{network_id}"

--- a/tests/functional/event_handler/test_api_gateway.py
+++ b/tests/functional/event_handler/test_api_gateway.py
@@ -740,15 +740,15 @@ def test_similar_dynamic_routes_with_whitespaces():
     # THEN
     event["resource"] = "/accounts/{account_id}"
     event["path"] = "/accounts/single account"
-    app.resolve(event, None)
+    assert app.resolve(event, {})["statusCode"] == 200
 
     event["resource"] = "/accounts/{account_id}/source_networks"
     event["path"] = "/accounts/nested account/source_networks"
-    app.resolve(event, None)
+    assert app.resolve(event, {})["statusCode"] == 200
 
     event["resource"] = "/accounts/{account_id}/source_networks/{network_id}"
     event["path"] = "/accounts/nested account/source_networks/network 123"
-    app.resolve(event, {})
+    assert app.resolve(event, {})["statusCode"] == 200
 
 
 @pytest.mark.parametrize(

--- a/tests/functional/event_handler/test_api_gateway.py
+++ b/tests/functional/event_handler/test_api_gateway.py
@@ -688,12 +688,12 @@ def test_similar_dynamic_routes():
     # r'^/accounts/(?P<account_id>\\w+\\b)$' # noqa: E800
     @app.get("/accounts/<account_id>")
     def get_account(account_id: str):
-        assert account_id in ("single_account", "single account")
+        assert account_id == "single_account"
 
     # r'^/accounts/(?P<account_id>\\w+\\b)/source_networks$' # noqa: E800
     @app.get("/accounts/<account_id>/source_networks")
     def get_account_networks(account_id: str):
-        assert account_id in ("nested_account", "nested account")
+        assert account_id == "nested_account"
 
     # r'^/accounts/(?P<account_id>\\w+\\b)/source_networks/(?P<network_id>\\w+\\b)$' # noqa: E800
     @app.get("/accounts/<account_id>/source_networks/<network_id>")
@@ -706,12 +706,40 @@ def test_similar_dynamic_routes():
     event["path"] = "/accounts/single_account"
     app.resolve(event, None)
 
-    event["resource"] = "/accounts/{account_id}"
-    event["path"] = "/accounts/single account"
-    app.resolve(event, None)
-
     event["resource"] = "/accounts/{account_id}/source_networks"
     event["path"] = "/accounts/nested_account/source_networks"
+    app.resolve(event, None)
+
+    event["resource"] = "/accounts/{account_id}/source_networks/{network_id}"
+    event["path"] = "/accounts/nested_account/source_networks/network"
+    app.resolve(event, {})
+
+
+def test_similar_dynamic_routes_with_whitespaces():
+    # GIVEN
+    app = ApiGatewayResolver()
+    event = deepcopy(LOAD_GW_EVENT)
+
+    # WHEN
+    # r'^/accounts/(?P<account_id>\\w+\\b)$' # noqa: E800
+    @app.get("/accounts/<account_id>")
+    def get_account(account_id: str):
+        assert account_id == "single account"
+
+    # r'^/accounts/(?P<account_id>\\w+\\b)/source_networks$' # noqa: E800
+    @app.get("/accounts/<account_id>/source_networks")
+    def get_account_networks(account_id: str):
+        assert account_id == "nested account"
+
+    # r'^/accounts/(?P<account_id>\\w+\\b)/source_networks/(?P<network_id>\\w+\\b)$' # noqa: E800
+    @app.get("/accounts/<account_id>/source_networks/<network_id>")
+    def get_network_account(account_id: str, network_id: str):
+        assert account_id == "nested account"
+        assert network_id == "network 123"
+
+    # THEN
+    event["resource"] = "/accounts/{account_id}"
+    event["path"] = "/accounts/single account"
     app.resolve(event, None)
 
     event["resource"] = "/accounts/{account_id}/source_networks"
@@ -719,7 +747,7 @@ def test_similar_dynamic_routes():
     app.resolve(event, None)
 
     event["resource"] = "/accounts/{account_id}/source_networks/{network_id}"
-    event["path"] = "/accounts/nested_account/source_networks/network"
+    event["path"] = "/accounts/nested account/source_networks/network 123"
     app.resolve(event, {})
 
 


### PR DESCRIPTION
**Issue number:** #1098

## Summary

### Changes

> Please provide a summary of what's being changed

Updated the `_UNSAFE_URI` constant to support whitespace in path parameter

### User experience

> Please share what the user experience looks like before and after this change

User facing nothing changed

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] [Meet tenets criteria](https://awslabs.github.io/aws-lambda-powertools-python/#tenets)
* [x] I have performed a self-review of my this change
* [x] Changes are tested
* [ ] Changes are documented
* [x] PR title follows [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-python/blob/376ec0a2ac0d2a40e0af5717bef42ff84ca0d1b9/.github/semantic.yml#L2)


<details>
<summary>Is this a breaking change?</summary>

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
