### PR TITLE
fix: fix labels in issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -56,10 +56,10 @@ body:
     attributes:
       label: AWS Lambda function runtime
       options:
-        - label: "3.6"
-        - label: "3.7"
-        - label: "3.8"
-        - label: "3.9"
+        - 3.6
+        - 3.7
+        - 3.8
+        - 3.9
     validations:
       required: true
   - type: dropdown
@@ -67,9 +67,9 @@ body:
     attributes:
       label: Packaging format used
       options:
-        - label: "Lambda Layers"
-        - label: "Serverless Application Repository (SAR) App"
-        - label: "PyPi"
+        - Lambda Layers
+        - Serverless Application Repository (SAR) App
+        - PyPi
       multiple: true
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/rfc.yml
+++ b/.github/ISSUE_TEMPLATE/rfc.yml
@@ -17,22 +17,22 @@ body:
     attributes:
       label: Which AWS Lambda Powertools utility does this relate to?
       options:
-        - label: "Tracer"
-        - label: "Logger"
-        - label: "Metrics"
-        - label: "Event Handler - REST API"
-        - label: "Event Handler - GraphQL API"
-        - label: "Middleware factory"
-        - label: "Parameters"
-        - label: "Batch processing"
-        - label: "Typing"
-        - label: "Validation"
-        - label: "Event Source Data Classes"
-        - label: "Parser"
-        - label: "Idempotency"
-        - label: "Feature flags"
-        - label: "JMESPath functions"
-        - label: "Other"
+        - Tracer
+        - Logger
+        - Metrics
+        - Event Handler - REST API
+        - Event Handler - GraphQL API
+        - Middleware factory
+        - Parameters
+        - Batch processing
+        - Typing
+        - Validation
+        - Event Source Data Classes
+        - Parser
+        - Idempotency
+        - Feature flags
+        - JMESPath functions
+        - Other
     validations:
       required: true
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/static_typing.yml
+++ b/.github/ISSUE_TEMPLATE/static_typing.yml
@@ -14,10 +14,10 @@ body:
     attributes:
       label: Static type checker used
       options:
-        - label: "mypy (project's standard)"
-        - label: "pyright/pylance"
-        - label: "pyre"
-        - label: "pytype"
+        - mypy (project's standard)
+        - pyright/pylance
+        - pyre
+        - pytype
     validations:
       required: true
   - type: dropdown
@@ -25,10 +25,10 @@ body:
     attributes:
       label: AWS Lambda function runtime
       options:
-        - label: "3.6"
-        - label: "3.7"
-        - label: "3.8"
-        - label: "3.9"
+        - 3.6
+        - 3.7
+        - 3.8
+        - 3.9
     validations:
       required: true
   - type: input


### PR DESCRIPTION
**Issue number:**

- #1105

## Summary

Fixes the drops dow the issue templates

### Changes

> Please provide a summary of what's being changed

Update dropdown format to be matching the GitHub docs:
- https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/syntax-for-issue-forms

### User experience

> Please share what the user experience looks like before and after this change

Drop downs now match what the user should be capturing.

<img width="369" alt="Screen Shot 2022-04-10 at 5 09 10 PM" src="https://user-images.githubusercontent.com/5442469/162645909-575e7b35-4f9e-4611-ac53-ec95d1dfa600.png">


## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [X] [Meet tenets criteria](https://awslabs.github.io/aws-lambda-powertools-python/#tenets)
* [x] I have performed a self-review of my this change
* [x] Changes are tested
* [ ] Changes are documented
* [x] PR title follows [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-python/blob/376ec0a2ac0d2a40e0af5717bef42ff84ca0d1b9/.github/semantic.yml#L2)


<details>
<summary>Is this a breaking change?</summary>

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
