### PR TITLE
docs(parser): add JSON string field extension example

### DIFF
--- a/docs/utilities/parser.md
+++ b/docs/utilities/parser.md
@@ -240,13 +240,14 @@ for order_item in ret.detail.items:
     When extending a `string` field containing JSON, you need to wrap the field
     with [Pydantic's Json Type](https://pydantic-docs.helpmanual.io/usage/types/#json-type):
 
-    ```python
-    from pydantic import Json
+    ```python hl_lines="14 18-19"
+    --8<-- "examples/parser/src/extending_built_in_models_with_json_mypy.py"
+    ```
 
-    ...
+    Alternatively, you could use a [Pydantic validator](https://pydantic-docs.helpmanual.io/usage/validators/) to transform the JSON string into a dict before the mapping:
 
-    class OrderEventModel(APIGatewayProxyEventV2Model):
-        body: Json[Order]
+    ```python hl_lines="18-20 24-25"
+    --8<-- "examples/parser/src/extending_built_in_models_with_json_validator.py"
     ```
 
 ## Envelopes

--- a/docs/utilities/parser.md
+++ b/docs/utilities/parser.md
@@ -171,7 +171,7 @@ Parser comes with the following built-in models:
 | **KafkaSelfManagedEventModel**  | Lambda Event Source payload for self managed Kafka payload         |
 | **KafkaMskEventModel**          | Lambda Event Source payload for AWS MSK payload                    |
 
-### extending built-in models
+### Extending built-in models
 
 You can extend them to include your own models, and yet have all other known fields parsed along the way.
 
@@ -235,6 +235,19 @@ for order_item in ret.detail.items:
 2. Defined how our `Order` should look like
 3. Defined how part of our EventBridge event should look like by overriding `detail` key within our `OrderEventModel`
 4. Parser parsed the original event against `OrderEventModel`
+
+???+ tip
+    When extending a `string` field containing JSON, you need to wrap the field
+    with [Pydantic's Json Type](https://pydantic-docs.helpmanual.io/usage/types/#json-type):
+
+    ```python
+    from pydantic import Json
+
+    ...
+
+    class OrderEventModel(APIGatewayProxyEventV2Model):
+        body: Json[Order]
+    ```
 
 ## Envelopes
 

--- a/examples/parser/src/extending_built_in_models_with_json_mypy.py
+++ b/examples/parser/src/extending_built_in_models_with_json_mypy.py
@@ -1,0 +1,21 @@
+from pydantic import BaseModel, Json
+
+from aws_lambda_powertools.utilities.parser import event_parser
+from aws_lambda_powertools.utilities.parser.models import APIGatewayProxyEventV2Model
+from aws_lambda_powertools.utilities.typing import LambdaContext
+
+
+class CancelOrder(BaseModel):
+    order_id: int
+    reason: str
+
+
+class CancelOrderModel(APIGatewayProxyEventV2Model):
+    body: Json[CancelOrder]  # type: ignore
+
+
+@event_parser(model=CancelOrderModel)
+def handler(event: CancelOrderModel, context: LambdaContext):
+    cancel_order: CancelOrder = event.body  # type: ignore
+
+    assert cancel_order.order_id is not None

--- a/examples/parser/src/extending_built_in_models_with_json_mypy.py
+++ b/examples/parser/src/extending_built_in_models_with_json_mypy.py
@@ -11,7 +11,7 @@ class CancelOrder(BaseModel):
 
 
 class CancelOrderModel(APIGatewayProxyEventV2Model):
-    body: Json[CancelOrder]  # type: ignore
+    body: Json[CancelOrder]  # type: ignore[assignment]
 
 
 @event_parser(model=CancelOrderModel)

--- a/examples/parser/src/extending_built_in_models_with_json_mypy.py
+++ b/examples/parser/src/extending_built_in_models_with_json_mypy.py
@@ -16,6 +16,6 @@ class CancelOrderModel(APIGatewayProxyEventV2Model):
 
 @event_parser(model=CancelOrderModel)
 def handler(event: CancelOrderModel, context: LambdaContext):
-    cancel_order: CancelOrder = event.body  # type: ignore
+    cancel_order: CancelOrder = event.body  # type: ignore[assignment]
 
     assert cancel_order.order_id is not None

--- a/examples/parser/src/extending_built_in_models_with_json_validator.py
+++ b/examples/parser/src/extending_built_in_models_with_json_validator.py
@@ -13,7 +13,7 @@ class CancelOrder(BaseModel):
 
 
 class CancelOrderModel(APIGatewayProxyEventV2Model):
-    body: CancelOrder  # type: ignore
+    body: CancelOrder  # type: ignore[assignment]
 
     @validator("body", pre=True)
     def transform_body_to_dict(cls, value: str):

--- a/examples/parser/src/extending_built_in_models_with_json_validator.py
+++ b/examples/parser/src/extending_built_in_models_with_json_validator.py
@@ -1,0 +1,27 @@
+import json
+
+from pydantic import BaseModel, validator
+
+from aws_lambda_powertools.utilities.parser import event_parser
+from aws_lambda_powertools.utilities.parser.models import APIGatewayProxyEventV2Model
+from aws_lambda_powertools.utilities.typing import LambdaContext
+
+
+class CancelOrder(BaseModel):
+    order_id: int
+    reason: str
+
+
+class CancelOrderModel(APIGatewayProxyEventV2Model):
+    body: CancelOrder  # type: ignore
+
+    @validator("body", pre=True)
+    def transform_body_to_dict(cls, value: str):
+        return json.loads(value)
+
+
+@event_parser(model=CancelOrderModel)
+def handler(event: CancelOrderModel, context: LambdaContext):
+    cancel_order: CancelOrder = event.body
+
+    assert cancel_order.order_id is not None


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
**Issue number:** #1518

## Summary

### Changes

> Please provide a summary of what's being changed

This PR adds a small tip to the parser documentation, highlighting how to override a string field containing Json.

### User experience

> Please share what the user experience looks like before and after this change

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] [Meet tenets criteria](https://awslabs.github.io/aws-lambda-powertools-python/#tenets)
* [x] I have performed a self-review of this change
* [ ] Changes have been tested
* [x] Changes are documented
* [x] PR title follows [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-python/blob/develop/.github/semantic.yml)

<details>
<summary>Is this a breaking change?</summary>

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.


-----
[View rendered docs/utilities/parser.md](https://github.com/rubenfonseca/aws-lambda-powertools-python/blob/chore/1518/docs/utilities/parser.md)