### PR TITLE
fix(parameters): accept boto3_client to support private endpoints

### DIFF
--- a/aws_lambda_powertools/utilities/parameters/appconfig.py
+++ b/aws_lambda_powertools/utilities/parameters/appconfig.py
@@ -30,7 +30,9 @@ class AppConfigProvider(BaseProvider):
     config: botocore.config.Config, optional
         Botocore configuration to pass during client initialization
     boto3_session : boto3.session.Session, optional
-            Boto3 session to use for AWS API communication
+            Boto3 session to use for AWS API communication, will not be used if boto3_client is not None
+    boto3_client: AppConfigClient, optional
+            Boto3 Client to use for AWS API communication, will be used instead of boto3_session if both provided
 
     Example
     -------
@@ -68,14 +70,19 @@ class AppConfigProvider(BaseProvider):
         application: Optional[str] = None,
         config: Optional[Config] = None,
         boto3_session: Optional[boto3.session.Session] = None,
+        boto3_client=None,
     ):
         """
         Initialize the App Config client
         """
 
         config = config or Config()
-        session = boto3_session or boto3.session.Session()
-        self.client = session.client("appconfig", config=config)
+        if boto3_client is not None:
+            self.client = boto3_client
+        else:
+            session = boto3_session or boto3.session.Session()
+            self.client = session.client("appconfig", config=config)
+
         self.application = resolve_env_var_choice(
             choice=application, env=os.getenv(constants.SERVICE_NAME_ENV, "service_undefined")
         )

--- a/aws_lambda_powertools/utilities/parameters/appconfig.py
+++ b/aws_lambda_powertools/utilities/parameters/appconfig.py
@@ -76,12 +76,7 @@ class AppConfigProvider(BaseProvider):
         Initialize the App Config client
         """
 
-        config = config or Config()
-        if boto3_client is not None:
-            self.client = boto3_client
-        else:
-            session = boto3_session or boto3.session.Session()
-            self.client = session.client("appconfig", config=config)
+        self.client = self._build_boto3_client("appconfig", boto3_client, boto3_session, config)
 
         self.application = resolve_env_var_choice(
             choice=application, env=os.getenv(constants.SERVICE_NAME_ENV, "service_undefined")

--- a/aws_lambda_powertools/utilities/parameters/base.py
+++ b/aws_lambda_powertools/utilities/parameters/base.py
@@ -9,6 +9,9 @@ from collections import namedtuple
 from datetime import datetime, timedelta
 from typing import Any, Dict, Optional, Tuple, Union
 
+import boto3
+from botocore.config import Config
+
 from .exceptions import GetParameterError, TransformParameterError
 
 DEFAULT_MAX_AGE_SECS = 5
@@ -179,6 +182,20 @@ class BaseProvider(ABC):
 
     def clear_cache(self):
         self.store.clear()
+
+    @staticmethod
+    def _build_boto3_client(
+        service_name: str,
+        client: Optional[Any],
+        session: Optional[boto3.Session],
+        config: Optional[Config],
+    ):
+        if client is not None:
+            return client
+
+        session = session or boto3.Session()
+        config = config or Config()
+        return session.client(service_name=service_name, config=config)
 
 
 def get_transform_method(key: str, transform: Optional[str] = None) -> Optional[str]:

--- a/aws_lambda_powertools/utilities/parameters/secrets.py
+++ b/aws_lambda_powertools/utilities/parameters/secrets.py
@@ -69,12 +69,7 @@ class SecretsProvider(BaseProvider):
         Initialize the Secrets Manager client
         """
 
-        config = config or Config()
-        if boto3_client is not None:
-            self.client = boto3_client
-        else:
-            session = boto3_session or boto3.session.Session()
-            self.client = session.client("secretsmanager", config=config)
+        self.client = self._build_boto3_client("secretsmanager", boto3_client, boto3_session, config)
 
         super().__init__()
 

--- a/aws_lambda_powertools/utilities/parameters/secrets.py
+++ b/aws_lambda_powertools/utilities/parameters/secrets.py
@@ -20,7 +20,9 @@ class SecretsProvider(BaseProvider):
     config: botocore.config.Config, optional
         Botocore configuration to pass during client initialization
     boto3_session : boto3.session.Session, optional
-            Boto3 session to use for AWS API communication
+            Boto3 session to use for AWS API communication, will not be used if boto3_client is not None
+    boto3_client: SecretsManagerClient, optional
+            Boto3 Client to use for AWS API communication, will be used instead of boto3_session if both provided
 
     Example
     -------
@@ -60,14 +62,19 @@ class SecretsProvider(BaseProvider):
 
     client: Any = None
 
-    def __init__(self, config: Optional[Config] = None, boto3_session: Optional[boto3.session.Session] = None):
+    def __init__(
+        self, config: Optional[Config] = None, boto3_session: Optional[boto3.session.Session] = None, boto3_client=None
+    ):
         """
         Initialize the Secrets Manager client
         """
 
         config = config or Config()
-        session = boto3_session or boto3.session.Session()
-        self.client = session.client("secretsmanager", config=config)
+        if boto3_client is not None:
+            self.client = boto3_client
+        else:
+            session = boto3_session or boto3.session.Session()
+            self.client = session.client("secretsmanager", config=config)
 
         super().__init__()
 

