### PR TITLE
fix(metrics): raise SchemaValidationError for >8 metric dimensions

### DIFF
--- a/aws_lambda_powertools/metrics/base.py
+++ b/aws_lambda_powertools/metrics/base.py
@@ -178,7 +178,8 @@ class MetricManager:
             metadata = self.metadata_set
 
         if self.service and not self.dimension_set.get("service"):
-            self.add_dimension(name="service", value=self.service)
+            # self.service won't be a float
+            self.add_dimension(name="service", value=self.service)  # type: ignore[arg-type]
 
         if len(metrics) == 0:
             raise SchemaValidationError("Must contain at least one metric.")

--- a/aws_lambda_powertools/metrics/base.py
+++ b/aws_lambda_powertools/metrics/base.py
@@ -178,7 +178,7 @@ class MetricManager:
             metadata = self.metadata_set
 
         if self.service and not self.dimension_set.get("service"):
-            self.dimension_set["service"] = self.service
+            self.add_dimension(name="service", value=self.service)
 
         if len(metrics) == 0:
             raise SchemaValidationError("Must contain at least one metric.")

--- a/docs/core/metrics.md
+++ b/docs/core/metrics.md
@@ -30,10 +30,10 @@ If you're new to Amazon CloudWatch, there are two terminologies you must be awar
 
 Metric has two global settings that will be used across all metrics emitted:
 
-Setting | Description | Environment variable | Constructor parameter
-------------------------------------------------- | ------------------------------------------------- | ------------------------------------------------- | -------------------------------------------------
-**Metric namespace** | Logical container where all metrics will be placed e.g. `ServerlessAirline` |  `POWERTOOLS_METRICS_NAMESPACE` | `namespace`
-**Service** | Optionally, sets **service** metric dimension across all metrics e.g. `payment` | `POWERTOOLS_SERVICE_NAME` | `service`
+| Setting              | Description                                                                     | Environment variable           | Constructor parameter |
+| -------------------- | ------------------------------------------------------------------------------- | ------------------------------ | --------------------- |
+| **Metric namespace** | Logical container where all metrics will be placed e.g. `ServerlessAirline`     | `POWERTOOLS_METRICS_NAMESPACE` | `namespace`           |
+| **Service**          | Optionally, sets **service** metric dimension across all metrics e.g. `payment` | `POWERTOOLS_SERVICE_NAME`      | `service`             |
 
 ???+ tip
     Use your application or main service as the metric namespace to easily group all metrics.
@@ -191,7 +191,7 @@ This decorator also **validates**, **serializes**, and **flushes** all your metr
 ???+ tip "Tip: Metric validation"
     If metrics are provided, and any of the following criteria are not met, **`SchemaValidationError`** exception will be raised:
 
-    * Maximum of 9 dimensions
+    * Maximum of 8 user-defined dimensions
     * Namespace is set, and no more than one
     * Metric units must be [supported by CloudWatch](https://docs.aws.amazon.com/AmazonCloudWatch/latest/APIReference/API_MetricDatum.html)
 

--- a/tests/functional/test_metrics.py
+++ b/tests/functional/test_metrics.py
@@ -319,9 +319,11 @@ def test_schema_no_metrics(service, namespace):
         my_metrics.serialize_metric_set()
 
 
-def test_exceed_number_of_dimensions(metric, namespace):
+def test_exceed_number_of_dimensions(metric, namespace, monkeypatch):
     # GIVEN we we have more dimensions than CloudWatch supports
-    dimensions = [{"name": f"test_{i}", "value": "test"} for i in range(11)]
+    # and that service dimension is injected like a user-defined dimension (N+1)
+    monkeypatch.setenv("POWERTOOLS_SERVICE_NAME", "test_service")
+    dimensions = [{"name": f"test_{i}", "value": "test"} for i in range(9)]
 
     # WHEN we attempt to serialize them into a valid EMF object
     # THEN it should fail validation and raise SchemaValidationError


### PR DESCRIPTION
**Issue number:** #1239

## Summary

### Changes

> Please provide a summary of what's being changed

Lambda Powertools adds a `service` CloudWatch Metric Dimension on top of user-defined dimensions. If customers add 9 user-defined dimensions, Powertools were previously adding `service` dimension directly into the dictionary making EMF to not process these metrics - EMF is an async process managed by CloudWatch Logs and it fails silently, all validation must happen on the client side for any feedback.

This PR addresses our documentation stating that the limit is **8** and ensures our `service` dimension addition goes through the same user-defined dimension validation process.

### User experience

> Please share what the user experience looks like before and after this change

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [ ] [Meet tenets criteria](https://awslabs.github.io/aws-lambda-powertools-python/#tenets)
* [ ] I have performed a self-review of my this change
* [ ] Changes are tested
* [ ] Changes are documented
* [ ] PR title follows [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-python/blob/376ec0a2ac0d2a40e0af5717bef42ff84ca0d1b9/.github/semantic.yml#L2)


<details>
<summary>Is this a breaking change?</summary>

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
