### PR TITLE
fix(batch): allow child_exceptions to be none

### DIFF
--- a/aws_lambda_powertools/utilities/batch/exceptions.py
+++ b/aws_lambda_powertools/utilities/batch/exceptions.py
@@ -12,7 +12,7 @@ class BaseBatchProcessingError(Exception):
     def __init__(self, msg="", child_exceptions: Optional[List[ExceptionInfo]] = None):
         super().__init__(msg)
         self.msg = msg
-        self.child_exceptions = child_exceptions
+        self.child_exceptions = child_exceptions or []
 
     def format_exceptions(self, parent_exception_str):
         exception_list = [f"{parent_exception_str}\n"]

--- a/tests/functional/test_utilities_batch.py
+++ b/tests/functional/test_utilities_batch.py
@@ -908,3 +908,7 @@ def test_batch_processor_error_when_entire_batch_fails(sqs_event_factory, record
 
     # THEN raise BatchProcessingError
     assert "All records failed processing. " in str(e.value)
+
+
+def test_child_exceptions_is_none():
+    assert SQSBatchProcessingError("").format_exceptions("example") == "example\n"


### PR DESCRIPTION
**Issue number:**

-  #1203

## Summary

Following code raises an error:

```python3
from aws_lambda_powertools.utilities.batch.exceptions import BaseBatchProcessingError

err = BaseBatchProcessingError(msg="something")  # types ok
err.format_exceptions("parent exception string")
```

### Changes

> Please provide a summary of what's being changed

Change:
- Allow for child_exceptions being none in format_exceptions

### User experience

> Please share what the user experience looks like before and after this change

Following code does not raise an error

```python3
from aws_lambda_powertools.utilities.batch.exceptions import BaseBatchProcessingError

err = BaseBatchProcessingError(msg="something")
err.format_exceptions("parent exception string")
```

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] [Meet tenets criteria](https://awslabs.github.io/aws-lambda-powertools-python/#tenets)
* [x] I have performed a self-review of my this change
* [x] Changes are tested
* [x] Changes are documented
* [x] PR title follows [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-python/blob/376ec0a2ac0d2a40e0af5717bef42ff84ca0d1b9/.github/semantic.yml#L2)


<details>
<summary>Is this a breaking change?</summary>

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
