### PR TITLE
feat(layer): publish SAR v2 via Github actions

### DIFF
--- a/.github/workflows/publish_v2_layer.yml
+++ b/.github/workflows/publish_v2_layer.yml
@@ -23,6 +23,8 @@ jobs:
     defaults:
       run:
         working-directory: ./layer
+    outputs:
+      release-tag-version: ${{ steps.release-notes-tag.outputs.release-tag-version }}
     steps:
       - name: checkout
         uses: actions/checkout@v3
@@ -46,11 +48,13 @@ jobs:
           poetry export --format requirements.txt --output requirements.txt
           pip install -r requirements.txt
       - name: Set release notes tag
+        id: release-notes-tag
         run: |
           RELEASE_INPUT=${{ inputs.latest_published_version }}
           LATEST_TAG=$(git describe --tag --abbrev=0)
           RELEASE_TAG_VERSION=${RELEASE_INPUT:-$LATEST_TAG}
           echo RELEASE_TAG_VERSION="${RELEASE_TAG_VERSION:1}" >> "$GITHUB_ENV"
+          echo "::set-output name=release-tag-version::$RELEASE_TAG_VERSION"
       - name: Set up QEMU
         uses: docker/setup-qemu-action@8b122486cedac8393e77aa9734c3528886e4a1a8 # v2.0.0
         # NOTE: we need QEMU to build Layer against a different architecture (e.g., ARM)
@@ -81,6 +85,17 @@ jobs:
       artefact-name: "cdk-layer-artefact"
       environment: "layer-beta"
 
+  deploy-sar-beta:
+    needs:
+      - build-layer
+    uses: ./.github/workflows/reusable_deploy_v2_sar.yml
+    secrets: inherit
+    with:
+      stage: "BETA"
+      artefact-name: "cdk-layer-artefact"
+      environment: "layer-beta"
+      package-version: ${{ needs.build-layer.outputs.release-tag-version }}
+
   # deploy-prod:
   #   needs:
   #     - deploy-beta
@@ -90,3 +105,14 @@ jobs:
   #     stage: "PROD"
   #     artefact-name: "cdk-layer-artefact"
   #     environment: "layer-prod"
+
+  # deploy-sar-prod:
+  #   needs:
+  #     - build-layer
+  #   uses: ./.github/workflows/reusable_deploy_v2_sar.yml
+  #   secrets: inherit
+  #   with:
+  #     stage: "PROD"
+  #     artefact-name: "cdk-layer-artefact"
+  #     environment: "layer-beta"
+  #     package-version: ${{ needs.build-layer.outputs.release-tag-version }}

