### PR TITLE
fix(docs): Extract typing code examples

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -90,3 +90,10 @@ changelog:
 
 mypy:
 	poetry run mypy --pretty aws_lambda_powertools
+
+format-examples:
+	poetry run isort docs/examples
+	poetry run black docs/examples/*/*/*.py
+
+lint-examples:
+	poetry run python3 -m py_compile docs/examples/*/*/*.py

--- a/docs/examples/utilities/typing/lambda_context.py
+++ b/docs/examples/utilities/typing/lambda_context.py
@@ -1,0 +1,8 @@
+from typing import Any, Dict
+
+from aws_lambda_powertools.utilities.typing import LambdaContext
+
+
+def handler(event: Dict[str, Any], context: LambdaContext) -> Dict[str, Any]:
+    # Insert business logic
+    return event

--- a/docs/utilities/typing.md
+++ b/docs/utilities/typing.md
@@ -11,11 +11,6 @@ This typing utility provides static typing classes that can be used to ease the 
 
 The `LambdaContext` typing is typically used in the handler method for the Lambda function.
 
-```python hl_lines="4" title="Annotating Lambda context type"
-from typing import Any, Dict
-from aws_lambda_powertools.utilities.typing import LambdaContext
-
-def handler(event: Dict[str, Any], context: LambdaContext) -> Dict[str, Any]:
-	# Insert business logic
-	return event
+```python hl_lines="6" title="Annotating Lambda context type"
+--8<-- "docs/examples/utilities/typing/lambda_context.py"
 ```


### PR DESCRIPTION
**Issue number:**

- #1064

## Summary

Extract the code example for the typing utility documentation

### Changes

> Please provide a summary of what's being changed

Changes:
- Extract code example
- Run isort and black
- Update line highlight
- Add make task for formatting and linting

### User experience

> Please share what the user experience looks like before and after this change

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] [Meet tenets criteria](https://awslabs.github.io/aws-lambda-powertools-python/#tenets)
* [x] I have performed a self-review of my this change
* [x] Changes are tested
* [x] Changes are documented
* [x] PR title follows [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-python/blob/376ec0a2ac0d2a40e0af5717bef42ff84ca0d1b9/.github/semantic.yml#L2)


<details>
<summary>Is this a breaking change?</summary>

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
