### PR TITLE
fix(deps-dev): remove jmespath due to dev deps conflict 

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -454,14 +454,6 @@ optional = false
 python-versions = ">=2.6, !=3.0.*, !=3.1.*, !=3.2.*"
 
 [[package]]
-name = "jmespath"
-version = "1.0.0"
-description = "JSON Matching Expressions"
-category = "main"
-optional = false
-python-versions = ">=3.7"
-
-[[package]]
 name = "mako"
 version = "1.1.6"
 description = "A super-fast templating language that borrows the  best ideas from the existing templating languages."
@@ -1064,7 +1056,7 @@ pydantic = ["pydantic", "email-validator"]
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.6.2"
-content-hash = "3d40b3b49476872ab8c7a42aaf8b9b10ee8f62e42004b0a9ee0c08a493776394"
+content-hash = "cc5db7165ea118a9f4f3999ddb380839d16d10765d869ec2565cff6d8c78e616"
 
 [metadata.files]
 atomicwrites = [
@@ -1256,8 +1248,6 @@ jinja2 = [
 jmespath = [
     {file = "jmespath-0.10.0-py2.py3-none-any.whl", hash = "sha256:cdf6525904cc597730141d61b36f2e4b8ecc257c420fa2f4549bac2c2d0cb72f"},
     {file = "jmespath-0.10.0.tar.gz", hash = "sha256:b85d0567b8666149a93172712e68920734333c0ce7e89b78b3e987f71e5ed4f9"},
-    {file = "jmespath-1.0.0-py3-none-any.whl", hash = "sha256:e8dcd576ed616f14ec02eed0005c85973b5890083313860136657e24784e4c04"},
-    {file = "jmespath-1.0.0.tar.gz", hash = "sha256:a490e280edd1f57d6de88636992d05b71e97d69a26a19f058ecf7d304474bf5e"},
 ]
 mako = [
     {file = "Mako-1.1.6-py2.py3-none-any.whl", hash = "sha256:afaf8e515d075b22fad7d7b8b30e4a1c90624ff2f3733a06ec125f5a5f043a57"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,8 @@ pydantic = {version = "^1.8.2", optional = true }
 email-validator = {version = "*", optional = true }
 
 [tool.poetry.dev-dependencies]
+# 2022-04-21: jmespath was removed, to be re-added once we drop python 3.6.
+# issue #1148
 coverage = {extras = ["toml"], version = "^6.2"}
 pytest = "^7.0.1"
 black = "^21.12b0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,10 +24,6 @@ python = "^3.6.2"
 aws-xray-sdk = "^2.8.0"
 fastjsonschema = "^2.14.5"
 boto3 = "^1.18"
-jmespath = [
-  { version = "<=0.10.0", python = "3.6" },
-  { version = "^1.0.0", python = "^3.7" }
-]
 pydantic = {version = "^1.8.2", optional = true }
 email-validator = {version = "*", optional = true }
 


### PR DESCRIPTION
**Issue number:**
#1147 

## Summary
Removes JMESPath to allow downstream deps to solve this.

### Changes

> Please provide a summary of what's being changed

Removes JMESPath dependency from `pyproject.toml`

### User experience

> Please share what the user experience looks like before and after this change

See issue (#1147)

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [X] [Meet tenets criteria](https://awslabs.github.io/aws-lambda-powertools-python/#tenets)
* [X] I have performed a self-review of my this change
* [X] Changes are tested
* [X] Changes are documented
* [X] PR title follows [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-python/blob/376ec0a2ac0d2a40e0af5717bef42ff84ca0d1b9/.github/semantic.yml#L2)


<details>
<summary>Is this a breaking change?</summary>

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