--- a/.github/workflows/reusable_deploy_v2_sar.yml
+++ b/.github/workflows/reusable_deploy_v2_sar.yml
@@ -1,0 +1,76 @@
+name: Deploy V2 SAR
+
+permissions:
+  id-token: write
+  contents: read
+
+env:
+  SAM_VERSION: 2.44.0
+  NODE_VERSION: 16.12
+  AWS_REGION: eu-central-1
+
+on:
+  workflow_call:
+    inputs:
+      stage:
+        description: "Deployment stage (BETA, PROD)"
+        required: true
+        type: string
+      artefact-name:
+        description: "CDK Layer Artefact name to download"
+        required: true
+        type: string
+      package-version:
+        description: "The version of the package to deploy"
+        required: true
+        type: string
+      environment:
+        description: "GitHub Environment to use for encrypted secrets"
+        required: true
+        type: string
+
+jobs:
+  deploy-cdk-stack:
+    runs-on: ubuntu-latest
+    environment: ${{ inputs.environment }}
+    defaults:
+      run:
+        working-directory: ./layer
+    steps:
+      - name: checkout
+        uses: actions/checkout@v3
+      - name: aws credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-region: $AWS_REGION
+          role-to-assume: ${{ secrets.AWS_SAR_ROLE_ARN }}
+      - name: Setup Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: $NODE_VERSION
+      - name: install cdk and deps
+        run: |
+          npm install -g "aws-cdk@$CDK_VERSION"
+          cdk --version
+      - name: Download artifact
+        uses: actions/download-artifact@v3
+        with:
+          name: ${{ inputs.artefact-name }}
+          path: layer
+      - name: unzip artefact
+        run: |
+          unzip cdk.out.zip
+      - name: Deploy x86_64 SAR
+        run: |
+          asset=$(jq -jc '.Resources[] | select(.Properties.CompatibleArchitectures == ["x86_64"]) | .Metadata."aws:asset:path"' cdk.out/LayerStack.template.json)
+          sed -e "s/<VERSION>/${{ inputs.package-version }}/g" -e "s/<SAR_APP_NAME>/aws-lambda-powertools-python-layer-v2/g" -e "s/<LAYER_CONTENT_PATH>/.\/cdk.out\/$asset/g" sar/template.txt > sar/template.yml
+          cp ../README.md ../LICENSE "./cdk.out/$asset/"
+          pipx run sam=="$SAM_VERSION" package --template-file sar/template.yml --output-template-file packaged.yml --s3-bucket ${{ secrets.AWS_SAR_S3_BUCKET }}
+          pipx run sam=="$SAM_VERSION" publish --template packaged.yml --region "$AWS_REGION"
+      - name: Deploy arm64 SAR
+        run: |
+          asset=$(jq -jc '.Resources[] | select(.Properties.CompatibleArchitectures == ["arm64"]) | .Metadata."aws:asset:path"' cdk.out/LayerStack.template.json)
+          sed -e "s/<VERSION>/${{ inputs.package-version }}/g" -e "s/<SAR_APP_NAME>/aws-lambda-powertools-python-layer-v2-arm64/g" -e "s/<LAYER_CONTENT_PATH>/.\/cdk.out\/$asset/g" sar/template.txt > sar/template.yml
+          cp ../README.md ../LICENSE "./cdk.out/$asset/"
+          pipx run sam=="$SAM_VERSION" package --template-file sar/template.yml --output-template-file packaged.yml --s3-bucket ${{ secrets.AWS_SAR_S3_BUCKET }}
+          pipx run sam=="$SAM_VERSION" publish --template packaged.yml --region "$AWS_REGION"

--- a/layer/sar/template.txt
+++ b/layer/sar/template.txt
@@ -1,0 +1,38 @@
+AWSTemplateFormatVersion: '2010-09-09'
+
+Metadata:
+  AWS::ServerlessRepo::Application:
+    Name: <SAR_APP_NAME>
+    Description: "AWS Lambda Layer for aws-lambda-powertools "
+    Author: AWS
+    SpdxLicenseId: Apache-2.0
+    LicenseUrl: LICENSE
+    ReadmeUrl: README.md
+    Labels: ['layer','lambda','powertools','python', 'aws']
+    HomePageUrl: https://github.com/awslabs/aws-lambda-powertools-python
+    SemanticVersion: <VERSION>
+    SourceCodeUrl: https://github.com/awslabs/aws-lambda-powertools-python
+
+Transform: AWS::Serverless-2016-10-31
+Description: AWS Lambda Layer for aws-lambda-powertools with python 3.9, 3.8 or 3.7
+
+Resources:
+  LambdaLayer:
+    Type: AWS::Serverless::LayerVersion
+    Properties:
+      Description: "AWS Lambda Layer for aws-lambda-powertools version <VERSION>"
+      LayerName: <SAR_APP_NAME>
+      ContentUri: <LAYER_CONTENT_PATH>
+      CompatibleRuntimes:
+        - python3.9
+        - python3.8
+        - python3.7
+      LicenseInfo: 'Available under the Apache-2.0 license.'
+      RetentionPolicy: Retain
+
+Outputs:
+  LayerVersionArn:
+    Description: ARN for the published Layer version
+    Value: !Ref LambdaLayer
+    Export:
+      Name: !Sub 'LayerVersionArn-${AWS::StackName}'


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
**Issue number:** #1543

## Summary

This PR adds support for creating the v2 SAR via Github Actions.

### Changes

> Please provide a summary of what's being changed

We use the job that creates the Lambda Layer artifact to publish the SAR using SAM.

### User experience

> Please share what the user experience looks like before and after this change

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] [Meet tenets criteria](https://awslabs.github.io/aws-lambda-powertools-python/#tenets)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [ ] Changes are documented
* [x] PR title follows [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-python/blob/develop/.github/semantic.yml)

<details>
<summary>Is this a breaking change?</summary>

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.