### PR TITLE
chore(ci): use gh environment for beta and prod layer deploy

### DIFF
--- a/.github/workflows/publish_layer.yml
+++ b/.github/workflows/publish_layer.yml
@@ -67,8 +67,7 @@ jobs:
     with:
       stage: "BETA"
       artefact-name: "cdk-layer-artefact"
-    secrets:
-      target-account-role: ${{ secrets.AWS_LAYERS_BETA_ROLE_ARN }}
+      environment: "layer-beta"
 
   deploy-prod:
     needs:
@@ -77,5 +76,4 @@ jobs:
     with:
       stage: "PROD"
       artefact-name: "cdk-layer-artefact"
-    secrets:
-      target-account-role: ${{ secrets.AWS_LAYERS_PROD_ROLE_ARN }}
+      environment: "layer-prod"

--- a/.github/workflows/reusable_deploy_layer_stack.yml
+++ b/.github/workflows/reusable_deploy_layer_stack.yml
@@ -13,6 +13,9 @@ on:
       artefact-name:
         required: true
         type: string
+      environment:
+        required: true
+        type: string
     secrets:
       target-account-role:
         required: true
@@ -20,6 +23,7 @@ on:
 jobs:
   deploy-cdk-stack:
     runs-on: ubuntu-latest
+    environment: ${{ inputs.environment }}
     defaults:
       run:
         working-directory: ./layer
@@ -58,7 +62,7 @@ jobs:
         uses: aws-actions/configure-aws-credentials@v1
         with:
           aws-region: ${{ matrix.region }}
-          role-to-assume: ${{ secrets.target-account-role }}
+          role-to-assume: ${{ secrets.AWS_LAYERS_ROLE_ARN }}
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
**Issue number:** #1354 

## Summary

Add layer specific environment in GitHub so we can use account specific secrets without passing the role name.

### Changes

> Please provide a summary of what's being changed

### User experience

> Please share what the user experience looks like before and after this change

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [ ] [Meet tenets criteria](https://awslabs.github.io/aws-lambda-powertools-python/#tenets)
* [ ] I have performed a self-review of this change
* [ ] Changes have been tested
* [ ] Changes are documented
* [ ] PR title follows [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-python/blob/develop/.github/semantic.yml)

<details>
<summary>Is this a breaking change?</summary>

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
