### PR TITLE
chore(layers): replace layers account secret

### DIFF
--- a/.github/workflows/publish_layer.yml
+++ b/.github/workflows/publish_layer.yml
@@ -16,7 +16,6 @@ on:
     types:
       - completed
 
-
 jobs:
   build-layer:
     runs-on: ubuntu-latest
@@ -69,7 +68,7 @@ jobs:
       stage: "BETA"
       artefact-name: "cdk-layer-artefact"
     secrets:
-      target-account-role: arn:aws:iam::${{ secrets.LAYERS_BETA_ACCOUNT }}:role/${{ secrets.AWS_GITHUB_OIDC_ROLE }}
+      target-account-role: ${{ secrets.AWS_LAYERS_BETA_ROLE_ARN }}
 
   deploy-prod:
     needs:
@@ -79,4 +78,4 @@ jobs:
       stage: "PROD"
       artefact-name: "cdk-layer-artefact"
     secrets:
-      target-account-role: arn:aws:iam::${{ secrets.LAYERS_PROD_ACCOUNT }}:role/${{ secrets.AWS_GITHUB_OIDC_ROLE }}
+      target-account-role: ${{ secrets.AWS_LAYERS_PROD_ROLE_ARN }}


### PR DESCRIPTION
**Issue number:** #1328

## Summary

### Changes

> Please provide a summary of what's being changed

This change updates our Lambda Layer prod account (beta remains the same) to point to the AWS Account ID documented in our documentation.

### User experience

> Please share what the user experience looks like before and after this change

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [ ] [Meet tenets criteria](https://awslabs.github.io/aws-lambda-powertools-python/#tenets)
* [ ] I have performed a self-review of this change
* [ ] Changes have been tested
* [ ] Changes are documented
* [ ] PR title follows [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-python/blob/develop/.github/semantic.yml)

<details>
<summary>Is this a breaking change?</summary>

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
