### PR TITLE
docs(logger): fix typo.

### DIFF
--- a/docs/core/logger.md
+++ b/docs/core/logger.md
@@ -619,7 +619,7 @@ By default all registered loggers will be modified. You can change this behavior
 
 ### How can I add standard library logging attributes to a log record?
 
-The Python standard library log records contains a [large set of atttributes](https://docs.python.org/3/library/logging.html#logrecord-attributes){target="_blank"}, however only a few are included in Powertools Logger log record by default.
+The Python standard library log records contains a [large set of attributes](https://docs.python.org/3/library/logging.html#logrecord-attributes){target="_blank"}, however only a few are included in Powertools Logger log record by default.
 
 You can include any of these logging attributes as key value arguments (`kwargs`) when instantiating `Logger` or `LambdaPowertoolsFormatter`.
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
**Issue number: #1586**

## Summary

Hello, everyone in the community.
I found a minor typo in `docs/core/logger.md` ([shortcut](https://github.com/awslabs/aws-lambda-powertools-python/blob/develop/docs/core/logger.md)) . :)

### Changes

The typo is `atttributes`, so we can change it to `attributes` normally.

### User experience

Multiple users will be able to understand the contents of the document more clearly.

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] [Meet tenets criteria](https://awslabs.github.io/aws-lambda-powertools-python/#tenets)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented
* [x] PR title follows [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-python/blob/develop/.github/semantic.yml)

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.


-----
[View rendered docs/core/logger.md](https://github.com/digitalisx/aws-lambda-powertools-python/blob/develop/docs/core/logger.md)