### PR TITLE
fix(event_sources): add test for Function URL AuthZ

### DIFF
--- a/aws_lambda_powertools/utilities/data_classes/api_gateway_proxy_event.py
+++ b/aws_lambda_powertools/utilities/data_classes/api_gateway_proxy_event.py
@@ -124,7 +124,7 @@ class RequestContextV2AuthorizerIam(DictWrapper):
         return self.get("callerId")
 
     def _cognito_identity(self) -> Dict:
-        return self.get("cognitoIdentity", {}) or {}
+        return self.get("cognitoIdentity", {}) or {}  # not available in FunctionURL
 
     @property
     def cognito_amr(self) -> Optional[List[str]]:

--- a/aws_lambda_powertools/utilities/data_classes/api_gateway_proxy_event.py
+++ b/aws_lambda_powertools/utilities/data_classes/api_gateway_proxy_event.py
@@ -123,26 +123,26 @@ class RequestContextV2AuthorizerIam(DictWrapper):
         """The principal identifier of the caller making the request."""
         return self.get("callerId")
 
+    def _cognito_identity(self) -> Dict:
+        return self.get("cognitoIdentity", {}) or {}
+
     @property
     def cognito_amr(self) -> Optional[List[str]]:
         """This represents how the user was authenticated.
         AMR stands for  Authentication Methods References as per the openid spec"""
-        cognito_identity = self["cognitoIdentity"] or {}  # not available in FunctionURL
-        return cognito_identity.get("amr")
+        return self._cognito_identity().get("amr")
 
     @property
     def cognito_identity_id(self) -> Optional[str]:
         """The Amazon Cognito identity ID of the caller making the request.
         Available only if the request was signed with Amazon Cognito credentials."""
-        cognito_identity = self.get("cognitoIdentity") or {}  # not available in FunctionURL
-        return cognito_identity.get("identityId")
+        return self._cognito_identity().get("identityId")
 
     @property
     def cognito_identity_pool_id(self) -> Optional[str]:
         """The Amazon Cognito identity pool ID of the caller making the request.
         Available only if the request was signed with Amazon Cognito credentials."""
-        cognito_identity = self.get("cognitoIdentity") or {}  # not available in FunctionURL
-        return cognito_identity.get("identityPoolId")
+        return self._cognito_identity().get("identityPoolId")
 
     @property
     def principal_org_id(self) -> Optional[str]:

