### PR TITLE
fix(metrics): ensure dimension_set is reused across instances (pointer)

### DIFF
--- a/aws_lambda_powertools/metrics/metrics.py
+++ b/aws_lambda_powertools/metrics/metrics.py
@@ -77,7 +77,8 @@ class Metrics(MetricManager):
         self.namespace: Optional[str] = namespace
         self.metadata_set = self._metadata
         self.default_dimensions = self._default_dimensions
-        self.dimension_set = {**self._default_dimensions, **self._dimensions}
+        self.dimension_set = self._dimensions
+        self.dimension_set.update(**self._default_dimensions)
 
         super().__init__(
             metric_set=self.metric_set,

--- a/tests/functional/test_metrics.py
+++ b/tests/functional/test_metrics.py
@@ -898,3 +898,16 @@ def test_log_metrics_with_default_dimensions(capsys, metrics, dimensions, namesp
     # THEN we should have default dimensions in both outputs
     assert "environment" in first_invocation
     assert "environment" in second_invocation
+
+
+def test_metrics_reuse_dimension_set(metric, dimension, namespace):
+    # GIVEN Metrics is initialized
+    my_metrics = Metrics(namespace=namespace)
+    my_metrics.add_dimension(**dimension)
+    my_metrics.add_metric(**metric)
+
+    # WHEN Metrics is initialized one more time
+    my_metrics_2 = Metrics(namespace=namespace)
+
+    # THEN Both class instances should have the same dimension set
+    assert my_metrics_2.dimension_set == my_metrics.dimension_set

--- a/tests/functional/test_metrics.py
+++ b/tests/functional/test_metrics.py
@@ -911,3 +911,17 @@ def test_metrics_reuse_dimension_set(metric, dimension, namespace):
 
     # THEN Both class instances should have the same dimension set
     assert my_metrics_2.dimension_set == my_metrics.dimension_set
+
+
+def test_metrics_reuse_metadata_set(metric, dimension, namespace):
+    # GIVEN Metrics is initialized
+    my_metrics = Metrics(namespace=namespace)
+    my_metrics.add_dimension(**dimension)
+    my_metrics.add_metric(**metric)
+    my_metrics.add_metadata(key="meta", value="data")
+
+    # WHEN Metrics is initialized one more time
+    my_metrics_2 = Metrics(namespace=namespace)
+
+    # THEN Both class instances should have the same metadata set
+    assert my_metrics_2.metadata_set == my_metrics.metadata_set

--- a/tests/functional/test_metrics.py
+++ b/tests/functional/test_metrics.py
@@ -901,7 +901,7 @@ def test_log_metrics_with_default_dimensions(capsys, metrics, dimensions, namesp
 
 
 def test_metrics_reuse_dimension_set(metric, dimension, namespace):
-    # GIVEN Metrics is initialized
+    # GIVEN Metrics is initialized with a metric and dimension
     my_metrics = Metrics(namespace=namespace)
     my_metrics.add_dimension(**dimension)
     my_metrics.add_metric(**metric)
@@ -909,12 +909,12 @@ def test_metrics_reuse_dimension_set(metric, dimension, namespace):
     # WHEN Metrics is initialized one more time
     my_metrics_2 = Metrics(namespace=namespace)
 
-    # THEN Both class instances should have the same dimension set
+    # THEN both class instances should have the same dimension set
     assert my_metrics_2.dimension_set == my_metrics.dimension_set
 
 
 def test_metrics_reuse_metadata_set(metric, dimension, namespace):
-    # GIVEN Metrics is initialized
+    # GIVEN Metrics is initialized with a metric, dimension, and metadata
     my_metrics = Metrics(namespace=namespace)
     my_metrics.add_dimension(**dimension)
     my_metrics.add_metric(**metric)
@@ -923,5 +923,5 @@ def test_metrics_reuse_metadata_set(metric, dimension, namespace):
     # WHEN Metrics is initialized one more time
     my_metrics_2 = Metrics(namespace=namespace)
 
-    # THEN Both class instances should have the same metadata set
+    # THEN both class instances should have the same metadata set
     assert my_metrics_2.metadata_set == my_metrics.metadata_set


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
**Issue number:** #1579

## Summary

### Changes

> Please provide a summary of what's being changed

This PR fixes a bug subsequent instances of Metrics don't reuse aggregated dimensions.

### User experience

> Please share what the user experience looks like before and after this change

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] [Meet tenets criteria](https://awslabs.github.io/aws-lambda-powertools-python/#tenets)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented
* [x] PR title follows [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-python/blob/develop/.github/semantic.yml)

<details>
<summary>Is this a breaking change?</summary>

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
