### PR TITLE
chore(ci): add linter for GitHub Actions as pre-commit hook

### DIFF
--- a/.github/workflows/build_changelog.yml
+++ b/.github/workflows/build_changelog.yml
@@ -6,5 +6,4 @@ on:
 
 jobs:
   changelog:
-    needs: release
     uses: ./.github/workflows/reusable_publish_changelog.yml

--- a/.github/workflows/on_opened_pr.yml
+++ b/.github/workflows/on_opened_pr.yml
@@ -20,8 +20,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: "Debug workflow_run event"
-        run: echo "${{ github }}"
       - name: "Ensure related issue is present"
         uses: actions/github-script@v6
         env:

--- a/.github/workflows/python_build.yml
+++ b/.github/workflows/python_build.yml
@@ -28,7 +28,6 @@ jobs:
       matrix:
         python-version: [3.7, 3.8, 3.9]
     env:
-      OS: ${{ matrix.os }}
       PYTHON: ${{ matrix.python-version }}
     steps:
       - uses: actions/checkout@v3
@@ -56,6 +55,6 @@ jobs:
         with:
           file: ./coverage.xml
           # flags: unittests
-          env_vars: OS,PYTHON
+          env_vars: PYTHON
           name: aws-lambda-powertools-python-codecov
           # fail_ci_if_error: true  # failing more consistently making CI unreliable despite all tests above passing

--- a/.github/workflows/reusable_deploy_layer_stack.yml
+++ b/.github/workflows/reusable_deploy_layer_stack.yml
@@ -8,12 +8,15 @@ on:
   workflow_call:
     inputs:
       stage:
+        description: "Deployment stage (BETA, PROD)"
         required: true
         type: string
       artefact-name:
+        description: "CDK Layer Artefact name to download"
         required: true
         type: string
       environment:
+        description: "GitHub Environment to use for encrypted secrets"
         required: true
         type: string
 

--- a/.github/workflows/reusable_export_pr_details.yml
+++ b/.github/workflows/reusable_export_pr_details.yml
@@ -4,13 +4,16 @@ on:
   workflow_call:
     inputs:
       record_pr_workflow_id:
+        description: "Record PR workflow execution ID to download PR details"
         required: true
         type: number
       workflow_origin: # see https://github.com/awslabs/aws-lambda-powertools-python/issues/1349
+        description: "Repository full name for runner integrity"
         required: true
         type: string
     secrets:
       token:
+        description: "GitHub Actions temporary and scoped token"
         required: true
     # Map the workflow outputs to job outputs
     outputs:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -39,3 +39,8 @@ repos:
     hooks:
       - id: cfn-python-lint
         files: examples/.*\.(yaml|yml)$
+  - repo: https://github.com/rhysd/actionlint
+    rev: v1.6.16
+    hooks:
+      - id: actionlint
+        args: [-pyflakes=]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -42,5 +42,5 @@ repos:
   - repo: https://github.com/rhysd/actionlint
     rev: v1.6.16
     hooks:
-      - id: actionlint
+      - id: actionlint-docker
         args: [-pyflakes=]


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
**Issue number:** #1332

## Summary

### Changes

> Please provide a summary of what's being changed

This introduces [Action Lint](https://github.com/rhysd/actionlint) as a pre-commit hook to catch unforeseen syntax errors to prevent future failures.

It also includes fixes for all issues caught: key but optional fields missing, dangling debug step, and incorrect syntax for new changelog adhoc workflow

### User experience

> Please share what the user experience looks like before and after this change

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [ ] [Meet tenets criteria](https://awslabs.github.io/aws-lambda-powertools-python/#tenets)
* [ ] I have performed a self-review of this change
* [ ] Changes have been tested
* [ ] Changes are documented
* [ ] PR title follows [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-python/blob/develop/.github/semantic.yml)

<details>
<summary>Is this a breaking change?</summary>

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
