### PR TITLE
fix(docs): remove Slack link

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,9 +47,7 @@ With [pip](https://pip.pypa.io/en/latest/index.html) installed, run: ``pip insta
 * Powertools idea [DAZN Powertools](https://github.com/getndazn/dazn-lambda-powertools/)
 
 ## Connect
-
-* **AWS Developers Slack**: `#lambda-powertools` - **[Invite, if you don't have an account](https://join.slack.com/t/awsdevelopers/shared_invite/zt-yryddays-C9fkWrmguDv0h2EEDzCqvw)**
-* **Email**: aws-lambda-powertools-feedback@amazon.com
+**Email**: aws-lambda-powertools-feedback@amazon.com
 
 ## Security disclosures
 


### PR DESCRIPTION
Removing the slack link from the readme to prepare for alternative communities.

**Issue number:**

## Summary

### Changes

> Please provide a summary of what's being changed

Removes the Slack link from the readme

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.


-----
[View rendered README.md](https://github.com/awslabs/aws-lambda-powertools-python/blob/thulsimo/connect/README.md)