--- a/tests/events/lambdaFunctionUrlEvent.json
+++ b/tests/events/lambdaFunctionUrlEvent.json
@@ -1,52 +1,47 @@
 {
-  "version": "2.0",
-  "routeKey": "$default",
-  "rawPath": "/my/path",
-  "rawQueryString": "parameter1=value1&parameter1=value2&parameter2=value",
-  "cookies": [
-    "cookie1",
-    "cookie2"
-  ],
-  "headers": {
-    "header1": "value1",
-    "header2": "value1,value2"
-  },
-  "queryStringParameters": {
-    "parameter1": "value1,value2",
-    "parameter2": "value"
-  },
-  "requestContext": {
-    "accountId": "123456789012",
-    "apiId": "<urlid>",
-    "authentication": null,
-    "authorizer": {
-        "iam": {
-                "accessKey": "AKIA...",
-                "accountId": "111122223333",
-                "callerId": "AIDA...",
-                "cognitoIdentity": null,
-                "principalOrgId": null,
-                "userArn": "arn:aws:iam::111122223333:user/example-user",
-                "userId": "AIDA..."
-        }
-    },
-    "domainName": "<url-id>.lambda-url.us-west-2.on.aws",
-    "domainPrefix": "<url-id>",
-    "http": {
-      "method": "POST",
-      "path": "/my/path",
-      "protocol": "HTTP/1.1",
-      "sourceIp": "123.123.123.123",
-      "userAgent": "agent"
-    },
-    "requestId": "id",
-    "routeKey": "$default",
-    "stage": "$default",
-    "time": "12/Mar/2020:19:03:58 +0000",
-    "timeEpoch": 1583348638390
-  },
-  "body": "Hello from client!",
-  "pathParameters": null,
-  "isBase64Encoded": false,
-  "stageVariables": null
+   "version":"2.0",
+   "routeKey":"$default",
+   "rawPath":"/",
+   "rawQueryString":"",
+   "headers":{
+      "sec-fetch-mode":"navigate",
+      "x-amzn-tls-version":"TLSv1.2",
+      "sec-fetch-site":"cross-site",
+      "accept-language":"pt-BR,pt;q=0.9",
+      "x-forwarded-proto":"https",
+      "x-forwarded-port":"443",
+      "x-forwarded-for":"123.123.123.123",
+      "sec-fetch-user":"?1",
+      "accept":"text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.9",
+      "x-amzn-tls-cipher-suite":"ECDHE-RSA-AES128-GCM-SHA256",
+      "sec-ch-ua":"\" Not A;Brand\";v=\"99\", \"Chromium\";v=\"102\", \"Google Chrome\";v=\"102\"",
+      "sec-ch-ua-mobile":"?0",
+      "x-amzn-trace-id":"Root=1-62ecd163-5f302e550dcde3b12402207d",
+      "sec-ch-ua-platform":"\"Linux\"",
+      "host":"<url-id>.lambda-url.us-east-1.on.aws",
+      "upgrade-insecure-requests":"1",
+      "cache-control":"max-age=0",
+      "accept-encoding":"gzip, deflate, br",
+      "sec-fetch-dest":"document",
+      "user-agent":"Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/102.0.0.0 Safari/537.36"
+   },
+   "requestContext":{
+      "accountId":"anonymous",
+      "apiId":"<url-id>",
+      "domainName":"<url-id>.lambda-url.us-east-1.on.aws",
+      "domainPrefix":"<url-id>",
+      "http":{
+         "method":"GET",
+         "path":"/",
+         "protocol":"HTTP/1.1",
+         "sourceIp":"123.123.123.123",
+         "userAgent":"agent"
+      },
+      "requestId":"id",
+      "routeKey":"$default",
+      "stage":"$default",
+      "time":"05/Aug/2022:08:14:39 +0000",
+      "timeEpoch":1659687279885
+   },
+   "isBase64Encoded":false
 }

--- a/tests/events/lambdaFunctionUrlIAMEvent.json
+++ b/tests/events/lambdaFunctionUrlIAMEvent.json
@@ -1,0 +1,52 @@
+{
+  "version": "2.0",
+  "routeKey": "$default",
+  "rawPath": "/my/path",
+  "rawQueryString": "parameter1=value1&parameter1=value2&parameter2=value",
+  "cookies": [
+    "cookie1",
+    "cookie2"
+  ],
+  "headers": {
+    "header1": "value1",
+    "header2": "value1,value2"
+  },
+  "queryStringParameters": {
+    "parameter1": "value1,value2",
+    "parameter2": "value"
+  },
+  "requestContext": {
+    "accountId": "123456789012",
+    "apiId": "<urlid>",
+    "authentication": null,
+    "authorizer": {
+        "iam": {
+                "accessKey": "AKIA...",
+                "accountId": "111122223333",
+                "callerId": "AIDA...",
+                "cognitoIdentity": null,
+                "principalOrgId": null,
+                "userArn": "arn:aws:iam::111122223333:user/example-user",
+                "userId": "AIDA..."
+        }
+    },
+    "domainName": "<url-id>.lambda-url.us-west-2.on.aws",
+    "domainPrefix": "<url-id>",
+    "http": {
+      "method": "POST",
+      "path": "/my/path",
+      "protocol": "HTTP/1.1",
+      "sourceIp": "123.123.123.123",
+      "userAgent": "agent"
+    },
+    "requestId": "id",
+    "routeKey": "$default",
+    "stage": "$default",
+    "time": "12/Mar/2020:19:03:58 +0000",
+    "timeEpoch": 1583348638390
+  },
+  "body": "Hello from client!",
+  "pathParameters": null,
+  "isBase64Encoded": false,
+  "stageVariables": null
+}

