### PR TITLE
fix(deps): ignore boto3 updates until needed

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,6 +17,10 @@ updates:
     commit-message:
       prefix: chore
       include: scope
+    ignore:
+      # 2022-04-23: Ignoring boto3 changes until we need to care about them.
+      - dependency-name: "boto3"
+        
 
 #   - package-ecosystem: "pip"
 #     directory: "/"


### PR DESCRIPTION
adds a ignore to dependabot to stop adding boto3 pull requests

## Summary

### Changes

> Please provide a summary of what's being changed

Adds an ignore to dependabot for the boto3 module

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [X] [Meet tenets criteria](https://awslabs.github.io/aws-lambda-powertools-python/#tenets)
* [X] I have performed a self-review of my this change
* [X] Changes are tested
* [X] Changes are documented
* [X] PR title follows [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-python/blob/376ec0a2ac0d2a40e0af5717bef42ff84ca0d1b9/.github/semantic.yml#L2)

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
