### PR TITLE
chore(governance): add new maintenance issue template for tech debt and governance

### DIFF
--- a/.github/ISSUE_TEMPLATE/maintenance.yml
+++ b/.github/ISSUE_TEMPLATE/maintenance.yml
@@ -1,0 +1,73 @@
+name: Maintenance
+description: Suggest an activity to help address tech debt, governance, and anything internal
+title: "Maintenance: TITLE"
+labels: ["internal", "triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thank you for taking the time to help us improve operational excellence.
+
+        *Future readers*: Please react with 👍 and your use case to help us understand customer demand.
+  - type: textarea
+    id: activity
+    attributes:
+      label: Technical debt
+      description: Please provide an overview in one or two paragraphs
+    validations:
+      required: true
+  - type: textarea
+    id: importance
+    attributes:
+      label: Why is this needed?
+      description: Please help us understand the value so we can prioritize it accordingly
+    validations:
+      required: true
+  - type: dropdown
+    id: area
+    attributes:
+      label: Which area does this relate to?
+      multiple: true
+      options:
+        - Automation
+        - Governance
+        - Tests
+        - Static typing
+        - Tracer
+        - Logger
+        - Metrics
+        - Event Handler - REST API
+        - Event Handler - GraphQL API
+        - Middleware factory
+        - Parameters
+        - Batch processing
+        - Typing
+        - Validation
+        - Event Source Data Classes
+        - Parser
+        - Idempotency
+        - Feature flags
+        - JMESPath functions
+        - Other
+  - type: textarea
+    id: suggestion
+    attributes:
+      label: Solution
+      description: If available, please share what a good solution would look like
+    validations:
+      required: false
+  - type: checkboxes
+    id: acknowledgment
+    attributes:
+      label: Acknowledgment
+      options:
+        - label: This request meets [Lambda Powertools Tenets](https://awslabs.github.io/aws-lambda-powertools-python/latest/#tenets)
+          required: true
+        - label: Should this be considered in other Lambda Powertools languages? i.e. [Java](https://github.com/awslabs/aws-lambda-powertools-java/), [TypeScript](https://github.com/awslabs/aws-lambda-powertools-typescript/)
+          required: false
+  - type: markdown
+    attributes:
+      value: |
+        ---
+
+        **Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -57,39 +57,39 @@ Previous active maintainers who contributed to this project.
 
 These are the most common labels used by maintainers to triage issues, pull requests (PR), and for project management:
 
-| Label                  | Usage                                                            | Notes                                                           |
-| ---------------------- | ---------------------------------------------------------------- | --------------------------------------------------------------- |
-| triage                 | New issues that require maintainers review                       | Issue template                                                  |
-| bug                    | Unexpected, reproducible and unintended software behavior        | PR/Release automation; Doc snippets are excluded;               |
-| not-a-bug              | New and existing bug reports incorrectly submitted as bug        | Analytics                                                       |
-| documentation          | Documentation improvements                                       | PR/Release automation; Doc additions, fixes, etc.;              |
-| feature-request        | New or enhancements to existing features                         | Issue template                                                  |
-| typing                 | New or enhancements to static typing                             | Issue template                                                  |
-| RFC                    | Technical design documents related to a feature request          | Issue template                                                  |
-| bug-upstream           | Bug caused by upstream dependency                                |                                                                 |
-| help wanted            | Tasks you want help from anyone to move forward                  | Bandwidth, complex topics, etc.                                 |
-| need-customer-feedback | Tasks that need more feedback before proceeding                  | 80/20% rule, uncertain, etc.                                    |
-| need-more-information  | Missing information before making any calls                      |                                                                 |
-| need-documentation     | PR is missing or has incomplete documentation                    |                                                                 |
-| need-issue             | PR is missing a related issue for tracking change                | Needs to be automated                                           |
-| need-rfc               | Feature request requires a RFC to improve discussion             |                                                                 |
-| pending-release        | Merged changes that will be available soon                       | Release automation auto-closes/notifies it                      |
-| revisit-in-3-months    | Blocked issues/PRs that need to be revisited                     | Often related to `need-customer-feedback`, prioritization, etc. |
-| breaking-change        | Changes that will cause customer impact and need careful triage  |                                                                 |
-| do-not-merge           | PRs that are blocked for varying reasons                         | Timeline is uncertain                                           |
-| size/XS                | PRs between 0-9 LOC                                              | PR automation                                                   |
-| size/S                 | PRs between 10-29 LOC                                            | PR automation                                                   |
-| size/M                 | PRs between 30-99 LOC                                            | PR automation                                                   |
-| size/L                 | PRs between 100-499 LOC                                          | PR automation                                                   |
-| size/XL                | PRs between 500-999 LOC, often PRs that grown with feedback      | PR automation                                                   |
-| size/XXL               | PRs with 1K+ LOC, largely documentation related                  | PR automation                                                   |
-| tests                  | PRs that add or change tests                                     | PR automation                                                   |
-| `<utility>`            | PRs related to a Powertools utility, e.g. `parameters`, `tracer` | PR automation                                                   |
-| feature                | New features or minor changes                                    | PR/Release automation                                           |
-| dependencies           | Changes that touch dependencies, e.g. Dependabot, etc.           | PR/ automation                                                  |
-| github-actions         | Changes in GitHub workflows                                      | PR automation                                                   |
-| github-templates       | Changes in GitHub issue/PR templates                             | PR automation                                                   |
-| internal               | Changes in governance and chores (linting setup, baseline, etc.) | PR automation                                                   |
+| Label                  | Usage                                                                       | Notes                                                           |
+| ---------------------- | --------------------------------------------------------------------------- | --------------------------------------------------------------- |
+| triage                 | New issues that require maintainers review                                  | Issue template                                                  |
+| bug                    | Unexpected, reproducible and unintended software behavior                   | PR/Release automation; Doc snippets are excluded;               |
+| not-a-bug              | New and existing bug reports incorrectly submitted as bug                   | Analytics                                                       |
+| documentation          | Documentation improvements                                                  | PR/Release automation; Doc additions, fixes, etc.;              |
+| feature-request        | New or enhancements to existing features                                    | Issue template                                                  |
+| typing                 | New or enhancements to static typing                                        | Issue template                                                  |
+| RFC                    | Technical design documents related to a feature request                     | Issue template                                                  |
+| bug-upstream           | Bug caused by upstream dependency                                           |                                                                 |
+| help wanted            | Tasks you want help from anyone to move forward                             | Bandwidth, complex topics, etc.                                 |
+| need-customer-feedback | Tasks that need more feedback before proceeding                             | 80/20% rule, uncertain, etc.                                    |
+| need-more-information  | Missing information before making any calls                                 |                                                                 |
+| need-documentation     | PR is missing or has incomplete documentation                               |                                                                 |
+| need-issue             | PR is missing a related issue for tracking change                           | Needs to be automated                                           |
+| need-rfc               | Feature request requires a RFC to improve discussion                        |                                                                 |
+| pending-release        | Merged changes that will be available soon                                  | Release automation auto-closes/notifies it                      |
+| revisit-in-3-months    | Blocked issues/PRs that need to be revisited                                | Often related to `need-customer-feedback`, prioritization, etc. |
+| breaking-change        | Changes that will cause customer impact and need careful triage             |                                                                 |
+| do-not-merge           | PRs that are blocked for varying reasons                                    | Timeline is uncertain                                           |
+| size/XS                | PRs between 0-9 LOC                                                         | PR automation                                                   |
+| size/S                 | PRs between 10-29 LOC                                                       | PR automation                                                   |
+| size/M                 | PRs between 30-99 LOC                                                       | PR automation                                                   |
+| size/L                 | PRs between 100-499 LOC                                                     | PR automation                                                   |
+| size/XL                | PRs between 500-999 LOC, often PRs that grown with feedback                 | PR automation                                                   |
+| size/XXL               | PRs with 1K+ LOC, largely documentation related                             | PR automation                                                   |
+| tests                  | PRs that add or change tests                                                | PR automation                                                   |
+| `<utility>`            | PRs related to a Powertools utility, e.g. `parameters`, `tracer`            | PR automation                                                   |
+| feature                | New features or minor changes                                               | PR/Release automation                                           |
+| dependencies           | Changes that touch dependencies, e.g. Dependabot, etc.                      | PR/ automation                                                  |
+| github-actions         | Changes in GitHub workflows                                                 | PR automation                                                   |
+| github-templates       | Changes in GitHub issue/PR templates                                        | PR automation                                                   |
+| internal               | Changes in governance, tech debt and chores (linting setup, baseline, etc.) | PR automation                                                   |
 
 ## Maintainer Responsibilities
 


### PR DESCRIPTION
**Issue number:** #1009 

## Summary

### Changes

> Please provide a summary of what's being changed

Introduces a new issue template to better classify all work related to governance, automation, internal, and tech debt. This will allow us to migrate issues in  #1009 and on [public board](https://github.com/orgs/awslabs/projects/51/views/11). These   haven't been converted to issues due to not belonging to existing templates.

**Question**: Should we keep `internal` label for these or create a new label?

Pros of keeping `internal`: Already defined in MAINTAINERS.md, PR and Release drafting automation

### User experience

> Please share what the user experience looks like before and after this change

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [ ] [Meet tenets criteria](https://awslabs.github.io/aws-lambda-powertools-python/#tenets)
* [ ] I have performed a self-review of this change
* [ ] Changes have been tested
* [ ] Changes are documented
* [ ] PR title follows [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-python/blob/develop/.github/semantic.yml)

<details>
<summary>Is this a breaking change?</summary>

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.


-----
[View rendered MAINTAINERS.md](https://github.com/heitorlessa/aws-lambda-powertools-python/blob/chore/add-maintenance-issue-template/MAINTAINERS.md)