### PR TITLE
chore(batch): deprecate sqs_batch_processor

### DIFF
--- a/aws_lambda_powertools/utilities/batch/sqs.py
+++ b/aws_lambda_powertools/utilities/batch/sqs.py
@@ -80,7 +80,7 @@ class PartialSQSProcessor(BasePartialProcessor):
 
         warnings.warn(
             "The sqs_batch_processor decorator and PartialSQSProcessor class are now deprecated, "
-            "and will be removed in the next major version of Powertools. "
+            "and will be removed in the next major version. "
             "Please follow the upgrade guide at "
             "https://awslabs.github.io/aws-lambda-powertools-python/latest/utilities/batch/#legacy "
             "to use the native batch_processor decorator or BatchProcessor class."

--- a/aws_lambda_powertools/utilities/batch/sqs.py
+++ b/aws_lambda_powertools/utilities/batch/sqs.py
@@ -6,6 +6,7 @@ Batch SQS utilities
 import logging
 import math
 import sys
+import warnings
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from typing import Any, Callable, Dict, List, Optional, Tuple, cast
 
@@ -76,6 +77,14 @@ class PartialSQSProcessor(BasePartialProcessor):
         self.client = session.client("sqs", config=config)
         self.suppress_exception = suppress_exception
         self.max_message_batch = 10
+
+        warnings.warn(
+            "The sqs_batch_processor decorator and PartialSQSProcessor class are now deprecated, "
+            "and will be removed in the next major version of Powertools. "
+            "Please follow the upgrade guide at "
+            "https://awslabs.github.io/aws-lambda-powertools-python/latest/utilities/batch/#legacy "
+            "to use the native batch_processor decorator or BatchProcessor class."
+        )
 
         super().__init__()
 

--- a/docs/overrides/main.html
+++ b/docs/overrides/main.html
@@ -1,5 +1,10 @@
 {% extends "base.html" %}
 
+{% block announce %}
+  The legacy <code>sqs_batch_processor</code> decorator and <code>PartialSQSProcessor</code> class are deprecated and are going to be removed soon.
+  Please check the <a href="/utilities/batch/#migration-guide">migration guide</a> for more information.
+{% endblock %}
+
 {% block outdated %}
   You're not viewing the latest version.
   <a href="{{ '../' ~ base_url }}">

--- a/docs/overrides/main.html
+++ b/docs/overrides/main.html
@@ -1,7 +1,7 @@
 {% extends "base.html" %}
 
 {% block announce %}
-  ⚠️ Powertools for Python v2 is coming soon!
+  👋 Powertools for Python v2 is coming soon!
   We encourage you to add your feedback and follow the progress on <a href="https://github.com/awslabs/aws-lambda-powertools-python/issues/1459">the RFC</a>.
 {% endblock %}
 

--- a/docs/overrides/main.html
+++ b/docs/overrides/main.html
@@ -1,8 +1,8 @@
 {% extends "base.html" %}
 
 {% block announce %}
-  The legacy <code>sqs_batch_processor</code> decorator and <code>PartialSQSProcessor</code> class are deprecated and are going to be removed soon.
-  Please check the <a href="/utilities/batch/#migration-guide">migration guide</a> for more information.
+  ⚠️ Powertools for Python v2 is coming soon!
+  We encourage you to add your feedback and follow the progress on <a href="https://github.com/awslabs/aws-lambda-powertools-python/issues/1459">the RFC</a>.
 {% endblock %}
 
 {% block outdated %}

--- a/docs/utilities/batch.md
+++ b/docs/utilities/batch.md
@@ -5,6 +5,11 @@ description: Utility
 
 The batch processing utility handles partial failures when processing batches from Amazon SQS, Amazon Kinesis Data Streams, and Amazon DynamoDB Streams.
 
+???+ warning
+    The legacy `sqs_batch_processor` decorator and `PartialSQSProcessor` class are deprecated and are going to be removed soon.
+
+    Please check the [migration guide](#migration-guide) for more information.
+
 ## Key Features
 
 * Reports batch item failures to reduce number of retries for a record upon errors

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -47,6 +47,7 @@ theme:
         icon: material/toggle-switch
         name: Switch to light mode
   features:
+    - header.autohide
     - navigation.sections
     - navigation.expand
     - navigation.top


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
**Issue number:** #1459

## Summary

### Changes

> Please provide a summary of what's being changed

This PR adds a deprecation warning to the `sqs_batch_processor` decorator and `PartialSQSProcessor` class.

It also adds a banner on the documentation urging customers to upgrade before the next major version.

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] [Meet tenets criteria](https://awslabs.github.io/aws-lambda-powertools-python/#tenets)
* [x] I have performed a self-review of this change
* [ ] Changes have been tested
* [ ] Changes are documented
* [x] PR title follows [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-python/blob/develop/.github/semantic.yml)

<details>
<summary>Is this a breaking change?</summary>

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
