### PR TITLE
fix(event_handlers): ImportError when importing Response from top-level event_handler

### DIFF
--- a/aws_lambda_powertools/event_handler/__init__.py
+++ b/aws_lambda_powertools/event_handler/__init__.py
@@ -12,5 +12,5 @@ __all__ = [
     "ALBResolver",
     "ApiGatewayResolver",
     "CORSConfig",
-    "Response"
+    "Response",
 ]

--- a/aws_lambda_powertools/event_handler/__init__.py
+++ b/aws_lambda_powertools/event_handler/__init__.py
@@ -2,7 +2,7 @@
 Event handler decorators for common Lambda events
 """
 
-from .api_gateway import ALBResolver, APIGatewayHttpResolver, ApiGatewayResolver, APIGatewayRestResolver, CORSConfig
+from .api_gateway import ALBResolver, APIGatewayHttpResolver, ApiGatewayResolver, APIGatewayRestResolver, CORSConfig, Response
 from .appsync import AppSyncResolver
 
 __all__ = [
@@ -12,4 +12,5 @@ __all__ = [
     "ALBResolver",
     "ApiGatewayResolver",
     "CORSConfig",
+    "Response"
 ]


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
**Issue number:** #1389

## Summary
The docs mention a `Response` that allows one to customize a Response that gets returned to API Gateway

https://awslabs.github.io/aws-lambda-powertools-python/latest/core/event_handler/api_gateway/#fine-grained-responses

However, in the current version the Response object is not included in the `__init__.py` file located in the `event_handler` sub package. This PR fixes that.

### Changes
Very minor.

### User experience
None. It will match what the documentation mentions.

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [ ] [Meet tenets criteria](https://awslabs.github.io/aws-lambda-powertools-python/#tenets)
* [ ] I have performed a self-review of this change
* [ ] Changes have been tested
* [ ] Changes are documented
* [ ] PR title follows [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-python/blob/develop/.github/semantic.yml)

<details>
<summary>Is this a breaking change?</summary>

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
