### PR TITLE
docs(homepage): emphasize additional powertools languages

### DIFF
--- a/.github/scripts/label_related_issue.js
+++ b/.github/scripts/label_related_issue.js
@@ -11,6 +11,7 @@ const {
 module.exports = async ({github, context, core}) => {
     core.debug(PR_BODY);
     core.debug(PR_IS_MERGED);
+    core.debug(PR_AUTHOR);
 
     if (IGNORE_AUTHORS.includes(PR_AUTHOR)) {
       return core.notice("Author in IGNORE_AUTHORS list; skipping...")

--- a/docs/index.md
+++ b/docs/index.md
@@ -7,9 +7,8 @@ description: AWS Lambda Powertools Python
 
 A suite of utilities for AWS Lambda functions to ease adopting best practices such as tracing, structured logging, custom metrics, idempotency, batching, and more.
 
-???+ tip "Tip: Looking for a quick read through how the core features are used?"
-
-    Check out [this detailed blog post](https://aws.amazon.com/blogs/opensource/simplifying-serverless-best-practices-with-lambda-powertools/) with a practical example.
+???+ note
+    Lambda Powertools is also available for [Java](https://awslabs.github.io/aws-lambda-powertools-java/){target="_blank"} and [TypeScript](https://awslabs.github.io/aws-lambda-powertools-typescript/latest/){target="_blank"}.
 
 ## Install
 


### PR DESCRIPTION
**Issue number:** #1009 

## Summary

### Changes

> Please provide a summary of what's being changed

Add note at the top. Remove blog post in favour of tutorial.

![image](https://user-images.githubusercontent.com/3340292/178511025-bbe3ac20-9667-4901-8dc8-f3d1511a7a63.png)


### User experience

> Please share what the user experience looks like before and after this change

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [ ] [Meet tenets criteria](https://awslabs.github.io/aws-lambda-powertools-python/#tenets)
* [ ] I have performed a self-review of my this change
* [ ] Changes are tested
* [ ] Changes are documented
* [ ] PR title follows [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-python/blob/376ec0a2ac0d2a40e0af5717bef42ff84ca0d1b9/.github/semantic.yml#L2)


<details>
<summary>Is this a breaking change?</summary>

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.


-----
[View rendered docs/index.md](https://github.com/heitorlessa/aws-lambda-powertools-python/blob/docs/refer-other-powertools/docs/index.md)