--- a/tests/functional/data_classes/test_lambda_function_url.py
+++ b/tests/functional/data_classes/test_lambda_function_url.py
@@ -105,6 +105,7 @@ def test_lambda_function_url_event_iam():
     assert iam.access_key is not None
     assert iam.account_id == "111122223333"
     assert iam.caller_id is not None
+    assert iam.cognito_amr is None
     assert iam.cognito_identity_id is None
     assert iam.cognito_identity_pool_id is None
     assert iam.principal_org_id is None

--- a/tests/functional/data_classes/test_lambda_function_url.py
+++ b/tests/functional/data_classes/test_lambda_function_url.py
@@ -8,6 +8,51 @@ def test_lambda_function_url_event():
     assert event.version == "2.0"
     assert event.route_key == "$default"
 
+    assert event.path == "/"
+    assert event.raw_query_string == ""
+
+    assert event.cookies is None
+
+    headers = event.headers
+    assert len(headers) == 20
+
+    assert event.query_string_parameters is None
+
+    assert event.is_base64_encoded is False
+    assert event.body is None
+    assert event.path_parameters is None
+    assert event.stage_variables is None
+    assert event.http_method == "GET"
+
+    request_context = event.request_context
+
+    assert request_context.account_id == "anonymous"
+    assert request_context.api_id is not None
+    assert request_context.domain_name == "<url-id>.lambda-url.us-east-1.on.aws"
+    assert request_context.domain_prefix == "<url-id>"
+    assert request_context.request_id == "id"
+    assert request_context.route_key == "$default"
+    assert request_context.stage == "$default"
+    assert request_context.time is not None
+    assert request_context.time_epoch == 1659687279885
+    assert request_context.authentication is None
+
+    http = request_context.http
+    assert http.method == "GET"
+    assert http.path == "/"
+    assert http.protocol == "HTTP/1.1"
+    assert http.source_ip == "123.123.123.123"
+    assert http.user_agent == "agent"
+
+    assert request_context.authorizer is None
+
+
+def test_lambda_function_url_event_iam():
+    event = LambdaFunctionUrlEvent(load_event("lambdaFunctionUrlIAMEvent.json"))
+
+    assert event.version == "2.0"
+    assert event.route_key == "$default"
+
     assert event.path == "/my/path"
     assert event.raw_query_string == "parameter1=value1&parameter1=value2&parameter2=value"
 

--- a/tests/functional/event_handler/test_lambda_function_url.py
+++ b/tests/functional/event_handler/test_lambda_function_url.py
@@ -15,7 +15,7 @@ def test_lambda_function_url_event():
         return Response(200, content_types.TEXT_HTML, "foo")
 
     # WHEN calling the event handler
-    result = app(load_event("lambdaFunctionUrlEvent.json"), {})
+    result = app(load_event("lambdaFunctionUrlIAMEvent.json"), {})
 
     # THEN process event correctly
     # AND set the current_event type as LambdaFunctionUrlEvent
@@ -33,7 +33,7 @@ def test_lambda_function_url_no_matches():
         raise RuntimeError()
 
     # WHEN calling the event handler
-    result = app(load_event("lambdaFunctionUrlEvent.json"), {})
+    result = app(load_event("lambdaFunctionUrlIAMEvent.json"), {})
 
     # THEN process event correctly
     # AND return 404 because the event doesn't match any known route


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
**Issue number:** #1416

## Summary

### Changes

> Please provide a summary of what's being changed

Function URL latest introduction is missing a test without authorization fields. This PR ensures code paths work when a function URL is configured as NONE for AuthType.

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] [Meet tenets criteria](https://awslabs.github.io/aws-lambda-powertools-python/#tenets)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [ ] Changes are documented
* [x] PR title follows [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-python/blob/develop/.github/semantic.yml)

<details>
<summary>Is this a breaking change?</summary>

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
