### PR TITLE
docs(metrics): snippets split, improved, and lint

### DIFF
--- a/docs/core/tracer.md
+++ b/docs/core/tracer.md
@@ -76,7 +76,7 @@ You can trace asynchronous functions and generator functions (including context 
 
 === "Async"
 
-    ```python hl_lines="8"
+    ```python hl_lines="9"
     --8<-- "examples/tracer/src/capture_method_async.py"
     ```
 

--- a/examples/metrics/sam/template.yaml
+++ b/examples/metrics/sam/template.yaml
@@ -1,0 +1,25 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Transform: AWS::Serverless-2016-10-31
+Description: AWS Lambda Powertools Metrics doc examples
+
+Globals:
+  Function:
+    Timeout: 5
+    Runtime: python3.9
+    Tracing: Active
+    Environment:
+      Variables:
+        POWERTOOLS_SERVICE_NAME: booking
+        POWERTOOLS_METRICS_NAMESPACE: ServerlessAirline
+
+    Layers:
+      # Find the latest Layer version in the official documentation
+      # https://awslabs.github.io/aws-lambda-powertools-python/latest/#lambda-layer
+      - !Sub arn:aws:lambda:${AWS::Region}:017000801446:layer:AWSLambdaPowertoolsPython:21
+
+Resources:
+  CaptureLambdaHandlerExample:
+    Type: AWS::Serverless::Function
+    Properties:
+      CodeUri: ../src
+      Handler: capture_lambda_handler.handler

--- a/examples/metrics/src/add_dimension.py
+++ b/examples/metrics/src/add_dimension.py
@@ -1,0 +1,14 @@
+import os
+
+from aws_lambda_powertools import Metrics
+from aws_lambda_powertools.metrics import MetricUnit
+from aws_lambda_powertools.utilities.typing import LambdaContext
+
+STAGE = os.getenv("STAGE", "dev")
+metrics = Metrics()
+
+
+@metrics.log_metrics  # ensures metrics are flushed upon request completion/failure
+def lambda_handler(event: dict, context: LambdaContext):
+    metrics.add_dimension(name="environment", value=STAGE)
+    metrics.add_metric(name="SuccessfulBooking", unit=MetricUnit.Count, value=1)

--- a/examples/metrics/src/add_metrics.py
+++ b/examples/metrics/src/add_metrics.py
@@ -1,0 +1,10 @@
+from aws_lambda_powertools import Metrics
+from aws_lambda_powertools.metrics import MetricUnit
+from aws_lambda_powertools.utilities.typing import LambdaContext
+
+metrics = Metrics()
+
+
+@metrics.log_metrics  # ensures metrics are flushed upon request completion/failure
+def lambda_handler(event: dict, context: LambdaContext):
+    metrics.add_metric(name="SuccessfulBooking", unit=MetricUnit.Count, value=1)

--- a/examples/metrics/src/add_multi_value_metrics.py
+++ b/examples/metrics/src/add_multi_value_metrics.py
@@ -1,0 +1,15 @@
+import os
+
+from aws_lambda_powertools import Metrics
+from aws_lambda_powertools.metrics import MetricUnit
+from aws_lambda_powertools.utilities.typing import LambdaContext
+
+STAGE = os.getenv("STAGE", "dev")
+metrics = Metrics()
+
+
+@metrics.log_metrics  # ensures metrics are flushed upon request completion/failure
+def lambda_handler(event: dict, context: LambdaContext):
+    metrics.add_dimension(name="environment", value=STAGE)
+    metrics.add_metric(name="TurbineReads", unit=MetricUnit.Count, value=1)
+    metrics.add_metric(name="TurbineReads", unit=MetricUnit.Count, value=8)

--- a/examples/metrics/src/add_multi_value_metrics_output.json
+++ b/examples/metrics/src/add_multi_value_metrics_output.json
@@ -1,0 +1,28 @@
+{
+    "_aws": {
+        "Timestamp": 1656685750622,
+        "CloudWatchMetrics": [
+            {
+                "Namespace": "ServerlessAirline",
+                "Dimensions": [
+                    [
+                        "environment",
+                        "service"
+                    ]
+                ],
+                "Metrics": [
+                    {
+                        "Name": "TurbineReads",
+                        "Unit": "Count"
+                    }
+                ]
+            }
+        ]
+    },
+    "environment": "dev",
+    "service": "booking",
+    "TurbineReads": [
+        1.0,
+        8.0
+    ]
+}

--- a/examples/metrics/src/capture_cold_start_metric.py
+++ b/examples/metrics/src/capture_cold_start_metric.py
@@ -1,0 +1,9 @@
+from aws_lambda_powertools import Metrics
+from aws_lambda_powertools.utilities.typing import LambdaContext
+
+metrics = Metrics()
+
+
+@metrics.log_metrics(capture_cold_start_metric=True)
+def lambda_handler(event: dict, context: LambdaContext):
+    ...

--- a/examples/metrics/src/capture_cold_start_metric_output.json
+++ b/examples/metrics/src/capture_cold_start_metric_output.json
@@ -1,0 +1,27 @@
+{
+    "_aws": {
+        "Timestamp": 1656687493142,
+        "CloudWatchMetrics": [
+            {
+                "Namespace": "ServerlessAirline",
+                "Dimensions": [
+                    [
+                        "function_name",
+                        "service"
+                    ]
+                ],
+                "Metrics": [
+                    {
+                        "Name": "ColdStart",
+                        "Unit": "Count"
+                    }
+                ]
+            }
+        ]
+    },
+    "function_name": "test",
+    "service": "booking",
+    "ColdStart": [
+        1.0
+    ]
+}

--- a/examples/metrics/src/log_metrics_output.json
+++ b/examples/metrics/src/log_metrics_output.json
@@ -1,0 +1,25 @@
+{
+    "_aws": {
+        "Timestamp": 1656686788803,
+        "CloudWatchMetrics": [
+            {
+                "Namespace": "ServerlessAirline",
+                "Dimensions": [
+                    [
+                        "service"
+                    ]
+                ],
+                "Metrics": [
+                    {
+                        "Name": "SuccessfulBooking",
+                        "Unit": "Count"
+                    }
+                ]
+            }
+        ]
+    },
+    "service": "booking",
+    "SuccessfulBooking": [
+        1.0
+    ]
+}

--- a/examples/metrics/src/raise_on_empty_metrics.py
+++ b/examples/metrics/src/raise_on_empty_metrics.py
@@ -1,0 +1,10 @@
+from aws_lambda_powertools.metrics import Metrics
+from aws_lambda_powertools.utilities.typing import LambdaContext
+
+metrics = Metrics()
+
+
+@metrics.log_metrics(raise_on_empty_metrics=True)
+def lambda_handler(event: dict, context: LambdaContext):
+    # no metrics being created will now raise SchemaValidationError
+    ...

--- a/examples/metrics/src/set_default_dimensions.py
+++ b/examples/metrics/src/set_default_dimensions.py
@@ -1,0 +1,15 @@
+import os
+
+from aws_lambda_powertools import Metrics
+from aws_lambda_powertools.metrics import MetricUnit
+from aws_lambda_powertools.utilities.typing import LambdaContext
+
+STAGE = os.getenv("STAGE", "dev")
+metrics = Metrics()
+metrics.set_default_dimensions(environment=STAGE, another="one")
+
+
+@metrics.log_metrics  # ensures metrics are flushed upon request completion/failure
+def lambda_handler(event: dict, context: LambdaContext):
+    metrics.add_metric(name="TurbineReads", unit=MetricUnit.Count, value=1)
+    metrics.add_metric(name="TurbineReads", unit=MetricUnit.Count, value=8)

--- a/examples/metrics/src/set_default_dimensions_log_metrics.py
+++ b/examples/metrics/src/set_default_dimensions_log_metrics.py
@@ -1,0 +1,16 @@
+import os
+
+from aws_lambda_powertools import Metrics
+from aws_lambda_powertools.metrics import MetricUnit
+from aws_lambda_powertools.utilities.typing import LambdaContext
+
+STAGE = os.getenv("STAGE", "dev")
+metrics = Metrics()
+DEFAULT_DIMENSIONS = {"environment": STAGE, "another": "one"}
+
+
+# ensures metrics are flushed upon request completion/failure
+@metrics.log_metrics(default_dimensions=DEFAULT_DIMENSIONS)
+def lambda_handler(event: dict, context: LambdaContext):
+    metrics.add_metric(name="TurbineReads", unit=MetricUnit.Count, value=1)
+    metrics.add_metric(name="TurbineReads", unit=MetricUnit.Count, value=8)

--- a/examples/tracer/sam/template.yaml
+++ b/examples/tracer/sam/template.yaml
@@ -9,7 +9,7 @@ Globals:
     Tracing: Active
     Environment:
       Variables:
-        POWERTOOLS_SERVICE_NAME: example
+        POWERTOOLS_SERVICE_NAME: payment
     Layers:
       # Find the latest Layer version in the official documentation
       # https://awslabs.github.io/aws-lambda-powertools-python/latest/#lambda-layer


### PR DESCRIPTION
**Issue number:** #1009 

## Summary

### Changes

> Please provide a summary of what's being changed

In addition to title, we've removed `nesting middleware` section as it's no longer relevant, and added `adding multi-value metrics` to be more explicit.

### User experience

> Please share what the user experience looks like before and after this change

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [ ] [Meet tenets criteria](https://awslabs.github.io/aws-lambda-powertools-python/#tenets)
* [ ] I have performed a self-review of my this change
* [ ] Changes are tested
* [ ] Changes are documented
* [ ] PR title follows [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-python/blob/376ec0a2ac0d2a40e0af5717bef42ff84ca0d1b9/.github/semantic.yml#L2)


<details>
<summary>Is this a breaking change?</summary>

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
