### PR TITLE
feat(ci): release docs as alpha when doing a pre-release

### DIFF
--- a/.github/workflows/on_release_notes.yml
+++ b/.github/workflows/on_release_notes.yml
@@ -129,7 +129,7 @@ jobs:
         run: |
           DOCS_ALIAS=latest
           if [[ "${{ github.event.release.prerelease || inputs.pre_release }}" == true ]] ; then
-            DOCS_ALIAS="alpha"
+            DOCS_ALIAS=alpha
           fi
           echo DOCS_ALIAS="$DOCS_ALIAS" >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/on_release_notes.yml
+++ b/.github/workflows/on_release_notes.yml
@@ -119,7 +119,7 @@ jobs:
     uses: ./.github/workflows/reusable_publish_changelog.yml
 
   # When doing a pre-release, we want to publish the docs as "alpha" instead of replacing the latest docs
-  prepare-docs-alias:
+  prepare_docs_alias:
     runs-on: ubuntu-latest
     outputs:
       DOCS_ALIAS: ${{ steps.set-alias.outputs.DOCS_ALIAS }}
@@ -134,14 +134,14 @@ jobs:
           echo DOCS_ALIAS="$DOCS_ALIAS" >> "$GITHUB_OUTPUT"
 
   docs:
-    needs: [release, changelog, prepare-docs-alias]
+    needs: [release, changelog, prepare_docs_alias]
     permissions:
       contents: write
       pages: write
     uses: ./.github/workflows/reusable_publish_docs.yml
     with:
       version: ${{ needs.release.outputs.RELEASE_VERSION }}
-      alias: ${{ needs.prepare-docs-alias.outputs.DOCS_ALIAS }}
+      alias: ${{ needs.prepare_docs_alias.outputs.DOCS_ALIAS }}
       detached_mode: true
 
   publish_layer:

--- a/.github/workflows/on_release_notes.yml
+++ b/.github/workflows/on_release_notes.yml
@@ -44,6 +44,11 @@ on:
         default: false
         type: boolean
         required: false
+      pre_release:
+        description: "Publishes documentation using a pre-release tag. You are still responsible for passing a pre-release version tag to the workflow."
+        default: false
+        type: boolean
+        required: false
 
 jobs:
   release:
@@ -113,15 +118,30 @@ jobs:
       contents: write
     uses: ./.github/workflows/reusable_publish_changelog.yml
 
+  # When we're doing a pre-release, we want to publish the docs as alpha
+  prepare-docs-alias:
+    runs-on: ubuntu-latest
+    outputs:
+      DOCS_ALIAS: ${{ steps.set-alias.outputs.DOCS_ALIAS }}
+    steps:
+      - name: Set docs alias
+        id: set-alias
+        run: |
+          DOCS_ALIAS=latest
+          if [[ "${{ github.event.release.prerelease || inputs.pre_release }}" == true ]] ; then
+            DOCS_ALIAS="alpha"
+          fi
+          echo DOCS_ALIAS="$DOCS_ALIAS" >> "$GITHUB_OUTPUT"
+
   docs:
-    needs: [release, changelog]
+    needs: [release, changelog, prepare-docs-alias]
     permissions:
       contents: write
       pages: write
     uses: ./.github/workflows/reusable_publish_docs.yml
     with:
       version: ${{ needs.release.outputs.RELEASE_VERSION }}
-      alias: latest
+      alias: ${{ needs.prepare-docs-alias.outputs.DOCS_ALIAS }}
       detached_mode: true
 
   publish_layer:

--- a/.github/workflows/on_release_notes.yml
+++ b/.github/workflows/on_release_notes.yml
@@ -118,7 +118,7 @@ jobs:
       contents: write
     uses: ./.github/workflows/reusable_publish_changelog.yml
 
-  # When we're doing a pre-release, we want to publish the docs as alpha
+  # When doing a pre-release, we want to publish the docs as "alpha" instead of replacing the latest docs
   prepare-docs-alias:
     runs-on: ubuntu-latest
     outputs:


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
**Issue number:** #1618

## Summary

### Changes

> Please provide a summary of what's being changed

This PR adds a new flag to release docs as alpha when doing a pre-release.

### User experience

> Please share what the user experience looks like before and after this change

When doing a pre-release, the documentation workflow will not override the latest public release.

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] [Meet tenets criteria](https://awslabs.github.io/aws-lambda-powertools-python/#tenets)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented
* [x] PR title follows [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-python/blob/develop/.github/semantic.yml)

<details>
<summary>Is this a breaking change?</summary>

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
