### PR TITLE
fix(event_sources): implement Mapping protocol on DictWrapper for better interop with existing middlewares

### DIFF
--- a/aws_lambda_powertools/utilities/data_classes/common.py
+++ b/aws_lambda_powertools/utilities/data_classes/common.py
@@ -1,6 +1,7 @@
 import base64
 import json
-from typing import Any, Dict, Iterator, Mapping, Optional
+from collections.abc import Mapping
+from typing import Any, Dict, Iterator, Optional
 
 
 class DictWrapper(Mapping):

--- a/aws_lambda_powertools/utilities/data_classes/common.py
+++ b/aws_lambda_powertools/utilities/data_classes/common.py
@@ -1,9 +1,9 @@
 import base64
 import json
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Iterator, Mapping, Optional
 
 
-class DictWrapper:
+class DictWrapper(Mapping):
     """Provides a single read only access to a wrapper dict"""
 
     def __init__(self, data: Dict[str, Any]):
@@ -18,6 +18,12 @@ class DictWrapper:
             return False
 
         return self._data == other._data
+
+    def __iter__(self) -> Iterator:
+        return iter(self._data)
+
+    def __len__(self) -> int:
+        return len(self._data)
 
     def get(self, key: str, default: Optional[Any] = None) -> Optional[Any]:
         return self._data.get(key, default)

--- a/aws_lambda_powertools/utilities/data_classes/dynamo_db_stream_event.py
+++ b/aws_lambda_powertools/utilities/data_classes/dynamo_db_stream_event.py
@@ -182,8 +182,10 @@ class StreamRecord(DictWrapper):
         item = self.get("ApproximateCreationDateTime")
         return None if item is None else int(item)
 
+    # This override breaks the Mapping protocol of DictWrapper, it's left here for backwards compatibility with
+    # a 'type: ignore' comment. This is currently the only subclass of DictWrapper that breaks this protocol.
     @property
-    def keys(self) -> Optional[Dict[str, AttributeValue]]:
+    def keys(self) -> Optional[Dict[str, AttributeValue]]:  # type: ignore
         """The primary key attribute(s) for the DynamoDB item that was modified."""
         return _attribute_value_dict(self._data, "Keys")
 

--- a/aws_lambda_powertools/utilities/data_classes/dynamo_db_stream_event.py
+++ b/aws_lambda_powertools/utilities/data_classes/dynamo_db_stream_event.py
@@ -182,10 +182,10 @@ class StreamRecord(DictWrapper):
         item = self.get("ApproximateCreationDateTime")
         return None if item is None else int(item)
 
-    # This override breaks the Mapping protocol of DictWrapper, it's left here for backwards compatibility with
-    # a 'type: ignore' comment. This is currently the only subclass of DictWrapper that breaks this protocol.
+    # NOTE: This override breaks the Mapping protocol of DictWrapper, it's left here for backwards compatibility with
+    # a 'type: ignore' comment. See #1516 for discussion
     @property
-    def keys(self) -> Optional[Dict[str, AttributeValue]]:  # type: ignore
+    def keys(self) -> Optional[Dict[str, AttributeValue]]:  # type: ignore[override]
         """The primary key attribute(s) for the DynamoDB item that was modified."""
         return _attribute_value_dict(self._data, "Keys")
 

--- a/tests/functional/test_data_classes.py
+++ b/tests/functional/test_data_classes.py
@@ -74,6 +74,7 @@ from aws_lambda_powertools.utilities.data_classes.dynamo_db_stream_event import 
     AttributeValueType,
     DynamoDBRecordEventName,
     DynamoDBStreamEvent,
+    StreamRecord,
     StreamViewType,
 )
 from aws_lambda_powertools.utilities.data_classes.event_source import event_source
@@ -99,6 +100,19 @@ def test_dict_wrapper_equals():
     assert data1 is not DataClassSample(data1)
 
     assert DataClassSample(data1).raw_event is data1
+
+
+def test_dict_wrapper_imlements_mapping():
+    class DataClassSample(DictWrapper):
+        pass
+
+    data = {"message": "foo1"}
+    dcs = DataClassSample(data)
+    assert len(dcs) == len(data)
+    assert list(dcs) == list(data)
+    assert dcs.keys() == data.keys()
+    assert list(dcs.values()) == list(data.values())
+    assert dcs.items() == data.items()
 
 
 def test_cloud_watch_dashboard_event():
