### PR TITLE
chore(layers): expand to all aws commercial regions

### DIFF
--- a/.github/workflows/reusable_deploy_layer_stack.yml
+++ b/.github/workflows/reusable_deploy_layer_stack.yml
@@ -26,30 +26,31 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        region: [
-          "af-south-1",
-          #          "eu-central-1",
-          #          "us-east-1",
-          #          "us-east-2",
-          #          "us-west-1",
-          #          "us-west-2",
-          #          "ap-east-1",
-          #          "ap-south-1",
-          #          "ap-northeast-1",
-          #          "ap-northeast-2",
-          #          "ap-southeast-1",
-          #          "ap-southeast-2",
-          #          "ca-central-1",
-          #          "eu-west-1",
-          #          "eu-west-2",
-          #          "eu-west-3",
-          #          "eu-south-1",
-          #          "eu-north-1",
-          #          "sa-east-1",
-          #          "ap-southeast-3",
-          #          "ap-northeast-3",
-          #          "me-south-1"
-        ]
+        region:
+          [
+            "af-south-1",
+            "eu-central-1",
+            "us-east-1",
+            "us-east-2",
+            "us-west-1",
+            "us-west-2",
+            "ap-east-1",
+            "ap-south-1",
+            "ap-northeast-1",
+            "ap-northeast-2",
+            "ap-southeast-1",
+            "ap-southeast-2",
+            "ca-central-1",
+            "eu-west-1",
+            "eu-west-2",
+            "eu-west-3",
+            "eu-south-1",
+            "eu-north-1",
+            "sa-east-1",
+            "ap-southeast-3",
+            "ap-northeast-3",
+            "me-south-1",
+          ]
     steps:
       - name: checkout
         uses: actions/checkout@v3

--- a/layer/layer/canary_stack.py
+++ b/layer/layer/canary_stack.py
@@ -1,6 +1,6 @@
 import uuid
 
-from aws_cdk import CfnParameter, CustomResource, Duration, Stack
+from aws_cdk import CfnOutput, CfnParameter, CustomResource, Duration, Stack
 from aws_cdk.aws_iam import Effect, ManagedPolicy, PolicyStatement, Role, ServicePrincipal
 from aws_cdk.aws_lambda import Code, Function, LayerVersion, Runtime
 from aws_cdk.aws_logs import RetentionDays
@@ -73,3 +73,5 @@ class CanaryStack(Stack):
         )
         # force to recreate resource on each deployment with randomized name
         CustomResource(self, f"CanaryTrigger-{str(uuid.uuid4())[0:7]}", service_token=provider.service_token)
+
+        CfnOutput(self, "LatestLayerArn", value=layer_arn)

--- a/layer/layer/canary_stack.py
+++ b/layer/layer/canary_stack.py
@@ -1,6 +1,6 @@
 import uuid
 
-from aws_cdk import CfnOutput, CfnParameter, CustomResource, Duration, Stack
+from aws_cdk import CfnParameter, CustomResource, Duration, Stack
 from aws_cdk.aws_iam import Effect, ManagedPolicy, PolicyStatement, Role, ServicePrincipal
 from aws_cdk.aws_lambda import Code, Function, LayerVersion, Runtime
 from aws_cdk.aws_logs import RetentionDays
@@ -73,5 +73,3 @@ class CanaryStack(Stack):
         )
         # force to recreate resource on each deployment with randomized name
         CustomResource(self, f"CanaryTrigger-{str(uuid.uuid4())[0:7]}", service_token=provider.service_token)
-
-        CfnOutput(self, "LatestLayerArn", value=layer_arn)

--- a/layer/layer/layer_stack.py
+++ b/layer/layer/layer_stack.py
@@ -1,4 +1,4 @@
-from aws_cdk import RemovalPolicy, Stack
+from aws_cdk import CfnOutput, RemovalPolicy, Stack
 from aws_cdk.aws_lambda import CfnLayerVersionPermission
 from aws_cdk.aws_ssm import StringParameter
 from cdk_lambda_powertools_python_layer import LambdaPowertoolsLayer
@@ -27,3 +27,5 @@ class LayerStack(Stack):
         layer.apply_removal_policy(RemovalPolicy.RETAIN)
 
         StringParameter(self, "VersionArn", parameter_name=ssm_paramter_layer_arn, string_value=layer.layer_version_arn)
+
+        CfnOutput(self, "LatestLayerArn", value=layer.layer_version_arn)


### PR DESCRIPTION
**Issue number:** #1183

## Summary

### Changes

> Please provide a summary of what's being changed

> Last successful run to Africa region: https://github.com/awslabs/aws-lambda-powertools-python/runs/7424696790?check_suite_focus=true

Expand public Lambda Layer deployment to all AWS commercial regions.

**Additional changes**

- [x] expose Layer ARN in CloudFormation Output to ease debugging in GH Actions

### User experience

> Please share what the user experience looks like before and after this change

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [ ] [Meet tenets criteria](https://awslabs.github.io/aws-lambda-powertools-python/#tenets)
* [ ] I have performed a self-review of this change
* [ ] Changes have been tested
* [ ] Changes are documented
* [ ] PR title follows [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-python/blob/develop/.github/semantic.yml)

<details>
<summary>Is this a breaking change?</summary>

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
