### PR TITLE
feat(metrics): update max user-defined dimensions from 9 to 29

### DIFF
--- a/aws_lambda_powertools/metrics/base.py
+++ b/aws_lambda_powertools/metrics/base.py
@@ -14,7 +14,7 @@ from .exceptions import MetricUnitError, MetricValueError, SchemaValidationError
 logger = logging.getLogger(__name__)
 
 MAX_METRICS = 100
-MAX_DIMENSIONS = 9
+MAX_DIMENSIONS = 29
 
 
 class MetricUnit(Enum):
@@ -233,7 +233,7 @@ class MetricManager:
             Dimension value
         """
         logger.debug(f"Adding dimension: {name}:{value}")
-        if len(self.dimension_set) == 9:
+        if len(self.dimension_set) == MAX_DIMENSIONS:
             raise SchemaValidationError(
                 f"Maximum number of dimensions exceeded ({MAX_DIMENSIONS}): Unable to add dimension {name}."
             )

--- a/docs/core/metrics.md
+++ b/docs/core/metrics.md
@@ -133,7 +133,7 @@ This decorator also **validates**, **serializes**, and **flushes** all your metr
 ???+ tip "Tip: Metric validation"
     If metrics are provided, and any of the following criteria are not met, **`SchemaValidationError`** exception will be raised:
 
-    * Maximum of 8 user-defined dimensions
+    * Maximum of 29 user-defined dimensions
     * Namespace is set, and no more than one
     * Metric units must be [supported by CloudWatch](https://docs.aws.amazon.com/AmazonCloudWatch/latest/APIReference/API_MetricDatum.html)
 

--- a/tests/functional/test_metrics.py
+++ b/tests/functional/test_metrics.py
@@ -8,7 +8,7 @@ import pytest
 from aws_lambda_powertools import Metrics, single_metric
 from aws_lambda_powertools.metrics import MetricUnit, MetricUnitError, MetricValueError, SchemaValidationError
 from aws_lambda_powertools.metrics import metrics as metrics_global
-from aws_lambda_powertools.metrics.base import MetricManager
+from aws_lambda_powertools.metrics.base import MAX_DIMENSIONS, MetricManager
 
 
 @pytest.fixture(scope="function", autouse=True)
@@ -321,7 +321,7 @@ def test_schema_no_metrics(service, namespace):
 
 def test_exceed_number_of_dimensions(metric, namespace):
     # GIVEN we have more dimensions than CloudWatch supports (N+1)
-    dimensions = [{"name": f"test_{i}", "value": "test"} for i in range(31)]
+    dimensions = [{"name": f"test_{i}", "value": "test"} for i in range(MAX_DIMENSIONS + 2)]
 
     # WHEN we attempt to serialize them into a valid EMF object
     # THEN it should fail validation and raise SchemaValidationError
@@ -334,7 +334,7 @@ def test_exceed_number_of_dimensions(metric, namespace):
 def test_exceed_number_of_dimensions_with_service(metric, namespace, monkeypatch):
     # GIVEN we have service set and add more dimensions than CloudWatch supports (N-1)
     monkeypatch.setenv("POWERTOOLS_SERVICE_NAME", "test_service")
-    dimensions = [{"name": f"test_{i}", "value": "test"} for i in range(29)]
+    dimensions = [{"name": f"test_{i}", "value": "test"} for i in range(MAX_DIMENSIONS)]
 
     # WHEN we attempt to serialize them into a valid EMF object
     # THEN it should fail validation and raise SchemaValidationError

--- a/tests/functional/test_metrics.py
+++ b/tests/functional/test_metrics.py
@@ -320,8 +320,8 @@ def test_schema_no_metrics(service, namespace):
 
 
 def test_exceed_number_of_dimensions(metric, namespace):
-    # GIVEN we have more dimensions than CloudWatch supports
-    dimensions = [{"name": f"test_{i}", "value": "test"} for i in range(11)]
+    # GIVEN we have more dimensions than CloudWatch supports (N+1)
+    dimensions = [{"name": f"test_{i}", "value": "test"} for i in range(31)]
 
     # WHEN we attempt to serialize them into a valid EMF object
     # THEN it should fail validation and raise SchemaValidationError
@@ -332,9 +332,9 @@ def test_exceed_number_of_dimensions(metric, namespace):
 
 
 def test_exceed_number_of_dimensions_with_service(metric, namespace, monkeypatch):
-    # GIVEN we have service set and add more dimensions than CloudWatch supports (N+1)
+    # GIVEN we have service set and add more dimensions than CloudWatch supports (N-1)
     monkeypatch.setenv("POWERTOOLS_SERVICE_NAME", "test_service")
-    dimensions = [{"name": f"test_{i}", "value": "test"} for i in range(9)]
+    dimensions = [{"name": f"test_{i}", "value": "test"} for i in range(29)]
 
     # WHEN we attempt to serialize them into a valid EMF object
     # THEN it should fail validation and raise SchemaValidationError

--- a/tests/functional/test_metrics.py
+++ b/tests/functional/test_metrics.py
@@ -321,7 +321,7 @@ def test_schema_no_metrics(service, namespace):
 
 def test_exceed_number_of_dimensions(metric, namespace):
     # GIVEN we have more dimensions than CloudWatch supports (N+1)
-    dimensions = [{"name": f"test_{i}", "value": "test"} for i in range(MAX_DIMENSIONS + 2)]
+    dimensions = [{"name": f"test_{i}", "value": "test"} for i in range(MAX_DIMENSIONS + 1)]
 
     # WHEN we attempt to serialize them into a valid EMF object
     # THEN it should fail validation and raise SchemaValidationError


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
**Issue number:** #1413

## Summary

### Changes

Amazon added support to up 30 dimensions per metric. In this PR we increase this limit

### User experience

Before: User could add up to 10 dimensions per user defined metric

After: User can add up to 30 dimensions per user defined metric.

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] [Meet tenets criteria](https://awslabs.github.io/aws-lambda-powertools-python/#tenets)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [ ] Changes are documented
* [x] PR title follows [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-python/blob/develop/.github/semantic.yml)

<details>
<summary>Is this a breaking change?</summary>

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
