### PR TITLE
fix(ci): remove additional quotes in PR action

### DIFF
--- a/.github/scripts/constants.js
+++ b/.github/scripts/constants.js
@@ -1,7 +1,7 @@
 module.exports = Object.freeze({
     /** @type {string} */
     // Values: https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request
-    "PR_ACTION": process.env.PR_ACTION || "",
+    "PR_ACTION": process.env.PR_ACTION?.replace(/"/g, '') || "",
 
     /** @type {string} */
     "PR_AUTHOR": process.env.PR_AUTHOR?.replace(/"/g, '') || "",


### PR DESCRIPTION
**Issue number:** #1009 

## Summary

### Changes

> Please provide a summary of what's being changed

Removes possible additional quotes from GH Actions env to ensure conditional logic matches actual value.

Example of a new PR that wasn't labelled correctly: https://github.com/awslabs/aws-lambda-powertools-python/pull/1316

### User experience

> Please share what the user experience looks like before and after this change

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [ ] [Meet tenets criteria](https://awslabs.github.io/aws-lambda-powertools-python/#tenets)
* [ ] I have performed a self-review of my this change
* [ ] Changes are tested
* [ ] Changes are documented
* [ ] PR title follows [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-python/blob/376ec0a2ac0d2a40e0af5717bef42ff84ca0d1b9/.github/semantic.yml#L2)


<details>
<summary>Is this a breaking change?</summary>

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
