### PR TITLE
fix(ci): calculate parallel jobs based on infrastructure needs

### DIFF
--- a/.github/workflows/run-e2e-tests.yml
+++ b/.github/workflows/run-e2e-tests.yml
@@ -21,8 +21,8 @@ jobs:
     strategy:
       matrix:
         # Maintenance: disabled until we discover concurrency lock issue with multiple versions and tmp
-        # version: ["3.7", "3.8", "3.9"]
-        version: ["3.7"]
+        version: ["3.7", "3.8", "3.9"]
+        # version: ["3.7"]
     steps:
       - name: "Checkout"
         uses: actions/checkout@v3

--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ unit-test:
 	poetry run pytest tests/unit
 
 e2e-test:
-	poetry run pytest -rP -n auto --dist loadfile -o log_cli=true tests/e2e
+	poetry run pytest -n 3 --dist loadfile -o log_cli=true tests/e2e
 
 coverage-html:
 	poetry run pytest -m "not perf" --ignore tests/e2e --cov=aws_lambda_powertools --cov-report=html

--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ unit-test:
 	poetry run pytest tests/unit
 
 e2e-test:
-	poetry run pytest -n 3 --dist loadfile -o log_cli=true tests/e2e
+	python parallel_run_e2e.py
 
 coverage-html:
 	poetry run pytest -m "not perf" --ignore tests/e2e --cov=aws_lambda_powertools --cov-report=html

--- a/parallel_run_e2e.py
+++ b/parallel_run_e2e.py
@@ -1,0 +1,16 @@
+""" Calculate how many parallel workers are needed to complete E2E infrastructure jobs across available CPU Cores """
+import subprocess
+from pathlib import Path
+
+
+def main():
+    features = Path("tests/e2e").rglob("infrastructure.py")
+    workers = len(list(features)) - 1
+
+    command = f"poetry run pytest -n {workers} --dist loadfile -o log_cli=true tests/e2e"
+    print(f"Running E2E tests with: {command}")
+    subprocess.run(command.split(), shell=False)
+
+
+if __name__ == "__main__":
+    main()

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,11 @@
+[tox]
+envlist = py37,py38,py39
+
+[testenv]
+deps =
+    filelock
+    pytest-xdist
+    pydantic
+    email-validator
+
+commands = python parallel_run_e2e.py

--- a/tox.ini
+++ b/tox.ini
@@ -9,3 +9,7 @@ deps =
     email-validator
 
 commands = python parallel_run_e2e.py
+
+; If you ever encounter another parallel lock across interpreters
+; pip install tox tox-poetry
+; tox -p --parallel-live


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
**Issue number:** #1435

## Summary

This addresses the unbalance work split across CPU Cores to coordinate CloudFormation stacks seen on: https://github.com/awslabs/aws-lambda-powertools-python/actions/runs/2917670742

Successful test after the change: https://github.com/awslabs/aws-lambda-powertools-python/actions/runs/2919001216

**Background**

The issue was that we automatically detected the number of CPU Cores and distributed jobs across them. It worked fine when we had a single interpreter when running locally. When we introduced a matrix CI with multiple interpreters, we had a mismatch of job queue per core - here's the scenario:

* Pytest-xdist detects 2 Core available in the GitHub Actions Runner container
* Worker 1 and Worker 2 are spawned for interpreter Python 3.7, 3.8, and 3.9
* Worker 1 receives Lambda Layer Stack infra job to deploy and block any extra work on Worker 1 and 2 to proceed
* Lambda Layer Stack completes and additional jobs in the queue are released for Worker 1 and Worker 2
* Worker 1 completes all of its jobs (Logger, Metrics) for Python 3.7 and believe it's fine to scale down
* However..... Worker 1 receives a new job (Tracer stack) as soon as it tries to delete Lambda Layer Stack (mistaken by test session being complete)

This causes the last jobs to fail for each additional interpreter because Layer stacks gets deleted and they can't complete creating Lambda Function, since the Layer no longer exists.

### Changes

> Please provide a summary of what's being changed

I created `parallel_run_e2e.py` to calculate how many infrastructure jobs must be scheduled per worker regardless of how many CPU Cores a machine has. It uses our `infrastructure.py` convention - 1 (root e2e).

I've also included `tox.ini` should we ever run into a similar situation with multiple interpreters and need to reproduce it locally. I didn't add dependencies but added notes on how to run if anyone ever needs it.

### User experience

> Please share what the user experience looks like before and after this change

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [ ] [Meet tenets criteria](https://awslabs.github.io/aws-lambda-powertools-python/#tenets)
* [ ] I have performed a self-review of this change
* [ ] Changes have been tested
* [ ] Changes are documented
* [ ] PR title follows [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-python/blob/develop/.github/semantic.yml)

<details>
<summary>Is this a breaking change?</summary>

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
