### PR TITLE
feat(logger): include logger name attribute when copy_config_to_registered_logger is used

### DIFF
--- a/aws_lambda_powertools/logging/utils.py
+++ b/aws_lambda_powertools/logging/utils.py
@@ -81,6 +81,8 @@ def _configure_logger(source_logger: Logger, logger: logging.Logger, level: Unio
     logger.handlers = []
     logger.setLevel(level)
     logger.propagate = False  # ensure we don't propagate logs to existing loggers, #1073
+    source_logger.append_keys(name="%(name)s")  # include logger name, see #1267
+
     source_logger.debug(f"Logger {logger} reconfigured to use logging level {level}")
     for source_handler in source_logger.handlers:
         logger.addHandler(source_handler)

--- a/docs/core/logger.md
+++ b/docs/core/logger.md
@@ -608,6 +608,9 @@ for the given name and level to the logging module. By default, this logs all bo
 
 You can copy the Logger setup to all or sub-sets of registered external loggers. Use the `copy_config_to_registered_logger` method to do this.
 
+???+ tip
+    To help differentiate between loggers, we include the standard logger `name` attribute for all loggers we copied configuration to.
+
 By default all registered loggers will be modified. You can change this behavior by providing `include` and `exclude` attributes. You can also provide optional `log_level` attribute external loggers will be configured with.
 
 ```python hl_lines="10" title="Cloning Logger config to all other registered standard loggers"

--- a/tests/functional/test_logger_utils.py
+++ b/tests/functional/test_logger_utils.py
@@ -280,9 +280,11 @@ def test_logger_name_is_included_during_copy(stdout, logger, log_level):
     utils.copy_config_to_registered_loggers(source_logger=powertools_logger, include={logger_1.name, logger_2.name})
     logger_1.info(msg)
     logger_2.info(msg)
+    powertools_logger.info(msg)
 
-    logger1_log, logger2_log = capture_multiple_logging_statements_output(stdout)
+    logger1_log, logger2_log, pt_log = capture_multiple_logging_statements_output(stdout)
 
-    # THEN
+    # THEN name attribute should be present in all loggers
     assert logger1_log["name"] == logger_1.name
     assert logger2_log["name"] == logger_2.name
+    assert pt_log["name"] == powertools_logger.name

--- a/tests/functional/test_logger_utils.py
+++ b/tests/functional/test_logger_utils.py
@@ -265,3 +265,24 @@ def test_copy_config_to_ext_loggers_no_duplicate_logs(stdout, logger, log_level)
     logs = capture_multiple_logging_statements_output(stdout)
     assert {"message": msg} not in logs
     assert sum(msg in log.values() for log in logs) == 1
+
+
+def test_logger_name_is_included_during_copy(stdout, logger, log_level):
+    # GIVEN two external loggers and powertools logger initialized
+    logger_1: logging.Logger = logger()
+    logger_2: logging.Logger = logger()
+    msg = "test message1"
+
+    powertools_logger = Logger(service=service_name(), level=log_level.INFO.value, stream=stdout)
+
+    # WHEN configuration copied from powertools logger to ALL external loggers
+    # AND external loggers used
+    utils.copy_config_to_registered_loggers(source_logger=powertools_logger, include={logger_1.name, logger_2.name})
+    logger_1.info(msg)
+    logger_2.info(msg)
+
+    logger1_log, logger2_log = capture_multiple_logging_statements_output(stdout)
+
+    # THEN
+    assert logger1_log["name"] == logger_1.name
+    assert logger2_log["name"] == logger_2.name


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
**Issue number:** #1267

## Summary

### Changes

> Please provide a summary of what's being changed

This change adds the standard logging attribute `name` when copying configuration from a Powertools Logger to all (or a set) registered loggers. 

### User experience

> Please share what the user experience looks like before and after this change

**BEFORE**

```json
[
    {
        "level": "INFO",
        "location": "<module>:16",
        "message": "Name should be equal service value",
        "timestamp": "2022-06-29 16:56:11,789+0200",
        "service": "payment",
    },
    {
        "level": "INFO",
        "location": "<module>:17",
        "message": "Something random",
        "timestamp": "2022-06-29 16:56:11,789+0200",
        "service": "payment",
    }
]
```

**AFTER**

```json
[
    {
        "level": "INFO",
        "location": "<module>:16",
        "message": "Name should be equal service value",
        "timestamp": "2022-06-29 16:56:11,789+0200",
        "service": "payment",
        "name": "payment"
    },
    {
        "level": "INFO",
        "location": "<module>:17",
        "message": "Something random",
        "timestamp": "2022-06-29 16:56:11,789+0200",
        "service": "payment",
        "name": "my_dependency_logger"
    }
]
```

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] [Meet tenets criteria](https://awslabs.github.io/aws-lambda-powertools-python/#tenets)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented
* [x] PR title follows [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-python/blob/develop/.github/semantic.yml)

<details>
<summary>Is this a breaking change?</summary>

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.


-----
[View rendered docs/core/logger.md](https://github.com/heitorlessa/aws-lambda-powertools-python/blob/logger/add-logger-name-on-config-copy/docs/core/logger.md)