### PR TITLE
fix(parser): raise ValidationError when SNS->SQS keys are intentionally missing

### DIFF
--- a/aws_lambda_powertools/utilities/parser/models/sns.py
+++ b/aws_lambda_powertools/utilities/parser/models/sns.py
@@ -31,8 +31,11 @@ class SnsNotificationModel(BaseModel):
     def check_sqs_protocol(cls, values):
         sqs_rewritten_keys = ("UnsubscribeURL", "SigningCertURL")
         if any(key in sqs_rewritten_keys for key in values):
-            values["UnsubscribeUrl"] = values.pop("UnsubscribeURL")
-            values["SigningCertUrl"] = values.pop("SigningCertURL")
+            # The sentinel value 'None' forces the validator to fail with
+            # ValidatorError instead of KeyError when the key is missing from
+            # the SQS payload
+            values["UnsubscribeUrl"] = values.pop("UnsubscribeURL", None)
+            values["SigningCertUrl"] = values.pop("SigningCertURL", None)
         return values
 
 

--- a/tests/functional/parser/test_sns.py
+++ b/tests/functional/parser/test_sns.py
@@ -1,3 +1,4 @@
+import json
 from typing import Any, List
 
 import pytest
@@ -103,3 +104,29 @@ def handle_sns_sqs_json_body(event: List[MySnsBusiness], _: LambdaContext):
 def test_handle_sns_sqs_trigger_event_json_body():  # noqa: F811
     event_dict = load_event("snsSqsEvent.json")
     handle_sns_sqs_json_body(event_dict, LambdaContext())
+
+
+def test_handle_sns_sqs_trigger_event_json_body_missing_signing_cert_url():
+    # GIVEN an event with a missing SigningCertURL
+    event_dict = load_event("snsSqsEvent.json")
+    payload = json.loads(event_dict["Records"][0]["body"])
+    assert payload.pop("SigningCertURL") is not None
+    event_dict["Records"][0]["body"] = json.dumps(payload)
+
+    # WHEN parsing the payload
+    # THEN raise a ValidationError error
+    with pytest.raises(ValidationError):
+        handle_sns_sqs_json_body(event_dict, LambdaContext())
+
+
+def test_handle_sns_sqs_trigger_event_json_body_missing_unsubscribe_url():
+    # GIVEN an event with a missing UnsubscribeURL
+    event_dict = load_event("snsSqsEvent.json")
+    payload = json.loads(event_dict["Records"][0]["body"])
+    assert payload.pop("UnsubscribeURL") is not None
+    event_dict["Records"][0]["body"] = json.dumps(payload)
+
+    # WHEN parsing the payload
+    # THEN raise a ValidationError error
+    with pytest.raises(ValidationError):
+        handle_sns_sqs_json_body(event_dict, LambdaContext())

--- a/tests/functional/parser/test_sns.py
+++ b/tests/functional/parser/test_sns.py
@@ -107,10 +107,10 @@ def test_handle_sns_sqs_trigger_event_json_body():  # noqa: F811
 
 
 def test_handle_sns_sqs_trigger_event_json_body_missing_signing_cert_url():
-    # GIVEN an event with a missing SigningCertURL
+    # GIVEN an event is tampered with a missing SigningCertURL
     event_dict = load_event("snsSqsEvent.json")
     payload = json.loads(event_dict["Records"][0]["body"])
-    assert payload.pop("SigningCertURL") is not None
+    payload.pop("SigningCertURL")
     event_dict["Records"][0]["body"] = json.dumps(payload)
 
     # WHEN parsing the payload
@@ -120,10 +120,10 @@ def test_handle_sns_sqs_trigger_event_json_body_missing_signing_cert_url():
 
 
 def test_handle_sns_sqs_trigger_event_json_body_missing_unsubscribe_url():
-    # GIVEN an event with a missing UnsubscribeURL
+    # GIVEN an event is tampered with a missing UnsubscribeURL
     event_dict = load_event("snsSqsEvent.json")
     payload = json.loads(event_dict["Records"][0]["body"])
-    assert payload.pop("UnsubscribeURL") is not None
+    payload.pop("UnsubscribeURL")
     event_dict["Records"][0]["body"] = json.dumps(payload)
 
     # WHEN parsing the payload


### PR DESCRIPTION
**Issue number:** #1009 

## Summary

### Changes

When `UnsubscribeURL` or `SigningCertURL` were intentionally missing from the SNS -> SQS payload, `KeyError` was thrown.

Since the objective of the parser is to validate the payload, we changed the code so it returns
an expected [ValidationError](https://prompt-build--pydantic-docs.netlify.app/#error-handling) instead.

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] [Meet tenets criteria](https://awslabs.github.io/aws-lambda-powertools-python/#tenets)
* [x] I have performed a self-review of my this change
* [x] Changes are tested
* [x] Changes are documented
* [x] PR title follows [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-python/blob/376ec0a2ac0d2a40e0af5717bef42ff84ca0d1b9/.github/semantic.yml#L2)


<details>
<summary>Is this a breaking change?</summary>

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
