### PR TITLE
fix(event_handlers): handle lack of headers when using auto-compression feature

### DIFF
--- a/aws_lambda_powertools/utilities/data_classes/common.py
+++ b/aws_lambda_powertools/utilities/data_classes/common.py
@@ -32,13 +32,12 @@ def get_header_value(
     headers: Dict[str, str], name: str, default_value: Optional[str], case_sensitive: Optional[bool]
 ) -> Optional[str]:
     """Get header value by name"""
-    if case_sensitive:
-        return headers.get(name, default_value)
-
     # If headers is NoneType, return default value
     if not headers:
         return default_value
 
+    if case_sensitive:
+        return headers.get(name, default_value)
     name_lower = name.lower()
 
     return next(

--- a/aws_lambda_powertools/utilities/data_classes/common.py
+++ b/aws_lambda_powertools/utilities/data_classes/common.py
@@ -35,6 +35,10 @@ def get_header_value(
     if case_sensitive:
         return headers.get(name, default_value)
 
+    # If headers is NoneType, return default value
+    if not headers:
+        return default_value
+
     name_lower = name.lower()
 
     return next(

--- a/tests/functional/event_handler/test_api_gateway.py
+++ b/tests/functional/event_handler/test_api_gateway.py
@@ -314,6 +314,24 @@ def test_compress_no_accept_encoding():
     assert result["body"] == expected_value
 
 
+def test_compress_no_accept_encoding_null_headers():
+    # GIVEN a function with compress=True
+    # AND the request has no headers
+    app = ApiGatewayResolver()
+    expected_value = "Foo"
+
+    @app.get("/my/path", compress=True)
+    def return_text() -> Response:
+        return Response(200, content_types.TEXT_PLAIN, expected_value)
+
+    # WHEN calling the event handler
+    result = app({"path": "/my/path", "httpMethod": "GET", "headers": None}, None)
+
+    # THEN don't perform any gzip compression
+    assert result["isBase64Encoded"] is False
+    assert result["body"] == expected_value
+
+
 def test_cache_control_200():
     # GIVEN a function with cache_control set
     app = ApiGatewayResolver()


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->

**Issue number**: #1327 

## Summary

This PR add the ability use compress=True  in decorator without throwing an error for a request containing null headers

### Changes

* Add check for NoneType / null header in `get_header_value` function and return default if so
* Add corresponding unit test `test_compress_no_accept_encoding_null_headers`

### User experience

* Before
Error for a request with empty/null headers to a method with `compress=True`:
`'NoneType' object has no attribute 'items'", "errorType": "AttributeError"`  

That was due to an error from api_gateway.py at line 212:

```python
 if self.route.compress and "gzip" in (event.get_header_value("accept-encoding", "") or ""):
```

* After 

No more error, return default value as expected. 

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] [Meet tenets criteria](https://awslabs.github.io/aws-lambda-powertools-python/#tenets)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [ ] Changes are documented
* [x ] PR title follows [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-python/blob/develop/.github/semantic.yml)

<details>
<summary>Is this a breaking change?</summary>

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
