### PR TITLE
chore(ci): automatically add area label based on title

### DIFF
--- a/.github/scripts/constants.js
+++ b/.github/scripts/constants.js
@@ -32,4 +32,23 @@ module.exports = Object.freeze({
 
     /** @type {string[]} */
     "IGNORE_AUTHORS": ["dependabot[bot]", "markdownify[bot]"],
+
+    /** @type {string[]} */
+    "AREAS": [
+        "tracer",
+        "metrics",
+        "utilities",
+        "logger",
+        "event_handlers",
+        "middleware_factory",
+        "idempotency",
+        "event_sources",
+        "feature_flags",
+        "parameters",
+        "batch",
+        "parser",
+        "validator",
+        "jmespath_util",
+        "lambda-layers",
+    ],
 });

--- a/.github/scripts/label_pr_based_on_title.js
+++ b/.github/scripts/label_pr_based_on_title.js
@@ -1,4 +1,4 @@
-const { PR_NUMBER, PR_TITLE } = require("./constants")
+const { PR_NUMBER, PR_TITLE, AREAS } = require("./constants")
 
 module.exports = async ({github, context, core}) => {
     const FEAT_REGEX = /feat(\((.+)\))?(\:.+)/
@@ -17,24 +17,6 @@ module.exports = async ({github, context, core}) => {
         "deprecated": DEPRECATED_REGEX,
     }
 
-    const areas = [
-        "tracer",
-        "metrics",
-        "utilities",
-        "logger",
-        "event_handlers",
-        "middleware_factory",
-        "idempotency",
-        "event_sources",
-        "feature_flags",
-        "parameters",
-        "batch",
-        "parser",
-        "validator",
-        "jmespath_util",
-        "lambda-layers",
-    ];
-
     // Maintenance: We should keep track of modified PRs in case their titles change
     let miss = 0;
     try {
@@ -52,7 +34,7 @@ module.exports = async ({github, context, core}) => {
                 })
 
                 const area = matches[2]; // second capture group contains the area
-                if (areas.indexOf(area) > -1) {
+                if (AREAS.indexOf(area) > -1) {
                     core.info(`Auto-labeling PR ${PR_NUMBER} with area ${area}`);
                     await github.rest.issues.addLabels({
                         issue_number: PR_NUMBER,

--- a/.github/scripts/label_pr_based_on_title.js
+++ b/.github/scripts/label_pr_based_on_title.js
@@ -19,7 +19,7 @@ module.exports = async ({github, context, core}) => {
 
     const areas = [
         "tracer",
-        "metric",
+        "metrics",
         "utilities",
         "logger",
         "event_handlers",

--- a/.github/scripts/label_pr_based_on_title.js
+++ b/.github/scripts/label_pr_based_on_title.js
@@ -51,7 +51,7 @@ module.exports = async ({github, context, core}) => {
                     labels: [label]
                 })
 
-				        const area = matches[2]; // second capture group contains the area
+                const area = matches[2]; // second capture group contains the area
                 if (areas.indexOf(area) > -1) {
                     core.info(`Auto-labeling PR ${PR_NUMBER} with area ${area}`);
                     await github.rest.issues.addLabels({

--- a/.github/scripts/label_pr_based_on_title.js
+++ b/.github/scripts/label_pr_based_on_title.js
@@ -17,6 +17,24 @@ module.exports = async ({github, context, core}) => {
         "deprecated": DEPRECATED_REGEX,
     }
 
+	  const areas = [
+	  	"tracer",
+	  	"metric",
+	  	"utilities",
+	  	"logger",
+	  	"event_handlers",
+	  	"middleware_factory",
+	  	"idempotency",
+	  	"event_sources",
+	  	"feature_flags",
+	  	"parameters",
+	  	"batch",
+	  	"parser",
+	  	"validator",
+	  	"jmespath_util",
+	  	"lambda-layers",
+	  ];
+
     // Maintenance: We should keep track of modified PRs in case their titles change
     let miss = 0;
     try {
@@ -26,12 +44,27 @@ module.exports = async ({github, context, core}) => {
             if (isMatch != null) {
                 core.info(`Auto-labeling PR ${PR_NUMBER} with ${label}`)
 
-                return await github.rest.issues.addLabels({
-                issue_number: PR_NUMBER,
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                labels: [label]
+                await github.rest.issues.addLabels({
+                    issue_number: PR_NUMBER,
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    labels: [label]
                 })
+
+				        const area = matches[2]; // second capture group contains the area
+                if (areas.indexOf(area) > -1) {
+                    core.info(`Auto-labeling PR ${PR_NUMBER} with area ${area}`);
+                    await github.rest.issues.addLabels({
+                        issue_number: PR_NUMBER,
+                        owner: context.repo.owner,
+                        repo: context.repo.repo,
+                        labels: [`area/${area}`],
+                    });
+                } else {
+                    core.debug(`'${PR_TITLE}' didn't match any known area.`);
+                }
+
+				        return;
             } else {
                 core.debug(`'${PR_TITLE}' didn't match '${label}' semantic.`)
                 miss += 1

--- a/.github/scripts/label_pr_based_on_title.js
+++ b/.github/scripts/label_pr_based_on_title.js
@@ -64,7 +64,7 @@ module.exports = async ({github, context, core}) => {
                     core.debug(`'${PR_TITLE}' didn't match any known area.`);
                 }
 
-				        return;
+                return;
             } else {
                 core.debug(`'${PR_TITLE}' didn't match '${label}' semantic.`)
                 miss += 1

--- a/.github/scripts/label_pr_based_on_title.js
+++ b/.github/scripts/label_pr_based_on_title.js
@@ -17,23 +17,23 @@ module.exports = async ({github, context, core}) => {
         "deprecated": DEPRECATED_REGEX,
     }
 
-	  const areas = [
-	  	"tracer",
-	  	"metric",
-	  	"utilities",
-	  	"logger",
-	  	"event_handlers",
-	  	"middleware_factory",
-	  	"idempotency",
-	  	"event_sources",
-	  	"feature_flags",
-	  	"parameters",
-	  	"batch",
-	  	"parser",
-	  	"validator",
-	  	"jmespath_util",
-	  	"lambda-layers",
-	  ];
+    const areas = [
+        "tracer",
+        "metric",
+        "utilities",
+        "logger",
+        "event_handlers",
+        "middleware_factory",
+        "idempotency",
+        "event_sources",
+        "feature_flags",
+        "parameters",
+        "batch",
+        "parser",
+        "validator",
+        "jmespath_util",
+        "lambda-layers",
+    ];
 
     // Maintenance: We should keep track of modified PRs in case their titles change
     let miss = 0;


### PR DESCRIPTION
**Issue number:** #1009

## Summary

### Changes

Automatically add the respective `area` label for known areas. The area is derived from the PR title.

### User experience

When a contributor submits a PR, an `area/xxx` label should be automatically applied if the title mentions a known powertools area.

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] [Meet tenets criteria](https://awslabs.github.io/aws-lambda-powertools-python/#tenets)
* [x] I have performed a self-review of my this change
* [ ] Changes are tested
* [x] Changes are documented
* [x] PR title follows [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-python/blob/376ec0a2ac0d2a40e0af5717bef42ff84ca0d1b9/.github/semantic.yml#L2)


<details>
<summary>Is this a breaking change?</summary>

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