--- a/aws_lambda_powertools/utilities/parameters/ssm.py
+++ b/aws_lambda_powertools/utilities/parameters/ssm.py
@@ -85,12 +85,7 @@ class SSMProvider(BaseProvider):
         Initialize the SSM Parameter Store client
         """
 
-        config = config or Config()
-        if boto3_client is not None:
-            self.client = boto3_client
-        else:
-            session = boto3_session or boto3.session.Session()
-            self.client = session.client("ssm", config=config)
+        self.client = self._build_boto3_client("ssm", boto3_client, boto3_session, config)
 
         super().__init__()
 

--- a/aws_lambda_powertools/utilities/parameters/ssm.py
+++ b/aws_lambda_powertools/utilities/parameters/ssm.py
@@ -20,7 +20,9 @@ class SSMProvider(BaseProvider):
     config: botocore.config.Config, optional
         Botocore configuration to pass during client initialization
     boto3_session : boto3.session.Session, optional
-            Boto3 session to use for AWS API communication
+            Boto3 session to use for AWS API communication, will not be used if boto3_client is not None
+    boto3_client: SSMClient, optional
+            Boto3 Client to use for AWS API communication, will be used instead of boto3_session if both provided
 
     Example
     -------
@@ -76,14 +78,19 @@ class SSMProvider(BaseProvider):
 
     client: Any = None
 
-    def __init__(self, config: Optional[Config] = None, boto3_session: Optional[boto3.session.Session] = None):
+    def __init__(
+        self, config: Optional[Config] = None, boto3_session: Optional[boto3.session.Session] = None, boto3_client=None
+    ):
         """
         Initialize the SSM Parameter Store client
         """
 
         config = config or Config()
-        session = boto3_session or boto3.session.Session()
-        self.client = session.client("ssm", config=config)
+        if boto3_client is not None:
+            self.client = boto3_client
+        else:
+            session = boto3_session or boto3.session.Session()
+            self.client = session.client("ssm", config=config)
 
         super().__init__()
 

--- a/docs/utilities/parameters.md
+++ b/docs/utilities/parameters.md
@@ -482,7 +482,7 @@ Here is the mapping between this utility's functions and methods and the underly
 
 ### Customizing boto configuration
 
-The **`config`** and **`boto3_session`** parameters enable you to pass in a custom [botocore config object](https://botocore.amazonaws.com/v1/documentation/api/latest/reference/config.html) or a custom [boto3 session](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/core/session.html) when constructing any of the built-in provider classes.
+The **`config`** , **`boto3_session`**, and **`boto3_client`**  parameters enable you to pass in a custom [botocore config object](https://botocore.amazonaws.com/v1/documentation/api/latest/reference/config.html) , [boto3 session](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/core/session.html), or  a [boto3 client](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/core/boto3.html) when constructing any of the built-in provider classes.
 
 ???+ tip
 	You can use a custom session for retrieving parameters cross-account/region and for snapshot testing.
@@ -509,6 +509,20 @@ The **`config`** and **`boto3_session`** parameters enable you to pass in a cust
 
 	boto_config = Config()
 	ssm_provider = parameters.SSMProvider(config=boto_config)
+
+	def handler(event, context):
+		# Retrieve a single parameter
+		value = ssm_provider.get("/my/parameter")
+		...
+	```
+=== "Custom client"
+
+	```python hl_lines="2 4 5"
+	from aws_lambda_powertools.utilities import parameters
+	import boto3
+
+	boto3_client= session.client(service_name="ssm", endpoint_url='custom_endpoint')
+	ssm_provider = parameters.SSMProvider(boto3_client=boto3_client)
 
 	def handler(event, context):
 		# Retrieve a single parameter

--- a/docs/utilities/parameters.md
+++ b/docs/utilities/parameters.md
@@ -487,6 +487,8 @@ The **`config`** , **`boto3_session`**, and **`boto3_client`**  parameters enabl
 ???+ tip
 	You can use a custom session for retrieving parameters cross-account/region and for snapshot testing.
 
+	When using VPC private endpoints, you can pass a custom client altogether. It's also useful for testing when injecting fake instances.
+
 === "Custom session"
 
 	```python hl_lines="2 4 5"


### PR DESCRIPTION
> A much smaller PR, with less production risks, just focusing on solving for #1079 for AppConfig

**Issue number:**
- #1079 (closes)
- #1096 (original pr with mypy typing)

## Summary

### Changes

> Please provide a summary of what's being changed

Same as #1096 minus the typing, but also includes a more relevant code example  for when you could use a custom boto3
client ie: `boto3_client= session.client(service_name="ssm", endpoint_url='custom_endpoint')`

### User experience

> Please share what the user experience looks like before and after this change

Same as #1096 minus the typing dependency

```python3
from aws_lambda_powertools.utilities import parameters
import boto3
boto3_client= session.client(service_name="ssm", endpoint_url='custom_endpoint')
ssm_provider = parameters.SSMProvider(boto3_client=boto3_client)
def handler(event, context):
	  # Retrieve a single parameter
	  value = ssm_provider.get("/my/parameter")
	  ...
```

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] [Meet tenets criteria](https://awslabs.github.io/aws-lambda-powertools-python/#tenets)
* [x] I have performed a self-review of my this change
* [x] Changes are tested
* [x] Changes are documented
* [x] PR title follows [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-python/blob/376ec0a2ac0d2a40e0af5717bef42ff84ca0d1b9/.github/semantic.yml#L2)

<details>
<summary>Is this a breaking change?</summary>

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.


-----
[View rendered docs/utilities/parameters.md](https://github.com/gyft/aws-lambda-powertools-python/blob/feat/1079-params-boto3-client/docs/utilities/parameters.md)