### PR TITLE
fix(parser): loose validation on SNS fields to support FIFO

### DIFF
--- a/aws_lambda_powertools/utilities/parser/models/sns.py
+++ b/aws_lambda_powertools/utilities/parser/models/sns.py
@@ -22,10 +22,10 @@ class SnsNotificationModel(BaseModel):
     MessageAttributes: Optional[Dict[str, SnsMsgAttributeModel]]
     Message: Union[str, TypingType[BaseModel]]
     MessageId: str
-    SigningCertUrl: HttpUrl
-    Signature: str
+    SigningCertUrl: Optional[HttpUrl]  # NOTE: FIFO opt-in removes attribute
+    Signature: Optional[str]  # NOTE: FIFO opt-in removes attribute
     Timestamp: datetime
-    SignatureVersion: str
+    SignatureVersion: Optional[str]  # NOTE: FIFO opt-in removes attribute
 
     @root_validator(pre=True, allow_reuse=True)
     def check_sqs_protocol(cls, values):

--- a/tests/events/snsSqsFifoEvent.json
+++ b/tests/events/snsSqsFifoEvent.json
@@ -1,0 +1,23 @@
+{
+    "Records": [
+        {
+            "messageId": "69bc4bbd-ed69-4325-a434-85c3b428ceab",
+            "receiptHandle": "AQEBbfAqjhrgIdW3HGWYPz57mdDatG/dT9LZhRPAsNQ1pJmw495w4esDc8ZSbOwMZuPBol7wtiNWug8U25GpSQDDLY1qv//8/lfmdzXOiprG6xRVeiXSHj0j731rJQ3xo+GPdGjOzjIxI09CrE3HtZ4lpXY9NjjHzP8hdxkCLlbttumc8hDBUR365/Tk+GfV2nNP9qvZtLGEbKCdTm/GYdTSoAr+ML9HnnGrS9T25Md71ASiZMI4DZqptN6g7CYYojFPs1LVM9o1258ferA72zbNoQ==",
+            "body": "{\n  \"Type\" : \"Notification\",\n  \"MessageId\" : \"a7c9d2fa-77fa-5184-9de9-89391027cc7d\",\n  \"SequenceNumber\" : \"10000000000000004000\",\n  \"TopicArn\" : \"arn:aws:sns:eu-west-1:231436140809:Test.fifo\",\n  \"Message\" : \"{\\\"message\\\": \\\"hello world\\\", \\\"username\\\": \\\"lessa\\\"}\",\n  \"Timestamp\" : \"2022-10-14T13:35:25.419Z\",\n  \"UnsubscribeURL\" : \"https://sns.eu-west-1.amazonaws.com/?Action=Unsubscribe&SubscriptionArn=arn:aws:sns:eu-west-1:231436140809:Test.fifo:bb81d3de-a0f9-46e4-b619-d3152a4d545f\"\n}",
+            "attributes": {
+                "ApproximateReceiveCount": "1",
+                "SentTimestamp": "1665754525442",
+                "SequenceNumber": "18873177232222703872",
+                "MessageGroupId": "powertools-test",
+                "SenderId": "AIDAWYJAWPFU7SUQGUJC6",
+                "MessageDeduplicationId": "4e0a0f61eed277a4b9e4c01d5722b07b0725e42fe782102abee5711adfac701f",
+                "ApproximateFirstReceiveTimestamp": "1665754525442"
+            },
+            "messageAttributes": {},
+            "md5OfBody": "f3c788e623445e3feb263e80c1bffc0b",
+            "eventSource": "aws:sqs",
+            "eventSourceARN": "arn:aws:sqs:eu-west-1:231436140809:Test.fifo",
+            "awsRegion": "eu-west-1"
+        }
+    ]
+}

--- a/tests/functional/parser/test_sns.py
+++ b/tests/functional/parser/test_sns.py
@@ -134,3 +134,8 @@ def test_handle_sns_sqs_trigger_event_json_body_missing_unsubscribe_url():
     # THEN raise a ValidationError error
     with pytest.raises(ValidationError):
         handle_sns_sqs_json_body(event_dict, LambdaContext())
+
+
+def test_handle_sns_sqs_fifo_trigger_event_json_body():
+    event_dict = load_event("snsSqsFifoEvent.json")
+    handle_sns_sqs_json_body(event_dict, LambdaContext())

--- a/tests/functional/parser/test_sns.py
+++ b/tests/functional/parser/test_sns.py
@@ -110,19 +110,6 @@ def test_handle_sns_sqs_trigger_event_json_body():  # noqa: F811
     handle_sns_sqs_json_body(event_dict, LambdaContext())
 
 
-def test_handle_sns_sqs_trigger_event_json_body_missing_signing_cert_url():
-    # GIVEN an event is tampered with a missing SigningCertURL
-    event_dict = load_event("snsSqsEvent.json")
-    payload = json.loads(event_dict["Records"][0]["body"])
-    payload.pop("SigningCertURL")
-    event_dict["Records"][0]["body"] = json.dumps(payload)
-
-    # WHEN parsing the payload
-    # THEN raise a ValidationError error
-    with pytest.raises(ValidationError):
-        handle_sns_sqs_json_body(event_dict, LambdaContext())
-
-
 def test_handle_sns_sqs_trigger_event_json_body_missing_unsubscribe_url():
     # GIVEN an event is tampered with a missing UnsubscribeURL
     event_dict = load_event("snsSqsEvent.json")


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
**Issue number:** #1590

## Summary

### Changes

> Please provide a summary of what's being changed

When enabling FIFO in SNS topics, SNS removes the following three keys leading to a `ValidationError` in Parser. 

**Error**

```python
SigningCertUrl
  none is not an allowed value (type=type_error.none.not_allowed)
Signature
  field required (type=value_error.missing)
SignatureVersion
  field required (type=value_error.missing)
```

This PR makes two changes:

* Marks all of these fields as Optional. In the future, we should look into having explicit FIFO Models to make strict typing better
* Removes `test_handle_sns_sqs_trigger_event_json_body_missing_signing_cert_url` that verified the field being tampered.. which is no longer valid due to FIFO behaviour completely removing this and other fields above



### User experience

> Please share what the user experience looks like before and after this change

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] [Meet tenets criteria](https://awslabs.github.io/aws-lambda-powertools-python/#tenets)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented
* [x] PR title follows [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-python/blob/develop/.github/semantic.yml)

<details>
<summary>Is this a breaking change?</summary>

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
