### PR TITLE
chore(ci): lockdown workflow_run by origin

### DIFF
--- a/.github/workflows/label_pr_on_title.yml
+++ b/.github/workflows/label_pr_on_title.yml
@@ -14,6 +14,7 @@ jobs:
     uses: ./.github/workflows/reusable_export_pr_details.yml
     with:
       record_pr_workflow_id: ${{ github.event.workflow_run.id }}
+      workflow_origin: ${{ github.event.repository.full_name }}
     secrets:
       token: ${{ secrets.GITHUB_TOKEN }}
   label_pr:

--- a/.github/workflows/on_merged_pr.yml
+++ b/.github/workflows/on_merged_pr.yml
@@ -12,6 +12,7 @@ jobs:
     uses: ./.github/workflows/reusable_export_pr_details.yml
     with:
       record_pr_workflow_id: ${{ github.event.workflow_run.id }}
+      workflow_origin: ${{ github.event.repository.full_name }}
     secrets:
       token: ${{ secrets.GITHUB_TOKEN }}
   release_label_on_merge:

--- a/.github/workflows/on_opened_pr.yml
+++ b/.github/workflows/on_opened_pr.yml
@@ -19,6 +19,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+      - name: "Debug workflow_run event"
+        run: echo ${{ toJSON(github.event) }}
       - name: "Ensure related issue is present"
         uses: actions/github-script@v6
         env:

--- a/.github/workflows/on_opened_pr.yml
+++ b/.github/workflows/on_opened_pr.yml
@@ -20,8 +20,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: "Debug workflow_run event"
-        run: echo ${{ toJSON(github.event) }}
       - name: "Ensure related issue is present"
         uses: actions/github-script@v6
         env:

--- a/.github/workflows/on_opened_pr.yml
+++ b/.github/workflows/on_opened_pr.yml
@@ -12,6 +12,7 @@ jobs:
     uses: ./.github/workflows/reusable_export_pr_details.yml
     with:
       record_pr_workflow_id: ${{ github.event.workflow_run.id }}
+      workflow_origin: ${{ github.event.repository.full_name }}
     secrets:
       token: ${{ secrets.GITHUB_TOKEN }}
   check_related_issue:

--- a/.github/workflows/reusable_export_pr_details.yml
+++ b/.github/workflows/reusable_export_pr_details.yml
@@ -6,6 +6,9 @@ on:
       record_pr_workflow_id:
         required: true
         type: number
+      workflow_origin: # see https://github.com/awslabs/aws-lambda-powertools-python/issues/1349
+        required: true
+        type: string
     secrets:
       token:
         required: true
@@ -32,6 +35,8 @@ on:
 
 jobs:
   export_pr_details:
+    # see https://github.com/awslabs/aws-lambda-powertools-python/issues/1349
+    if: inputs.workflow_origin == 'awslabs/aws-lambda-powertools-python'
     runs-on: ubuntu-latest
     env:
       FILENAME: pr.txt


### PR DESCRIPTION
**Issue number:** #1349

## Summary

### Changes

> Please provide a summary of what's being changed

Introduces `workflow_origin` input in central workflow that extracts PR information, and only run from the base repo. It updates all workflows that handle PR automation (on new PR, on merge, on PR title)

### User experience

> Please share what the user experience looks like before and after this change

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] [Meet tenets criteria](https://awslabs.github.io/aws-lambda-powertools-python/#tenets)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented
* [x] PR title follows [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-python/blob/develop/.github/semantic.yml)

<details>
<summary>Is this a breaking change?</summary>

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
