### PR TITLE
fix(batch): missing space in BatchProcessingError message

### DIFF
--- a/aws_lambda_powertools/utilities/batch/base.py
+++ b/aws_lambda_powertools/utilities/batch/base.py
@@ -380,7 +380,7 @@ class BatchProcessor(BasePartialProcessor):
 
         if self._entire_batch_failed():
             raise BatchProcessingError(
-                msg=f"All records failed processing. {len(self.exceptions)} individual errors logged"
+                msg=f"All records failed processing. {len(self.exceptions)} individual errors logged "
                 f"separately below.",
                 child_exceptions=self.exceptions,
             )


### PR DESCRIPTION
## Summary

### Changes

Just a simple typo I noticed while using the library.

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [ ] [Meet tenets criteria](https://awslabs.github.io/aws-lambda-powertools-python/#tenets)
* [X] I have performed a self-review of my this change
* [ ] Changes are tested
* [ ] Changes are documented
* [ ] PR title follows [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-python/blob/376ec0a2ac0d2a40e0af5717bef42ff84ca0d1b9/.github/semantic.yml#L2)


<details>
<summary>Is this a breaking change?</summary>

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
