### PR TITLE
feat(event-handler): context support to share data between routers

### DIFF
--- a/aws_lambda_powertools/event_handler/api_gateway.py
+++ b/aws_lambda_powertools/event_handler/api_gateway.py
@@ -237,6 +237,7 @@ class ResponseBuilder:
 class BaseRouter(ABC):
     current_event: BaseProxyEvent
     lambda_context: LambdaContext
+    context: dict
 
     @abstractmethod
     def route(

--- a/docs/core/event_handler/api_gateway.md
+++ b/docs/core/event_handler/api_gateway.md
@@ -449,6 +449,28 @@ When necessary, you can set a prefix when including a router object. This means 
     --8<-- "examples/event_handler_rest/src/split_route_prefix_module.py"
     ```
 
+#### Sharing contextual data
+
+You can use `append_context` when you want to share data between your App and Router instances. Any data you share will be available via the `context` dictionary available in your App or Router context.
+
+???+ info
+    For safety, we always clear any data available in the `context` dictionary after each invocation.
+
+???+ tip
+    This can also be useful for middlewares injecting contextual information before a request is processed.
+
+=== "split_route_append_context.py"
+
+	```python hl_lines="18"
+    --8<-- "examples/event_handler_rest/src/split_route_append_context.py"
+	```
+
+=== "split_route_append_context_module.py"
+
+	```python hl_lines="16"
+    --8<-- "examples/event_handler_rest/src/split_route_append_context_module.py"
+	```
+
 #### Sample layout
 
 This is a sample project layout for a monolithic function with routes split in different files (`/todos`, `/health`).

--- a/docs/core/event_handler/appsync.md
+++ b/docs/core/event_handler/appsync.md
@@ -226,6 +226,28 @@ Let's assume you have `split_operation.py` as your Lambda function entrypoint an
     --8<-- "examples/event_handler_graphql/src/split_operation.py"
     ```
 
+#### Sharing contextual data
+
+You can use `append_context` when you want to share data between your App and Router instances. Any data you share will be available via the `context` dictionary available in your App or Router context.
+
+???+ info
+    For safety, we always clear any data available in the `context` dictionary after each invocation.
+
+???+ tip
+    This can also be useful for middlewares injecting contextual information before a request is processed.
+
+=== "split_route_append_context.py"
+
+	```python hl_lines="17"
+    --8<-- "examples/event_handler_graphql/src/split_operation_append_context.py"
+	```
+
+=== "split_route_append_context_module.py"
+
+	```python hl_lines="29"
+    --8<-- "examples/event_handler_graphql/src/split_operation_append_context_module.py"
+	```
+
 ## Testing your code
 
 You can test your resolvers by passing a mocked or actual AppSync Lambda event that you're expecting.

--- a/examples/event_handler_graphql/src/split_operation_append_context.py
+++ b/examples/event_handler_graphql/src/split_operation_append_context.py
@@ -1,0 +1,18 @@
+import split_operation_append_context_module
+
+from aws_lambda_powertools import Logger, Tracer
+from aws_lambda_powertools.event_handler import AppSyncResolver
+from aws_lambda_powertools.logging import correlation_paths
+from aws_lambda_powertools.utilities.typing import LambdaContext
+
+tracer = Tracer()
+logger = Logger()
+app = AppSyncResolver()
+app.include_router(split_operation_append_context_module.router)
+
+
+@logger.inject_lambda_context(correlation_id_path=correlation_paths.APPSYNC_RESOLVER)
+@tracer.capture_lambda_handler
+def lambda_handler(event: dict, context: LambdaContext) -> dict:
+    app.append_context(is_admin=True)  # arbitrary number of key=value data
+    return app.resolve(event, context)

--- a/examples/event_handler_graphql/src/split_operation_append_context_module.py
+++ b/examples/event_handler_graphql/src/split_operation_append_context_module.py
@@ -1,0 +1,30 @@
+import sys
+
+if sys.version_info >= (3, 8):
+    from typing import TypedDict
+else:
+    from typing_extensions import TypedDict
+
+from typing import List
+
+from aws_lambda_powertools import Logger, Tracer
+from aws_lambda_powertools.event_handler.appsync import Router
+
+tracer = Tracer()
+logger = Logger()
+router = Router()
+
+
+class Location(TypedDict, total=False):
+    id: str  # noqa AA03 VNE003, required due to GraphQL Schema
+    name: str
+    description: str
+    address: str
+
+
+@router.resolver(field_name="listLocations")
+@router.resolver(field_name="locations")
+@tracer.capture_method
+def get_locations(name: str, description: str = "") -> List[Location]:  # match GraphQL Query arguments
+    is_admin: bool = router.context.get("is_admin", False)
+    return [{"name": name, "description": description}] if is_admin else []

--- a/examples/event_handler_rest/src/split_route_append_context.py
+++ b/examples/event_handler_rest/src/split_route_append_context.py
@@ -1,0 +1,19 @@
+import split_route_append_context_module
+
+from aws_lambda_powertools import Logger, Tracer
+from aws_lambda_powertools.event_handler import APIGatewayRestResolver
+from aws_lambda_powertools.logging import correlation_paths
+from aws_lambda_powertools.utilities.typing import LambdaContext
+
+tracer = Tracer()
+logger = Logger()
+app = APIGatewayRestResolver()
+app.include_router(split_route_append_context_module.router)
+
+
+# You can continue to use other utilities just as before
+@logger.inject_lambda_context(correlation_id_path=correlation_paths.API_GATEWAY_REST)
+@tracer.capture_lambda_handler
+def lambda_handler(event: dict, context: LambdaContext) -> dict:
+    app.append_context(is_admin=True)  # arbitrary number of key=value data
+    return app.resolve(event, context)

--- a/examples/event_handler_rest/src/split_route_append_context_module.py
+++ b/examples/event_handler_rest/src/split_route_append_context_module.py
@@ -1,0 +1,25 @@
+import requests
+from requests import Response
+
+from aws_lambda_powertools import Tracer
+from aws_lambda_powertools.event_handler.api_gateway import Router
+
+tracer = Tracer()
+router = Router()
+
+endpoint = "https://jsonplaceholder.typicode.com/todos"
+
+
+@router.get("/todos")
+@tracer.capture_method
+def get_todos():
+    is_admin: bool = router.context.get("is_admin", False)
+    todos = {}
+
+    if is_admin:
+        todos: Response = requests.get(endpoint)
+        todos.raise_for_status()
+        todos = todos.json()[:10]
+
+    # for brevity, we'll limit to the first 10 only
+    return {"todos": todos}

--- a/tests/functional/event_handler/test_api_gateway.py
+++ b/tests/functional/event_handler/test_api_gateway.py
@@ -1296,3 +1296,66 @@ def test_response_with_status_code_only():
     assert ret.status_code == 204
     assert ret.body is None
     assert ret.headers == {}
+
+
+def test_append_context():
+    app = APIGatewayRestResolver()
+    app.append_context(is_admin=True)
+    assert app.context.get("is_admin") is True
+
+
+def test_router_append_context():
+    router = Router()
+    router.append_context(is_admin=True)
+    assert router.context.get("is_admin") is True
+
+
+def test_route_context_is_cleared_after_resolve():
+    # GIVEN a Http API V1 proxy type event
+    app = APIGatewayRestResolver()
+    app.append_context(is_admin=True)
+
+    @app.get("/my/path")
+    def my_path():
+        return {"is_admin": app.context["is_admin"]}
+
+    # WHEN event resolution kicks in
+    app.resolve(LOAD_GW_EVENT, {})
+
+    # THEN context should be empty
+    assert app.context == {}
+
+
+def test_router_has_access_to_app_context(json_dump):
+    # GIVEN a Router with registered routes
+    app = ApiGatewayResolver()
+    router = Router()
+    ctx = {"is_admin": True}
+
+    @router.get("/my/path")
+    def my_path():
+        return {"is_admin": router.context["is_admin"]}
+
+    app.include_router(router)
+
+    # WHEN context is added and event resolution kicks in
+    app.append_context(**ctx)
+    ret = app.resolve(LOAD_GW_EVENT, {})
+
+    # THEN response include initial context
+    assert ret["body"] == json_dump(ctx)
+    assert router.context == {}
+
+
+def test_include_router_merges_context():
+    # GIVEN
+    app = APIGatewayRestResolver()
+    router = Router()
+
+    # WHEN
+    app.append_context(is_admin=True)
+    router.append_context(product_access=True)
+
+    app.include_router(router)
+
+    assert app.context == router.context


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
**Issue number:** #1547

## Summary

### Changes

> Please provide a summary of what's being changed

This feature introduces a context (dict) to share data between app and router instances. For safety, it auto clears any data available within context after an event is routed.

By default, we merge a router context into app's context when customers use `app.include_router()`. This prevents common situations where a Router naturally wants to access a key only available in an App instance: `router.context["my_key"]`.

**NOTE**. The same experience will work for ALB, API Gateway REST, API Gateway HTTP, and AppSync resolvers.

### User experience

> Please share what the user experience looks like before and after this change

**Single view where handler makes some context available**

```python
from aws_lambda_powertools.event_handler import APIGatewayRestResolver
from aws_lambda_powertools.utilities.typing import LambdaContext

app = APIGatewayRestResolver()


@app.get("/todos")
def my_path():
    return {"is_admin": app.context["is_admin"]}


def lambda_handler(event: dict, context: LambdaContext) -> dict:
    app.append_context(is_admin=True, another_useful_data={})
    return app.resolve(event, context)
```

**Accessing context from Router instances**

```python
import requests

from aws_lambda_powertools.event_handler.api_gateway import Router
from requests import Response

router = Router()


@router.get("/todos")
def get_todos():
    is_admin = router.context.get("is_admin", False)
    todos = {}

    if is_admin:
        todos: Response = requests.get("https://jsonplaceholder.typicode.com/todos")
        todos.raise_for_status()
        todos = todos.json()

    return {"todos": todos}
```


## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] [Meet tenets criteria](https://awslabs.github.io/aws-lambda-powertools-python/#tenets)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented
* [x] PR title follows [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-python/blob/develop/.github/semantic.yml)
* [x] Provide context support for AppSync 

<details>
<summary>Is this a breaking change?</summary>

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
