### PR TITLE
chore(maintenance): Change the project.toml to restrict Python 3.10 version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ keywords = ["aws_lambda_powertools", "aws", "tracing", "logging", "lambda", "pow
 license = "MIT-0"
 
 [tool.poetry.dependencies]
-python = "^3.6.2"
+python = "^3.6.2, < 3.10"
 aws-xray-sdk = "^2.8.0"
 fastjsonschema = "^2.14.5"
 boto3 = "^1.18"


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
**Issue number:** #1404 

## Summary

### Changes

Added a restriction in project.toml to only accept Python versions higher than 3.6.2 and lower than 3.10.

@heitorlessa @rubenfonseca should we add a paragraph to ensure that contributors/users are aware of this restriction? 

### User experience

Before: User could install the Lambda Powertools project even using Python 3.10. 
![image](https://user-images.githubusercontent.com/4295173/182668156-28c7db15-e756-47a0-b1cb-2bdab3f06104.png)
![image](https://user-images.githubusercontent.com/4295173/182668503-f4457a9f-23ae-4fd4-b536-839cc54bf124.png)

After: User must use python lower than 3.10
![image](https://user-images.githubusercontent.com/4295173/182668642-a24766e2-9ea0-4626-a308-5231d15e636c.png)
![image](https://user-images.githubusercontent.com/4295173/182668901-b773c564-b921-48bb-81ca-009e9eed2539.png)



## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] [Meet tenets criteria](https://awslabs.github.io/aws-lambda-powertools-python/#tenets)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [ ] Changes are documented
* [x] PR title follows [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-python/blob/develop/.github/semantic.yml)

<details>
<summary>Is this a breaking change?</summary>

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
