### PR TITLE
fix(logger): support additional args for a lambda handler when injecting lambda context

### DIFF
--- a/aws_lambda_powertools/logging/logger.py
+++ b/aws_lambda_powertools/logging/logger.py
@@ -335,7 +335,7 @@ class Logger(logging.Logger):  # lgtm [py/missing-call-to-init]
         )
 
         @functools.wraps(lambda_handler)
-        def decorate(event, context, **kwargs):
+        def decorate(event, context, *args, **kwargs):
             lambda_context = build_lambda_context_model(context)
             cold_start = _is_cold_start()
 
@@ -351,7 +351,7 @@ class Logger(logging.Logger):  # lgtm [py/missing-call-to-init]
                 logger.debug("Event received")
                 self.info(getattr(event, "raw_event", event))
 
-            return lambda_handler(event, context)
+            return lambda_handler(event, context, *args, **kwargs)
 
         return decorate
 

--- a/tests/functional/test_logger.py
+++ b/tests/functional/test_logger.py
@@ -773,3 +773,20 @@ def test_inject_lambda_context_log_event_request_data_classes(lambda_context, st
     # THEN logger should log event received from Lambda
     logged_event, _ = capture_multiple_logging_statements_output(stdout)
     assert logged_event["message"] == lambda_event
+
+
+def test_inject_lambda_context_with_additional_args(lambda_context, stdout, service_name):
+    # GIVEN Logger is initialized
+    logger = Logger(service=service_name, stream=stdout)
+
+    # AND a handler that use additional parameters
+    @logger.inject_lambda_context
+    def handler(event, context, planet, str_end="."):
+        logger.info(f"Hello {planet}{str_end}")
+
+    handler({}, lambda_context, "World", str_end="!")
+
+    # THEN the decorator should included them
+    log = capture_logging_output(stdout)
+
+    assert log["message"] == "Hello World!"


### PR DESCRIPTION
## Summary

### Changes

Preserve `args` and `kwargs` in the `logger.inject_lambda_context` decorator

### User experience

After @heitorlessa 's talk at our meetup last Thursday I tried to add the logger to our project. The lambda handler was already decorated with a couple of decorators, one of which injects additional parameters into the handler. The decorator did not support this, simply passing on args and kwargs fixes this issue and allows the decorator to be used on lambda handlers that support additional arguments.

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [v] [Meet tenets criteria](https://awslabs.github.io/aws-lambda-powertools-python/#tenets)
* [v] I have performed a self-review of my this change
* [v] Changes are tested
* [ ] Changes are documented
* [v] PR title follows [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-python/blob/376ec0a2ac0d2a40e0af5717bef42ff84ca0d1b9/.github/semantic.yml#L2)

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
