### PR TITLE
feat(logger): pretty-print JSON when POWERTOOLS_DEV is set

### DIFF
--- a/aws_lambda_powertools/logging/formatter.py
+++ b/aws_lambda_powertools/logging/formatter.py
@@ -9,6 +9,7 @@ from functools import partial
 from typing import Any, Callable, Dict, Iterable, List, Optional, Tuple, Union
 
 from ..shared import constants
+from ..shared.functions import strtobool
 
 RESERVED_LOG_ATTRS = (
     "name",

--- a/aws_lambda_powertools/logging/formatter.py
+++ b/aws_lambda_powertools/logging/formatter.py
@@ -111,9 +111,15 @@ class LambdaPowertoolsFormatter(BasePowertoolsFormatter):
             Key-value to be included in log messages
 
         """
+
         self.json_deserializer = json_deserializer or json.loads
         self.json_default = json_default or str
-        self.json_serializer = json_serializer or partial(json.dumps, default=self.json_default, separators=(",", ":"))
+        self.json_indent = (
+            4 if os.getenv("AWS_SAM_LOCAL", "").lower() == "true" else None
+        )  # indented json serialization when in AWS SAM Local
+        self.json_serializer = json_serializer or partial(
+            json.dumps, default=self.json_default, separators=(",", ":"), indent=self.json_indent
+        )
 
         self.datefmt = datefmt
         self.use_datetime_directive = use_datetime_directive

--- a/aws_lambda_powertools/logging/formatter.py
+++ b/aws_lambda_powertools/logging/formatter.py
@@ -115,7 +115,7 @@ class LambdaPowertoolsFormatter(BasePowertoolsFormatter):
         self.json_deserializer = json_deserializer or json.loads
         self.json_default = json_default or str
         self.json_indent = (
-            constants.PRETTY_INDENT if os.getenv("POWERTOOLS_DEV", "").lower() == "true" else constants.COMPACT_INDENT
+            constants.PRETTY_INDENT if strtobool(os.getenv("POWERTOOLS_DEV", "0")) else constants.COMPACT_INDENT
         )  # indented json serialization when in AWS SAM Local
         self.json_serializer = json_serializer or partial(
             json.dumps, default=self.json_default, separators=(",", ":"), indent=self.json_indent

--- a/aws_lambda_powertools/logging/formatter.py
+++ b/aws_lambda_powertools/logging/formatter.py
@@ -115,7 +115,7 @@ class LambdaPowertoolsFormatter(BasePowertoolsFormatter):
         self.json_deserializer = json_deserializer or json.loads
         self.json_default = json_default or str
         self.json_indent = (
-            4 if os.getenv("AWS_SAM_LOCAL", "").lower() == "true" else None
+            constants.PRETTY_INDENT if os.getenv("POWERTOOLS_DEV", "").lower() == "true" else constants.COMPACT_INDENT
         )  # indented json serialization when in AWS SAM Local
         self.json_serializer = json_serializer or partial(
             json.dumps, default=self.json_default, separators=(",", ":"), indent=self.json_indent

--- a/aws_lambda_powertools/shared/constants.py
+++ b/aws_lambda_powertools/shared/constants.py
@@ -32,3 +32,6 @@ LOGGER_LAMBDA_CONTEXT_KEYS = [
     "cold_start",
     "xray_trace_id",
 ]
+
+PRETTY_INDENT: int = 4
+COMPACT_INDENT = None

--- a/aws_lambda_powertools/shared/constants.py
+++ b/aws_lambda_powertools/shared/constants.py
@@ -33,5 +33,6 @@ LOGGER_LAMBDA_CONTEXT_KEYS = [
     "xray_trace_id",
 ]
 
+# JSON indentation level
 PRETTY_INDENT: int = 4
 COMPACT_INDENT = None

--- a/docs/core/logger.md
+++ b/docs/core/logger.md
@@ -369,6 +369,9 @@ If you prefer configuring it separately, or you'd want to bring this JSON Format
 | **`log_record_order`**       | set order of log keys when logging                                                                                       | `["level", "location", "message", "timestamp"]`               |
 | **`kwargs`**                 | key-value to be included in log messages                                                                                 | `None`                                                        |
 
+???+ info
+    When `POWERTOOLS_DEV` env var is present and set to `"true"`, Logger's default serializer (`json.dumps`) will pretty-print log messages for easier readability.
+
 ```python hl_lines="2 7-8" title="Pre-configuring Lambda Powertools Formatter"
 --8<-- "examples/logger/src/powertools_formatter_setup.py"
 ```
@@ -554,9 +557,6 @@ As parameters don't always translate well between them, you can pass any callabl
 ```python hl_lines="1 3 7-8 13" title="Using Rust orjson library as serializer"
 --8<-- "examples/logger/src/bring_your_own_json_serializer.py"
 ```
-
-???+ info
-    When your code runs in [AWS SAM local invoke](https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/sam-cli-command-reference-sam-local-invoke.html) (marked by the `AWS_SAM_LOCAL` env var), Logger's default `json.dumps` will apply indentation by four spaces.
 
 ## Testing your code
 

--- a/docs/core/logger.md
+++ b/docs/core/logger.md
@@ -555,6 +555,9 @@ As parameters don't always translate well between them, you can pass any callabl
 --8<-- "examples/logger/src/bring_your_own_json_serializer.py"
 ```
 
+???+ info
+    When your code runs in [AWS SAM local invoke](https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/sam-cli-command-reference-sam-local-invoke.html) (marked by the `AWS_SAM_LOCAL` env var), Logger's default `json.dumps` will apply indentation by four spaces.
+
 ## Testing your code
 
 ### Inject Lambda Context

--- a/tests/functional/test_logger_powertools_formatter.py
+++ b/tests/functional/test_logger_powertools_formatter.py
@@ -9,7 +9,6 @@ import time
 import pytest
 
 from aws_lambda_powertools import Logger
-from aws_lambda_powertools.shared import constants
 
 
 @pytest.fixture
@@ -297,8 +296,9 @@ def test_log_json_indent_compact_indent(stdout, service_name, monkeypatch):
     monkeypatch.delenv(name="POWERTOOLS_DEV", raising=False)
     logger = Logger(service=service_name, stream=stdout)
     logger.info("Test message")
-    # THEN the json should not be indented using constant.PRETTY_INDENT blank spaces
-    assert " " * constants.PRETTY_INDENT not in stdout.getvalue()
+    # THEN the json should not have multiple lines
+    new_lines = stdout.getvalue().count(os.linesep)
+    assert new_lines == 1
 
 
 def test_log_json_pretty_indent(stdout, service_name, monkeypatch):
@@ -306,5 +306,6 @@ def test_log_json_pretty_indent(stdout, service_name, monkeypatch):
     monkeypatch.setenv(name="POWERTOOLS_DEV", value="true")
     logger = Logger(service=service_name, stream=stdout)
     logger.info("Test message")
-    # THEN the json should contain indentation (of constant.PRETTY_INDENT blank spaces)
-    assert " " * constants.PRETTY_INDENT in stdout.getvalue()
+    # THEN the json should contain more than line
+    new_lines = stdout.getvalue().count(os.linesep)
+    assert new_lines > 1

--- a/tests/functional/test_logger_powertools_formatter.py
+++ b/tests/functional/test_logger_powertools_formatter.py
@@ -294,8 +294,7 @@ def test_log_formatting(stdout, service_name):
 
 def test_log_json_indent_compact_indent(stdout, service_name, monkeypatch):
     # GIVEN a logger with default settings and WHEN POWERTOOLS_DEV is not set
-    if "POWERTOOLS_DEV" in os.environ:
-        monkeypatch.delenv(name="POWERTOOLS_DEV")
+    monkeypatch.delenv(name="POWERTOOLS_DEV", raising=False)
     logger = Logger(service=service_name, stream=stdout)
     logger.info("Test message")
     # THEN the json should not be indented using constant.PRETTY_INDENT blank spaces

--- a/tests/functional/test_logger_powertools_formatter.py
+++ b/tests/functional/test_logger_powertools_formatter.py
@@ -9,6 +9,7 @@ import time
 import pytest
 
 from aws_lambda_powertools import Logger
+from aws_lambda_powertools.shared import constants
 
 
 @pytest.fixture
@@ -291,20 +292,20 @@ def test_log_formatting(stdout, service_name):
     assert log_dict["message"] == '["foo bar 123 [1, None]", null]'
 
 
-def test_log_json_indent_default(stdout, service_name, monkeypatch):
-    # GIVEN a logger with default settings while NOT in AWS SAM Local
-    if "AWS_SAM_LOCAL" in os.environ:
-        monkeypatch.delenv(name="AWS_SAM_LOCAL")
+def test_log_json_indent_compact_indent(stdout, service_name, monkeypatch):
+    # GIVEN a logger with default settings and WHEN POWERTOOLS_DEV is not set
+    if "POWERTOOLS_DEV" in os.environ:
+        monkeypatch.delenv(name="POWERTOOLS_DEV")
     logger = Logger(service=service_name, stream=stdout)
     logger.info("Test message")
-    # THEN the json should not be indented at all (using four blank spaces)
-    assert " " * 4 not in stdout.getvalue()
+    # THEN the json should not be indented using constant.PRETTY_INDENT blank spaces
+    assert " " * constants.PRETTY_INDENT not in stdout.getvalue()
 
 
-def test_log_json_indent_aws_sam_local(stdout, service_name, monkeypatch):
-    # GIVEN a logger with default settings while in AWS SAM Local
-    monkeypatch.setenv(name="AWS_SAM_LOCAL", value="true")
+def test_log_json_pretty_indent(stdout, service_name, monkeypatch):
+    # GIVEN a logger with default settings and WHEN POWERTOOLS_DEV=="true"
+    monkeypatch.setenv(name="POWERTOOLS_DEV", value="true")
     logger = Logger(service=service_name, stream=stdout)
     logger.info("Test message")
-    # THEN the json should contain indentation (of four blank spaces)
-    assert " " * 4 in stdout.getvalue()
+    # THEN the json should contain indentation (of constant.PRETTY_INDENT blank spaces)
+    assert " " * constants.PRETTY_INDENT in stdout.getvalue()


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
**Issue number: #1527**

## Summary

### Changes

* Logger's default serialize function `json.dumps` will use indentation by four spaces when in AWS SAM Local. Detection happens using [`AWS_SAM_LOCAL` env var](https://github.com/aws/aws-sam-cli/commit/5e56d94c22d71b1ae2a18057ba9182372cade11b) (if `=="true"`).

### User experience

There should be no impact unless in AWS SAM Local. 

In AWS SAM Local, logs are output to console. To make the serialized json messages more readable and consequently debugging with AWS SAM Local easier, logger's default formatter will in this case automatically use indentation by four spaces. That means that messages normally serialized as
```
{"level": "INFO", "location": "lambda_handler:39", "message": "Some log message...", "timestamp": "2022-09-26 09:03:38,349+0000", "service": "issue-1527"}
```
will be in AWS SAM Local by default indented by four spaces:
```
{
    "level": "INFO",
    "location": "lambda_handler:39",
    "message": "Some log message...",
    "timestamp": "2022-09-26 09:02:05,262+0000",
    "service": "issue-1527"
}
This is to make debugging easier
```

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] [Meet tenets criteria](https://awslabs.github.io/aws-lambda-powertools-python/#tenets)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
    * (only using pytest)
* [x] Changes are documented
* [x] PR title follows [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-python/blob/develop/.github/semantic.yml)

<details>
<summary>Is this a breaking change?</summary>

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.


-----
[View rendered docs/core/logger.md](https://github.com/pmarko1711/aws-lambda-powertools-python/blob/develop/docs/core/logger.md)