### PR TITLE
docs(governance): allow community to suggest feature content

### DIFF
--- a/.github/ISSUE_TEMPLATE/share_your_work.yml
+++ b/.github/ISSUE_TEMPLATE/share_your_work.yml
@@ -1,0 +1,56 @@
+name: I Made This (showcase your work)
+description: Share what you did with Powertools 💞💞. Blog post, workshops, presentation, sample apps, etc.
+title: "[I Made This]: <TITLE>"
+labels: ["community-content"]
+body:
+  - type: markdown
+    attributes:
+      value: Thank you for helping spread the word out on Powertools, truly!
+  - type: input
+    id: content
+    attributes:
+      label: Link to your material
+      description: |
+        Please share the original link to your material.
+
+        *Note: Short links will be expanded when added to Powertools documentation*
+    validations:
+      required: true
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: Describe in one paragraph what's in it for them (readers)
+    validations:
+      required: true
+  - type: input
+    id: author
+    attributes:
+      label: Preferred contact
+      description: What's your preferred contact? We'll list it next to this content
+    validations:
+      required: true
+  - type: input
+    id: author-social
+    attributes:
+      label: (Optional) Social Network
+      description: If different from preferred contact, what's your preferred contact for social interactions?
+    validations:
+      required: false
+  - type: textarea
+    id: notes
+    attributes:
+      label: (Optional) Additional notes
+      description: |
+        Any notes you might want to share with us related to this material.
+
+        *Note: These notes are explicitly to Powertools maintainers. It will not be added to the community resources page.*
+    validations:
+      required: false
+  - type: checkboxes
+    id: acknowledgment
+    attributes:
+      label: Acknowledgment
+      options:
+        - label: I understand this content may be removed from Powertools documentation if it doesn't conform with the [Code of Conduct](https://aws.github.io/code-of-conduct)
+          required: true

--- a/.github/ISSUE_TEMPLATE/support_powertools.yml
+++ b/.github/ISSUE_TEMPLATE/support_powertools.yml
@@ -1,7 +1,7 @@
 name: Support Lambda Powertools (become a reference)
 description: Add your organization's name or logo to the Lambda Powertools documentation
 title: "[Support Lambda Powertools]: <your organization name>"
-labels: ["customer_reference"]
+labels: ["customer-reference"]
 body:
   - type: markdown
     attributes:

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -94,6 +94,8 @@ These are the most common labels used by maintainers to triage issues, pull requ
 | github-actions         | Changes in GitHub workflows                                                 | PR automation                                                   |
 | github-templates       | Changes in GitHub issue/PR templates                                        | PR automation                                                   |
 | internal               | Changes in governance, tech debt and chores (linting setup, baseline, etc.) | PR automation                                                   |
+| customer-reference     | Authorization to use company name in our documentation                      | Public Relations                                                |
+| community-content      | Suggested content to feature in our documentation                           | Public Relations                                                |
 
 ## Maintainer Responsibilities
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
**Issue number:** #995

## Summary

### Changes

> Please provide a summary of what's being changed

New GitHub Issue Template to suggest content to feature in a new section in the documentation named: `We Made This`. We'll create this section in a separate PR.

### User experience

> Please share what the user experience looks like before and after this change

<img width="760" alt="image" src="https://user-images.githubusercontent.com/3340292/195617206-6dc0ea10-2023-41b4-bfbd-ee6824a5b3da.png">

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] [Meet tenets criteria](https://awslabs.github.io/aws-lambda-powertools-python/#tenets)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented
* [x] PR title follows [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-python/blob/develop/.github/semantic.yml)

<details>
<summary>Is this a breaking change?</summary>

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.


-----
[View rendered MAINTAINERS.md](https://github.com/heitorlessa/aws-lambda-powertools-python/blob/docs/open-for-community-content/MAINTAINERS.md)