### PR TITLE
chore(ci): lockdown 3rd party workflows to pin sha

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -93,14 +93,14 @@ jobs:
           make release-docs VERSION=${RELEASE_TAG_VERSION} ALIAS="latest"
           poetry run mike set-default --push latest
       - name: Release API docs to release version
-        uses: peaceiris/actions-gh-pages@v3
+        uses: peaceiris/actions-gh-pages@068dc23d9710f1ba62e86896f84735d869951305 # v3.8.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./api
           keep_files: true
           destination_dir: ${{ env.RELEASE_TAG_VERSION }}/api
       - name: Release API docs to latest
-        uses: peaceiris/actions-gh-pages@v3
+        uses: peaceiris/actions-gh-pages@068dc23d9710f1ba62e86896f84735d869951305 # v3.8.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./api

--- a/.github/workflows/publish_layer.yml
+++ b/.github/workflows/publish_layer.yml
@@ -12,10 +12,9 @@ on:
         default: "v1.22.0"
         required: true
   workflow_run:
-    workflows: [ "Publish to PyPi" ]
+    workflows: ["Publish to PyPi"]
     types:
       - completed
-
 
 jobs:
   build-layer:
@@ -25,16 +24,16 @@ jobs:
         working-directory: ./layer
     steps:
       - name: checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: '16.12'
+          node-version: "16.12"
       - name: Setup python
         uses: actions/setup-python@v4
         with:
-          python-version: '3.9'
-          cache: 'pip'
+          python-version: "3.9"
+          cache: "pip"
       - name: Set release notes tag
         run: |
           RELEASE_INPUT=${{ inputs.latest_published_version }}

--- a/.github/workflows/python_build.yml
+++ b/.github/workflows/python_build.yml
@@ -49,11 +49,10 @@ jobs:
       - name: Complexity baseline
         run: make complexity-baseline
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v3.1.0
+        uses: codecov/codecov-action@81cd2dc8148241f03f5839d295e000b8f761e378 # 3.1.0
         with:
           file: ./coverage.xml
           # flags: unittests
           env_vars: OS,PYTHON
           name: aws-lambda-powertools-python-codecov
           # fail_ci_if_error: true  # failing more consistently making CI unreliable despite all tests above passing
-          token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/python_docs.yml
+++ b/.github/workflows/python_docs.yml
@@ -27,7 +27,7 @@ jobs:
           python-version: "3.8"
       # Maintenance: temporarily until we drop Python 3.6 and make cfn-lint a dev dependency
       - name: Setup Cloud Formation Linter with Latest Version
-        uses: scottbrenner/cfn-lint-action@v2
+        uses: scottbrenner/cfn-lint-action@ee9ee62016ef62c5fd366e6be920df4b310ed353 # v2.2.4
       - name: Install dependencies
         run: make dev
       - name: Lint documentation
@@ -41,7 +41,7 @@ jobs:
       - name: Build docs website and API reference
         run: make release-docs VERSION="develop" ALIAS="stage"
       - name: Deploy all docs
-        uses: peaceiris/actions-gh-pages@v3
+        uses: peaceiris/actions-gh-pages@068dc23d9710f1ba62e86896f84735d869951305 # v3.8.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./api

--- a/.github/workflows/rebuild_latest_docs.yml
+++ b/.github/workflows/rebuild_latest_docs.yml
@@ -49,14 +49,14 @@ jobs:
           make release-docs VERSION=${RELEASE_TAG_VERSION} ALIAS="latest"
           poetry run mike set-default --push latest
       - name: Release API docs to release version
-        uses: peaceiris/actions-gh-pages@v3
+        uses: peaceiris/actions-gh-pages@068dc23d9710f1ba62e86896f84735d869951305 # v3.8.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./api
           keep_files: true
           destination_dir: ${{ env.RELEASE_TAG_VERSION }}/api
       - name: Release API docs to latest
-        uses: peaceiris/actions-gh-pages@v3
+        uses: peaceiris/actions-gh-pages@068dc23d9710f1ba62e86896f84735d869951305 # v3.8.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./api

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -2,7 +2,6 @@ name: Release Drafter
 
 on:
   push:
-    # branches to consider in the event; optional, defaults to all
     branches:
       - develop
   workflow_dispatch:
@@ -11,6 +10,6 @@ jobs:
   update_release_draft:
     runs-on: ubuntu-latest
     steps:
