### PR TITLE
fix(ci): keep layer version permission resource

### DIFF
--- a/layer/layer/layer_stack.py
+++ b/layer/layer/layer_stack.py
@@ -1,4 +1,5 @@
 from aws_cdk import RemovalPolicy, Stack
+from aws_cdk.aws_lambda import CfnLayerVersionPermission
 from aws_cdk.aws_ssm import StringParameter
 from cdk_lambda_powertools_python_layer import LambdaPowertoolsLayer
 from constructs import Construct
@@ -14,7 +15,15 @@ class LayerStack(Stack):
             self, "Layer", layer_version_name="AWSLambdaPowertoolsPython", version=powertools_version
         )
 
-        layer.add_permission("PublicLayerAccess", account_id="*")
+        layer_permission = CfnLayerVersionPermission(
+            self,
+            "PublicLayerAccess",
+            action="lambda:GetLayerVersion",
+            layer_version_arn=layer.layer_version_arn,
+            principal="*",
+        )
+
+        layer_permission.apply_removal_policy(RemovalPolicy.RETAIN)
         layer.apply_removal_policy(RemovalPolicy.RETAIN)
 
         StringParameter(self, "VersionArn", parameter_name=ssm_paramter_layer_arn, string_value=layer.layer_version_arn)


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
**Issue number:**

## Summary

### Changes

While we can keep the previous layer version, the default removal policy on the permission is `DESTROY`. Thus deploying new version keeps layer version but removes the permission, so it is no longer publicly accessible. Thus, we need to use low level construct `CfnLayerVersionPermission` and set the removal policy. 

This bug has been reported to the CDK upstream project: https://github.com/aws/aws-cdk/issues/21232

### User experience

> Please share what the user experience looks like before and after this change

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] [Meet tenets criteria](https://awslabs.github.io/aws-lambda-powertools-python/#tenets)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [ ] Changes are documented
* [ ] PR title follows [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-dotnet/blob/develop/.github/semantic.yml)

<details>
<summary>Is this a breaking change?</summary>

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
