### PR TITLE
fix(typing): level arg in copy_config_to_registered_loggers

### DIFF
--- a/aws_lambda_powertools/logging/utils.py
+++ b/aws_lambda_powertools/logging/utils.py
@@ -8,7 +8,7 @@ PACKAGE_LOGGER = "aws_lambda_powertools"
 
 def copy_config_to_registered_loggers(
     source_logger: Logger,
-    log_level: Optional[str] = None,
+    log_level: Optional[Union[int, str]] = None,
     exclude: Optional[Set[str]] = None,
     include: Optional[Set[str]] = None,
 ) -> None:
@@ -19,7 +19,7 @@ def copy_config_to_registered_loggers(
     ----------
     source_logger : Logger
         Powertools Logger to copy configuration from
-    log_level : str, optional
+    log_level : Union[int, str], optional
         Logging level to set to registered loggers, by default uses source_logger logging level
     include : Optional[Set[str]], optional
         List of logger names to include, by default all registered loggers are included

--- a/tests/functional/test_logger_utils.py
+++ b/tests/functional/test_logger_utils.py
@@ -161,15 +161,17 @@ def test_copy_config_to_ext_loggers_clean_old_handlers(stdout, logger, log_level
     assert isinstance(logger.handlers[0].formatter, formatter.LambdaPowertoolsFormatter)
 
 
-def test_copy_config_to_ext_loggers_custom_log_level(stdout, logger, log_level):
+@pytest.mark.parametrize("level_to_set", ["WARNING", 30])
+def test_copy_config_to_ext_loggers_custom_log_level(stdout, logger, log_level, level_to_set):
     # GIVEN an external logger and powertools logger initialized
     logger = logger()
     powertools_logger = Logger(service=service_name(), level=log_level.CRITICAL.value, stream=stdout)
-    level = log_level.WARNING.name
 
     # WHEN configuration copied from powertools logger to INCLUDED external logger
     # AND external logger used with custom log_level
-    utils.copy_config_to_registered_loggers(source_logger=powertools_logger, include={logger.name}, log_level=level)
+    utils.copy_config_to_registered_loggers(
+        source_logger=powertools_logger, include={logger.name}, log_level=level_to_set
+    )
     msg = "test message4"
     logger.warning(msg)
     log = capture_logging_output(stdout)


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
**Issue number:** Fixes #1525 

## Summary

### Changes

Allow both int or str for `level` to copy_config_to_registered_loggers

### User experience

See linked issue for type error fixed.

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] [Meet tenets criteria](https://awslabs.github.io/aws-lambda-powertools-python/#tenets)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented
* [x] PR title follows [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-python/blob/develop/.github/semantic.yml)

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