@@ -615,6 +629,23 @@ def test_dynamo_attribute_value_type_error():
         print(attribute_value.get_value)
     with pytest.raises(ValueError):
         print(attribute_value.get_type)
+
+
+def test_stream_record_keys_with_valid_keys():
+    attribute_value = {"Foo": "Bar"}
+    sr = StreamRecord({"Keys": {"Key1": attribute_value}})
+    assert sr.keys == {"Key1": AttributeValue(attribute_value)}
+
+
+def test_stream_record_keys_with_no_keys():
+    sr = StreamRecord({})
+    assert sr.keys is None
+
+
+def test_stream_record_keys_overrides_dict_wrapper_keys():
+    data = {"Keys": {"key1": {"attr1": "value1"}}}
+    sr = StreamRecord(data)
+    assert sr.keys != data.keys()
 
 
 def test_event_bridge_event():

--- a/tests/functional/test_data_classes.py
+++ b/tests/functional/test_data_classes.py
@@ -102,17 +102,17 @@ def test_dict_wrapper_equals():
     assert DataClassSample(data1).raw_event is data1
 
 
-def test_dict_wrapper_imlements_mapping():
+def test_dict_wrapper_implements_mapping():
     class DataClassSample(DictWrapper):
         pass
 
     data = {"message": "foo1"}
-    dcs = DataClassSample(data)
-    assert len(dcs) == len(data)
-    assert list(dcs) == list(data)
-    assert dcs.keys() == data.keys()
-    assert list(dcs.values()) == list(data.values())
-    assert dcs.items() == data.items()
+    event_source = DataClassSample(data)
+    assert len(event_source) == len(data)
+    assert list(event_source) == list(data)
+    assert event_source.keys() == data.keys()
+    assert list(event_source.values()) == list(data.values())
+    assert event_source.items() == data.items()
 
 
 def test_cloud_watch_dashboard_event():
@@ -633,19 +633,19 @@ def test_dynamo_attribute_value_type_error():
 
 def test_stream_record_keys_with_valid_keys():
     attribute_value = {"Foo": "Bar"}
-    sr = StreamRecord({"Keys": {"Key1": attribute_value}})
-    assert sr.keys == {"Key1": AttributeValue(attribute_value)}
+    record = StreamRecord({"Keys": {"Key1": attribute_value}})
+    assert record.keys == {"Key1": AttributeValue(attribute_value)}
 
 
 def test_stream_record_keys_with_no_keys():
-    sr = StreamRecord({})
-    assert sr.keys is None
+    record = StreamRecord({})
+    assert record.keys is None
 
 
 def test_stream_record_keys_overrides_dict_wrapper_keys():
     data = {"Keys": {"key1": {"attr1": "value1"}}}
-    sr = StreamRecord(data)
-    assert sr.keys != data.keys()
+    record = StreamRecord(data)
+    assert record.keys != data.keys()
 
 
 def test_event_bridge_event():


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
**Issue #1503**

## Summary

DictWrapper and all of its subclasses should fully implement the Mapping interface so that it can be used interchangeably with code that expects the event to be a dictionary. This helps Powertools Middleware play nicely with existing middleware.

### Changes

Add `Mapping` as parent class of `DictWrapper`, implement missing `__len__` and `__iter__` abstract methods.

### User experience

Before this change, a user would encounter exceptions when trying to use many standard functions on dictionaries coerced into `DictWrapper`. Though a user could access the raw dictionary with the `raw_event` property, this was often clumsy, causing existing middleware to break (or to be order dependent) or causing the user to write lots of type-checking code.

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] [Meet tenets criteria](https://awslabs.github.io/aws-lambda-powertools-python/#tenets)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [ ] Changes are documented
* [x] PR title follows [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-python/blob/develop/.github/semantic.yml)

<details>
<summary>Is this a breaking change? <b>No</b></summary>

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.


-----
[View rendered CHANGELOG.md](https://github.com/Tankanow/aws-lambda-powertools-python/blob/ISSUE-1503/CHANGELOG.md)