### PR TITLE
feat(ci): create reusable changelog generation

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -97,10 +97,15 @@ jobs:
 
   changelog:
     needs: release
+    permissions:
+      contents: write
     uses: ./.github/workflows/reusable_publish_changelog.yml
 
   docs:
     needs: [release, changelog]
+    permissions:
+      contents: write
+      pages: write
     runs-on: ubuntu-latest
     env:
       RELEASE_VERSION: ${{ needs.release.outputs.RELEASE_VERSION }}
@@ -142,6 +147,11 @@ jobs:
 
   post_release:
     needs: release
+    permissions:
+      contents: read
+      issues: write
+      discussions: write
+      pull-requests: write
     runs-on: ubuntu-latest
     env:
       RELEASE_VERSION: ${{ needs.release.outputs.RELEASE_VERSION }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,8 +14,9 @@ name: Publish to PyPi
 # 3. Bump package version and generate latest Changelog
 # 4. Publish package to PyPi test and prod repository
 # 5. Kick off SAR App pipeline to publish latest version with minimal and extra dependencies
-# 6. Builds a new user guide and API docs with release version; update /latest pointing to newly released version
-# 7. Close all issues labeled "pending-release" and notify customers about the release
+# 6. Builds and publish latest changelog from tip of the branch
+# 7. Builds a new user guide and API docs with release version; update /latest pointing to newly released version
+# 8. Close all issues labeled "pending-release" and notify customers about the release
 
 # See MAINTAINERS.md "Releasing a new version" for release mechanisms
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -33,6 +33,11 @@ on:
         default: false
         type: boolean
         required: false
+      skip_code_quality:
+        description: "Skip tests, linting, and baseline. Only use if release fail for reasons beyond our control and you need a quick release."
+        default: false
+        type: boolean
+        required: false
 
 jobs:
   release:
@@ -66,7 +71,7 @@ jobs:
       - name: Install dependencies
         run: make dev
       - name: Run all tests, linting and baselines
-        if: ${{ !inputs.skip_pypi }}
+        if: ${{ !inputs.skip_code_quality }}
         run: make pr
       - name: Bump package version
         run: poetry version ${RELEASE_VERSION}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -95,8 +95,12 @@ jobs:
           aws ssm put-parameter --name "powertools-python-release-version" --value $RELEASE_VERSION --overwrite
           aws codepipeline start-pipeline-execution --name ${{ secrets.AWS_SAR_PIPELINE_NAME }}
 
-  docs:
+  changelog:
     needs: release
+    uses: ./.github/workflows/reusable_publish_changelog.yml
+
+  docs:
+    needs: [release, changelog]
     runs-on: ubuntu-latest
     env:
       RELEASE_VERSION: ${{ needs.release.outputs.RELEASE_VERSION }}

--- a/.github/workflows/python_docs.yml
+++ b/.github/workflows/python_docs.yml
@@ -13,7 +13,13 @@ on:
       - "examples/**"
 
 jobs:
+  changelog:
+    permissions:
+      contents: write
+    uses: ./.github/workflows/reusable_publish_changelog.yml
+
   docs:
+    needs: changelog
     # Force Github action to run only a single job at a time (based on the group name)
     # This is to prevent "race-condition" in publishing a new version of doc to `gh-pages`
     concurrency:

--- a/.github/workflows/rebuild_latest_docs.yml
+++ b/.github/workflows/rebuild_latest_docs.yml
@@ -16,7 +16,13 @@ on:
         required: true
 
 jobs:
+  changelog:
+    permissions:
+      contents: write
+    uses: ./.github/workflows/reusable_publish_changelog.yml
+
   release:
+    needs: changelog
     # Force Github action to run only a single job at a time (based on the group name)
     # This is to prevent "race-condition" in publishing a new version of doc to `gh-pages`
     concurrency:
@@ -43,14 +49,6 @@ jobs:
         run: |
           git config --global user.name Docs deploy
           git config --global user.email aws-devax-open-source@amazon.com
-      - name: Generate latest CHANGELOG
-        run: make changelog
-      - name: Push project metadata and changelog to trunk
-        run: |
-          git add CHANGELOG.md
-          git add pyproject.toml
-          git commit -m "chore(ci): update project with version ${RELEASE_TAG_VERSION}"
-          git push origin HEAD:refs/heads/develop
       - name: Build docs website and API reference
         run: |
           make release-docs VERSION=${RELEASE_TAG_VERSION} ALIAS="latest"

--- a/.github/workflows/reusable_publish_changelog.yml
+++ b/.github/workflows/reusable_publish_changelog.yml
@@ -1,0 +1,31 @@
+name: Build and publish latest changelog
+
+on:
+  workflow_call:
+
+permissions:
+  contents: write
+
+jobs:
+  publish_changelog:
+    # Force Github action to run only a single job at a time (based on the group name)
+    # This is to prevent race-condition and inconsistencies with changelog push
+    concurrency:
+      group: changelog-build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository # reusable workflows start clean, so we need to checkout again
+        uses: actions/checkout@v3
+      - name: Git client setup and refresh tip
+        run: |
+          git config user.name "Release bot"
+          git config user.email "aws-devax-open-source@amazon.com"
+          git config pull.rebase true
+          git pull --rebase
+      - name: "Generate latest changelog"
+        run: make changelog
+      - name: Update Changelog in trunk
+        run: |
+          git add CHANGELOG.md
+          git commit -m "chore(ci): update changelog with latest changes"
+          git push origin HEAD:refs/heads/develop


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
**Issue number:** #1398

## Summary

### Changes

> Please provide a summary of what's being changed

This PR introduces a reusable workflow to update changelog, and correct permissions that made release failed last time - both related to the introduction of changelog generation.

**Tasks**

* [x] include changelog generation on docs build
* [x] update release automated activities docs
* [x] add additional release input to accurately describe intent on skip
* [x] job permissions
* [x] read changelog step on release
* [x] create reusable changelog workflow
* [x] update rebuild latest doc workflow to use new changelog worklfow
* [x] correct race condition when files are changed halfway through changelogs are pushed

### User experience

> Please share what the user experience looks like before and after this change

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [ ] [Meet tenets criteria](https://awslabs.github.io/aws-lambda-powertools-python/#tenets)
* [ ] I have performed a self-review of this change
* [ ] Changes have been tested
* [ ] Changes are documented
* [ ] PR title follows [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-python/blob/develop/.github/semantic.yml)

<details>
<summary>Is this a breaking change?</summary>

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
