### PR TITLE
docs(homepage): add Pulumi code example

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -240,8 +240,8 @@ You can include Lambda Powertools Lambda Layer using [AWS Lambda Console](https:
                 runtime=aws.lambda_.Runtime.PYTHON3D9,
                 handler="index.handler",
                 role=role.arn,
-                architectures=["x86_64"]
-                # other props like code and more...
+                architectures=["x86_64"],
+                code=pulumi.FileArchive("lambda_function_payload.zip")
             )
             ```
 
@@ -408,8 +408,8 @@ You can include Lambda Powertools Lambda Layer using [AWS Lambda Console](https:
                 runtime=aws.lambda_.Runtime.PYTHON3D9,
                 handler="index.handler",
                 role=role.arn,
-                architectures=["arm64"]
-                # other props like code and more...
+                architectures=["arm64"],
+                code=pulumi.FileArchive("lambda_function_payload.zip")
             )
             ```
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -233,16 +233,15 @@ You can include Lambda Powertools Lambda Layer using [AWS Lambda Console](https:
             )
 
             lambda_function = aws.lambda_.Function("function",
-                layers=[pulumi.Output.concat("arn:aws:lambda:",aws.get_region_output().name,":094274105915:layer:AWSLambdaPowertoolsTypeScript:3")],
-                code=pulumi.AssetArchive({
-                    ".": pulumi.FileArchive("./app")
-                }),
+                layers=[pulumi.Output.concat("arn:aws:lambda:",aws.get_region_output().name,":017000801446:layer:AWSLambdaPowertoolsPythonV2:11")],
                 tracing_config={
                     "mode": "Active"
                 },
-                runtime=aws.lambda_.Runtime.NODE_JS16D_X,
+                runtime=aws.lambda_.Runtime.PYTHON3D9,
                 handler="index.handler",
-                role=role.arn
+                role=role.arn,
+                architectures=["x86_64"]
+                # other props like code and more...
             )
             ```
 
@@ -402,19 +401,15 @@ You can include Lambda Powertools Lambda Layer using [AWS Lambda Console](https:
             )
 
             lambda_function = aws.lambda_.Function("function",
-                layers=[
-                    pulumi.Output.concat("arn:aws:lambda:",aws.get_region_output().name,":017000801446:layer:AWSLambdaPowertoolsPythonV2-Arm64:11")
-                ],
-                code=pulumi.AssetArchive({
-                    ".": pulumi.FileArchive("./app")
-                }),
+                layers=[pulumi.Output.concat("arn:aws:lambda:",aws.get_region_output().name,":017000801446:layer:AWSLambdaPowertoolsPythonV2-Arm64:11")],
                 tracing_config={
                     "mode": "Active"
                 },
-                runtime=aws.lambda_.Runtime.NODE_JS16D_X,
+                runtime=aws.lambda_.Runtime.PYTHON3D9,
                 handler="index.handler",
                 role=role.arn,
                 architectures=["arm64"]
+                # other props like code and more...
             )
             ```
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -209,6 +209,43 @@ You can include Lambda Powertools Lambda Layer using [AWS Lambda Console](https:
             }
             ```
 
+        === "Pulumi"
+
+            ```python
+            import json
+            import pulumi
+            import pulumi_aws as aws
+
+            role = aws.iam.Role("role",
+                assume_role_policy=json.dumps({
+                "Version": "2012-10-17",
+                "Statement": [
+                    {
+                    "Action": "sts:AssumeRole",
+                    "Principal": {
+                        "Service": "lambda.amazonaws.com"
+                    },
+                    "Effect": "Allow"
+                    }
+                ]
+                }),
+                managed_policy_arns=[aws.iam.ManagedPolicy.AWS_LAMBDA_BASIC_EXECUTION_ROLE]
+            )
+
+            lambda_function = aws.lambda_.Function("function",
+                layers=[pulumi.Output.concat("arn:aws:lambda:",aws.get_region_output().name,":094274105915:layer:AWSLambdaPowertoolsTypeScript:3")],
+                code=pulumi.AssetArchive({
+                    ".": pulumi.FileArchive("./app")
+                }),
+                tracing_config={
+                    "mode": "Active"
+                },
+                runtime=aws.lambda_.Runtime.NODE_JS16D_X,
+                handler="index.handler",
+                role=role.arn
+            )
+            ```
+
         === "Amplify"
 
             ```zsh
@@ -339,6 +376,46 @@ You can include Lambda Powertools Lambda Layer using [AWS Lambda Console](https:
             }
 
 
+            ```
+
+        === "Pulumi"
+
+            ```python
+            import json
+            import pulumi
+            import pulumi_aws as aws
+
+            role = aws.iam.Role("role",
+                assume_role_policy=json.dumps({
+                "Version": "2012-10-17",
+                "Statement": [
+                    {
+                    "Action": "sts:AssumeRole",
+                    "Principal": {
+                        "Service": "lambda.amazonaws.com"
+                    },
+                    "Effect": "Allow"
+                    }
+                ]
+                }),
+                managed_policy_arns=[aws.iam.ManagedPolicy.AWS_LAMBDA_BASIC_EXECUTION_ROLE]
+            )
+
+            lambda_function = aws.lambda_.Function("function",
+                layers=[
+                    pulumi.Output.concat("arn:aws:lambda:",aws.get_region_output().name,":017000801446:layer:AWSLambdaPowertoolsPythonV2-Arm64:11")
+                ],
+                code=pulumi.AssetArchive({
+                    ".": pulumi.FileArchive("./app")
+                }),
+                tracing_config={
+                    "mode": "Active"
+                },
+                runtime=aws.lambda_.Runtime.NODE_JS16D_X,
+                handler="index.handler",
+                role=role.arn,
+                architectures=["arm64"]
+            )
             ```
 
         === "Amplify"


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
**Issue number:** #1657 

Fixes: #1657

## Summary

Adding code to deploy lambda functions with the lambda layer added (similar PR for typescript here: awslabs/aws-lambda-powertools-typescript#1135)

### Changes

Added Pulumi code both for x86 and arm64 lambda functions

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] [Meet tenets criteria](https://awslabs.github.io/aws-lambda-powertools-python/#tenets)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [ ] Changes are documented
* [ ] PR title follows [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-python/blob/develop/.github/semantic.yml)

<details>
<summary>Is this a breaking change?</summary>

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.


-----
[View rendered docs/index.md](https://github.com/pierskarsenbarg/aws-lambda-powertools-python/blob/add-pulumi/docs/index.md)