### PR TITLE
fix(ci): remove v2 suffix from SAR apps

### DIFF
--- a/.github/workflows/reusable_deploy_v2_sar.yml
+++ b/.github/workflows/reusable_deploy_v2_sar.yml
@@ -16,7 +16,7 @@ permissions:
 env:
   NODE_VERSION: 16.12
   AWS_REGION: eu-west-1
-  SAR_NAME: aws-lambda-powertools-python-layer-v2
+  SAR_NAME: aws-lambda-powertools-python-layer
   TEST_STACK_NAME: serverlessrepo-v2-powertools-layer-test-stack
 
 on:

--- a/docs/index.md
+++ b/docs/index.md
@@ -377,8 +377,8 @@ Despite having more steps compared to the [public Layer ARN](#lambda-layer) opti
 
 | App                                                                                                                                                                  | ARN                                                                                                                               | Description                                                           |
 | -------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------- |
-| [aws-lambda-powertools-python-layer-v2](https://serverlessrepo.aws.amazon.com/applications/eu-west-1/057560766410/aws-lambda-powertools-python-layer-v2)             | [arn:aws:serverlessrepo:eu-west-1:057560766410:applications/aws-lambda-powertools-python-layer-v2](#){: .copyMe}:clipboard:       | Contains all extra dependencies (e.g: pydantic).                      |
-| [aws-lambda-powertools-python-layer-v2-arm64](https://serverlessrepo.aws.amazon.com/applications/eu-west-1/057560766410/aws-lambda-powertools-python-layer-v2-arm64) | [arn:aws:serverlessrepo:eu-west-1:057560766410:applications/aws-lambda-powertools-python-layer-v2-arm64](#){: .copyMe}:clipboard: | Contains all extra dependencies (e.g: pydantic). For arm64 functions. |
+| [aws-lambda-powertools-python-layer](https://serverlessrepo.aws.amazon.com/applications/eu-west-1/057560766410/aws-lambda-powertools-python-layer)             | [arn:aws:serverlessrepo:eu-west-1:057560766410:applications/aws-lambda-powertools-python-layer](#){: .copyMe}:clipboard:       | Contains all extra dependencies (e.g: pydantic).                      |
+| [aws-lambda-powertools-python-layer-arm64](https://serverlessrepo.aws.amazon.com/applications/eu-west-1/057560766410/aws-lambda-powertools-python-layer-arm64) | [arn:aws:serverlessrepo:eu-west-1:057560766410:applications/aws-lambda-powertools-python-layer-arm64](#){: .copyMe}:clipboard: | Contains all extra dependencies (e.g: pydantic). For arm64 functions. |
 
 ???+ tip
 	You can create a shared Lambda Layers stack and make this along with other account level layers stack.
@@ -392,7 +392,7 @@ If using SAM, you can include this SAR App as part of your shared Layers stack, 
         Type: AWS::Serverless::Application
         Properties:
             Location:
-                ApplicationId: arn:aws:serverlessrepo:eu-west-1:057560766410:applications/aws-lambda-powertools-python-layer-v2
+                ApplicationId: arn:aws:serverlessrepo:eu-west-1:057560766410:applications/aws-lambda-powertools-python-layer
                 SemanticVersion: 2.0.0 # change to latest semantic version available in SAR
 
     MyLambdaFunction:
@@ -419,7 +419,7 @@ If using SAM, you can include this SAR App as part of your shared Layers stack, 
             Type: AWS::Serverless::Application
             Properties:
                 Location:
-                    ApplicationId: arn:aws:serverlessrepo:eu-west-1:057560766410:applications/aws-lambda-powertools-python-layer-v2
+                    ApplicationId: arn:aws:serverlessrepo:eu-west-1:057560766410:applications/aws-lambda-powertools-python-layer
                     # Find latest from github.com/awslabs/aws-lambda-powertools-python/releases
                     SemanticVersion: 2.0.0
     ```
@@ -432,7 +432,7 @@ If using SAM, you can include this SAR App as part of your shared Layers stack, 
     POWERTOOLS_BASE_NAME = 'AWSLambdaPowertools'
     # Find latest from github.com/awslabs/aws-lambda-powertools-python/releases
     POWERTOOLS_VER = '2.0.0'
-    POWERTOOLS_ARN = 'arn:aws:serverlessrepo:eu-west-1:057560766410:applications/aws-lambda-powertools-python-layer-v2'
+    POWERTOOLS_ARN = 'arn:aws:serverlessrepo:eu-west-1:057560766410:applications/aws-lambda-powertools-python-layer'
 
     class SampleApp(core.Construct):
 
@@ -489,7 +489,7 @@ If using SAM, you can include this SAR App as part of your shared Layers stack, 
     }
 
     data "aws_serverlessapplicationrepository_application" "sar_app" {
-      application_id   = "arn:aws:serverlessrepo:eu-west-1:057560766410:applications/aws-lambda-powertools-python-layer-v2"
+      application_id   = "arn:aws:serverlessrepo:eu-west-1:057560766410:applications/aws-lambda-powertools-python-layer"
       semantic_version = var.aws_powertools_version
     }
 
@@ -552,7 +552,7 @@ If using SAM, you can include this SAR App as part of your shared Layers stack, 
                         - serverlessrepo:GetCloudFormationTemplate
                     Resource:
                         # this is arn of the powertools SAR app
-                        - arn:aws:serverlessrepo:eu-west-1:057560766410:applications/aws-lambda-powertools-python-layer-v2
+                        - arn:aws:serverlessrepo:eu-west-1:057560766410:applications/aws-lambda-powertools-python-layer
                     - Sid: S3AccessLayer
                     Effect: Allow
                     Action:
@@ -569,7 +569,7 @@ If using SAM, you can include this SAR App as part of your shared Layers stack, 
                         - lambda:PublishLayerVersion
                         - lambda:GetLayerVersion
                     Resource:
-                        - !Sub arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:layer:aws-lambda-powertools-python-layer-v2*
+                        - !Sub arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:layer:aws-lambda-powertools-python-layer*
                 Roles:
                 - Ref: "PowertoolsLayerIamRole"
         ```
@@ -578,7 +578,7 @@ You can fetch available versions via SAR ListApplicationVersions API:
 
 ```bash title="AWS CLI example"
 aws serverlessrepo list-application-versions \
-	--application-id arn:aws:serverlessrepo:eu-west-1:057560766410:applications/aws-lambda-powertools-python-layer-v2
+	--application-id arn:aws:serverlessrepo:eu-west-1:057560766410:applications/aws-lambda-powertools-python-layer
 ```
 
 ## Quick getting started

--- a/layer/sar/template.txt
+++ b/layer/sar/template.txt
@@ -3,7 +3,7 @@ AWSTemplateFormatVersion: '2010-09-09'
 Metadata:
   AWS::ServerlessRepo::Application:
     Name: <SAR_APP_NAME>
-    Description: "AWS Lambda Layer for aws-lambda-powertools "
+    Description: "AWS Lambda Layer for aws-lambda-powertools"
     Author: AWS
     SpdxLicenseId: Apache-2.0
     LicenseUrl: <LAYER_CONTENT_PATH>/LICENSE


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
**Issue number:** #1618

## Summary

### Changes

> Please provide a summary of what's being changed

Update SAR workflow to point to existing SAR App

### User experience

> Please share what the user experience looks like before and after this change

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] [Meet tenets criteria](https://awslabs.github.io/aws-lambda-powertools-python/#tenets)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [ ] Changes are documented
* [x] PR title follows [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-python/blob/develop/.github/semantic.yml)

<details>
<summary>Is this a breaking change?</summary>

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.


-----
[View rendered docs/index.md](https://github.com/rubenfonseca/aws-lambda-powertools-python/blob/chore/sar-v2/docs/index.md)