### PR TITLE
feat(event_handler): Allow cookies in response

### DIFF
--- a/tests/functional/event_handler/test_api_gateway.py
+++ b/tests/functional/event_handler/test_api_gateway.py
@@ -1258,3 +1258,35 @@ def test_event_source_compatibility():
     # THEN
     result = handler(load_event("apiGatewayProxyV2Event.json"), None)
     assert result["statusCode"] == 200
+
+
+def test_api_gateway_http_cookie():
+    # GIVEN
+    app = APIGatewayHttpResolver()
+
+    @app.post("/my/path")
+    def my_path() -> Response:
+        return Response(200, content_types.TEXT_PLAIN, "Test", cookies=["key=value"])
+
+    # WHEN
+    result = app(load_event("apiGatewayProxyV2Event.json"), {})
+
+    # THEN
+    assert result["headers"]["Content-Type"] == content_types.TEXT_PLAIN
+    assert result["cookies"] == ["key=value"]
+
+
+def test_api_gateway_rest_cookie():
+    # GIVEN
+    app = APIGatewayRestResolver()
+
+    @app.get("/my/path")
+    def get_lambda() -> Response:
+        return Response(200, content_types.TEXT_PLAIN, "Test", cookies=["foo=bar"])
+
+    # WHEN
+    result = app(LOAD_GW_EVENT, {})
+
+    # THEN
+    assert result["headers"]["Content-Type"] == content_types.TEXT_PLAIN
+    assert result["multiValueHeaders"]["Set-Cookie"] == ["foo=bar"]


### PR DESCRIPTION
**Issue number:**

- #1192

## Summary

### Changes

> Please provide a summary of what's being changed

- Add cookies field in Response
- For http api gateway format 2.0 responses serialize to cookies
- For alb and rest api use multiValueHeaders

### User experience

> Please share what the user experience looks like before and after this change

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] [Meet tenets criteria](https://awslabs.github.io/aws-lambda-powertools-python/#tenets)
* [x] I have performed a self-review of my this change
* [x] Changes are tested
* [x] Changes are documented
* [x] PR title follows [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-python/blob/376ec0a2ac0d2a40e0af5717bef42ff84ca0d1b9/.github/semantic.yml#L2)


<details>
<summary>Is this a breaking change?</summary>

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
