### PR TITLE
chore(metrics): revert dimensions test before splitting

### DIFF
--- a/tests/functional/test_metrics.py
+++ b/tests/functional/test_metrics.py
@@ -319,11 +319,9 @@ def test_schema_no_metrics(service, namespace):
         my_metrics.serialize_metric_set()
 
 
-def test_exceed_number_of_dimensions(metric, namespace, monkeypatch):
+def test_exceed_number_of_dimensions(metric, namespace):
     # GIVEN we we have more dimensions than CloudWatch supports
-    # and that service dimension is injected like a user-defined dimension (N+1)
-    monkeypatch.setenv("POWERTOOLS_SERVICE_NAME", "test_service")
-    dimensions = [{"name": f"test_{i}", "value": "test"} for i in range(9)]
+    dimensions = [{"name": f"test_{i}", "value": "test"} for i in range(11)]
 
     # WHEN we attempt to serialize them into a valid EMF object
     # THEN it should fail validation and raise SchemaValidationError

--- a/tests/functional/test_metrics.py
+++ b/tests/functional/test_metrics.py
@@ -331,6 +331,19 @@ def test_exceed_number_of_dimensions(metric, namespace):
                 my_metric.add_dimension(**dimension)
 
 
+def test_exceed_number_of_dimensions_with_service(metric, namespace, monkeypatch):
+    # GIVEN we have service set and add more dimensions than CloudWatch supports (N+1)
+    monkeypatch.setenv("POWERTOOLS_SERVICE_NAME", "test_service")
+    dimensions = [{"name": f"test_{i}", "value": "test"} for i in range(9)]
+
+    # WHEN we attempt to serialize them into a valid EMF object
+    # THEN it should fail validation and raise SchemaValidationError
+    with pytest.raises(SchemaValidationError, match="Maximum number of dimensions exceeded.*"):
+        with single_metric(**metric, namespace=namespace) as my_metric:
+            for dimension in dimensions:
+                my_metric.add_dimension(**dimension)
+
+
 def test_log_metrics_during_exception(capsys, metric, dimension, namespace):
     # GIVEN Metrics is initialized
     my_metrics = Metrics(namespace=namespace)

--- a/tests/functional/test_metrics.py
+++ b/tests/functional/test_metrics.py
@@ -320,7 +320,7 @@ def test_schema_no_metrics(service, namespace):
 
 
 def test_exceed_number_of_dimensions(metric, namespace):
-    # GIVEN we we have more dimensions than CloudWatch supports
+    # GIVEN we have more dimensions than CloudWatch supports
     dimensions = [{"name": f"test_{i}", "value": "test"} for i in range(11)]
 
     # WHEN we attempt to serialize them into a valid EMF object


### PR DESCRIPTION
**Issue number:** #1239

## Summary

### Changes

In #1240, I repurposed the original test `test_exceed_number_of_dimensions` to account for `service` dimension, since the outcome would be the same (`SchemaValidationError`).

This PR reverts that test change, fix an old typo (`we we`), and adds a specific test `test_exceed_number_of_dimensions_with_service`.

### User experience

> Please share what the user experience looks like before and after this change

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] [Meet tenets criteria](https://awslabs.github.io/aws-lambda-powertools-python/#tenets)
* [x] I have performed a self-review of my this change
* [x] Changes are tested
* [ ] Changes are documented
* [x] PR title follows [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-python/blob/376ec0a2ac0d2a40e0af5717bef42ff84ca0d1b9/.github/semantic.yml#L2)


<details>
<summary>Is this a breaking change?</summary>

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
