### PR TITLE
fix(event-handler): body to empty string in CORS preflight (ALB non-compliant)

### DIFF
--- a/aws_lambda_powertools/event_handler/api_gateway.py
+++ b/aws_lambda_powertools/event_handler/api_gateway.py
@@ -595,7 +595,7 @@ class ApiGatewayResolver(BaseRouter):
             if method == "OPTIONS":
                 logger.debug("Pre-flight request detected. Returning CORS with null response")
                 headers["Access-Control-Allow-Methods"] = ",".join(sorted(self._cors_methods))
-                return ResponseBuilder(Response(status_code=204, content_type=None, headers=headers, body=None))
+                return ResponseBuilder(Response(status_code=204, content_type=None, headers=headers, body=""))
 
         handler = self._lookup_exception_handler(NotFoundError)
         if handler:

--- a/tests/functional/event_handler/test_api_gateway.py
+++ b/tests/functional/event_handler/test_api_gateway.py
@@ -236,6 +236,19 @@ def test_cors():
     assert "Access-Control-Allow-Origin" not in result["headers"]
 
 
+def test_cors_preflight_body_is_empty_not_null():
+    # GIVEN CORS is configured
+    app = ALBResolver(cors=CORSConfig())
+
+    event = {"path": "/my/request", "httpMethod": "OPTIONS"}
+
+    # WHEN calling the event handler
+    result = app(event, {})
+
+    # THEN there body should be empty strings
+    assert result["body"] == ""
+
+
 def test_compress():
     # GIVEN a function that has compress=True
     # AND an event with a "Accept-Encoding" that include gzip
@@ -485,7 +498,7 @@ def test_cors_preflight():
     # THEN return no content
     # AND include Access-Control-Allow-Methods of the cors methods used
     assert result["statusCode"] == 204
-    assert result["body"] is None
+    assert result["body"] == ""
     headers = result["headers"]
     assert "Content-Type" not in headers
     assert "Access-Control-Allow-Origin" in result["headers"]


### PR DESCRIPTION
**Issue number:** #1248

## Summary

### Changes

> Please provide a summary of what's being changed

ALB doesn't follow [HTTP CORS Spec](https://fetch.spec.whatwg.org/#http-responses) and returns 502 when a body response is null. This PR returns an empty string to make it compliant.

### User experience

> Please share what the user experience looks like before and after this change

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] [Meet tenets criteria](https://awslabs.github.io/aws-lambda-powertools-python/#tenets)
* [x] I have performed a self-review of my this change
* [x] Changes are tested
* [x] Changes are documented
* [x] PR title follows [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-python/blob/376ec0a2ac0d2a40e0af5717bef42ff84ca0d1b9/.github/semantic.yml#L2)


<details>
<summary>Is this a breaking change?</summary>

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