-      - uses: release-drafter/release-drafter@v5
+      - uses: release-drafter/release-drafter@ac463ffd9cc4c6ad5682af93dc3e3591c4657ee3 # v5.20.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/reusable_deploy_layer_stack.yml
+++ b/.github/workflows/reusable_deploy_layer_stack.yml
@@ -26,33 +26,31 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        region: [
-          "af-south-1",
-          #          "eu-central-1",
-          #          "us-east-1",
-          #          "us-east-2",
-          #          "us-west-1",
-          #          "us-west-2",
-          #          "ap-east-1",
-          #          "ap-south-1",
-          #          "ap-northeast-1",
-          #          "ap-northeast-2",
-          #          "ap-southeast-1",
-          #          "ap-southeast-2",
-          #          "ca-central-1",
-          #          "eu-west-1",
-          #          "eu-west-2",
-          #          "eu-west-3",
-          #          "eu-south-1",
-          #          "eu-north-1",
-          #          "sa-east-1",
-          #          "ap-southeast-3",
-          #          "ap-northeast-3",
-          #          "me-south-1"
-        ]
+        region: ["af-south-1"]
+    #          "eu-central-1",
+    #          "us-east-1",
+    #          "us-east-2",
+    #          "us-west-1",
+    #          "us-west-2",
+    #          "ap-east-1",
+    #          "ap-south-1",
+    #          "ap-northeast-1",
+    #          "ap-northeast-2",
+    #          "ap-southeast-1",
+    #          "ap-southeast-2",
+    #          "ca-central-1",
+    #          "eu-west-1",
+    #          "eu-west-2",
+    #          "eu-west-3",
+    #          "eu-south-1",
+    #          "eu-north-1",
+    #          "sa-east-1",
+    #          "ap-southeast-3",
+    #          "ap-northeast-3",
+    #          "me-south-1"
     steps:
       - name: checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: aws credentials
         uses: aws-actions/configure-aws-credentials@v1
         with:
@@ -61,12 +59,12 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: '16.12'
+          node-version: "16.12"
       - name: Setup python
         uses: actions/setup-python@v4
         with:
-          python-version: '3.9'
-          cache: 'pip'
+          python-version: "3.9"
+          cache: "pip"
       - name: install cdk and deps
         run: |
           npm install -g aws-cdk@2.29.0

--- a/.github/workflows/secure_workflows.yml
+++ b/.github/workflows/secure_workflows.yml
@@ -1,0 +1,32 @@
+name: Lockdown untrusted workflows
+
+on:
+  push:
+    paths:
+      - ".github/workflows/**"
+  pull_request:
+    paths:
+      - ".github/workflows/**"
+
+jobs:
+  enforce_pinned_workflows:
+    name: Harden Security
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+      - name: Ensure 3rd party workflows have SHA pinned
+        uses: zgosalvez/github-actions-ensure-sha-pinned-actions@6ca5574367befbc9efdb2fa25978084159c5902d # v1.3.0
+        with:
+          # Trusted GitHub Actions and/or organizations
+          allowlist: |
+            aws-actions/
+            actions/checkout
+            actions/github-script
+            actions/setup-node
+            actions/setup-python
+            actions/upload-artifact
+            actions/download-artifact
+            github/codeql-action/init
+            github/codeql-action/analyze
+            dependabot/fetch-metadata


### PR DESCRIPTION
**Issue number:** #1009 

## Summary

### Changes

> Please provide a summary of what's being changed

This PR increases our security posture following an older malicious token leak from codecov workflow (addressed last year). This guarantees that any change to GitHub Actions workflows that include or update 3rd party actions use pin to their respective git sha, thus making it an immutable use.

Official docs: https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions

### User experience

> Please share what the user experience looks like before and after this change

As a maintainer, we should see the following error when non-compliant:

![image](https://user-images.githubusercontent.com/3340292/179009607-6cc0babb-5755-431c-9811-83635485d1a8.png)


## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [ ] [Meet tenets criteria](https://awslabs.github.io/aws-lambda-powertools-python/#tenets)
* [ ] I have performed a self-review of my this change
* [ ] Changes are tested
* [ ] Changes are documented
* [ ] PR title follows [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-python/blob/376ec0a2ac0d2a40e0af5717bef42ff84ca0d1b9/.github/semantic.yml#L2)


<details>
<summary>Is this a breaking change?</summary>

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
