### PR TITLE
docs(home): add discord invitation link

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ With [pip](https://pip.pypa.io/en/latest/index.html) installed, run: ``pip insta
 
 ## Connect
 
-* **AWS Lambda Powertools on Discord**: `#python` - **[Invite, if you don't have an account](https://discord.gg/B8zZKbbyET)**
+* **AWS Lambda Powertools on Discord**: `#python` - **[Invite link(https://discord.gg/B8zZKbbyET)**
 * **Email**: aws-lambda-powertools-feedback@amazon.com
 
 ## Security disclosures

--- a/README.md
+++ b/README.md
@@ -27,11 +27,9 @@ A suite of Python utilities for AWS Lambda functions to ease adopting best pract
 * **[Idempotency](https://awslabs.github.io/aws-lambda-powertools-python/latest/utilities/idempotency/)** - Convert your Lambda functions into idempotent operations which are safe to retry
 * **[Feature Flags](https://awslabs.github.io/aws-lambda-powertools-python/latest/utilities/feature_flags/)** - A simple rule engine to evaluate when one or multiple features should be enabled depending on the input
 
-
 ### Installation
 
 With [pip](https://pip.pypa.io/en/latest/index.html) installed, run: ``pip install aws-lambda-powertools``
-
 
 ## Tutorial and Examples
 
@@ -47,7 +45,9 @@ With [pip](https://pip.pypa.io/en/latest/index.html) installed, run: ``pip insta
 * Powertools idea [DAZN Powertools](https://github.com/getndazn/dazn-lambda-powertools/)
 
 ## Connect
-**Email**: aws-lambda-powertools-feedback@amazon.com
+
+* **AWS Lambda Powertools on Discord**: `#python` - **[Invite, if you don't have an account](https://discord.gg/B8zZKbbyET)**
+* **Email**: aws-lambda-powertools-feedback@amazon.com
 
 ## Security disclosures
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
**Issue number:** #1469 

## Summary

### Changes

> Please provide a summary of what's being changed

Add Discord invitation where the Slack invitation was before (#1210 ). I wasn't sure if the Discord link should be added to [docs/tutorial](https://github.com/awslabs/aws-lambda-powertools-python/blob/develop/docs/tutorial/index.md) as well.

### User experience

> Please share what the user experience looks like before and after this change

New users will now be redirected to the community in Discord, instead of Slack.

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] [Meet tenets criteria](https://awslabs.github.io/aws-lambda-powertools-python/#tenets)
* [x] I have performed a self-review of this change
* [ ] Changes have been tested
* [ ] Changes are documented
* [x] PR title follows [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-python/blob/develop/.github/semantic.yml)

<details>
<summary>Is this a breaking change?</summary>
No

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.


-----
[View rendered README.md](https://github.com/sthuber90/aws-lambda-powertools-python/blob/add-new-discord-invite-1469/README.md)