### PR TITLE
feat(logger): accept arbitrary keyword=value for ephemeral metadata

### DIFF
--- a/aws_lambda_powertools/logging/logger.py
+++ b/aws_lambda_powertools/logging/logger.py
@@ -464,6 +464,26 @@ class Logger(logging.Logger):  # lgtm [py/missing-call-to-init]
             msg, *args, exc_info=exc_info, stack_info=stack_info, stacklevel=stacklevel, extra=extra
         )
 
+    def debug(
+        self,
+        msg: object,
+        *args,
+        exc_info=None,
+        stack_info: bool = False,
+        stacklevel: int = 2,
+        extra: Optional[Mapping[str, object]] = None,
+        **kwargs,
+    ):
+        extra = extra or {}
+        extra = {**extra, **kwargs}
+
+        # Maintenance: We can drop this upon Py3.7 EOL. It's a backport for "location" key to work
+        if sys.version_info < (3, 8):  # pragma: no cover
+            return self._logger.debug(msg, *args, exc_info=exc_info, stack_info=stack_info, extra=extra)
+        return self._logger.debug(
+            msg, *args, exc_info=exc_info, stack_info=stack_info, stacklevel=stacklevel, extra=extra
+        )
+
     def append_keys(self, **additional_keys):
         self.registered_formatter.append_keys(**additional_keys)
 

--- a/aws_lambda_powertools/logging/logger.py
+++ b/aws_lambda_powertools/logging/logger.py
@@ -378,7 +378,7 @@ class Logger(logging.Logger):  # lgtm [py/missing-call-to-init]
         extra = {**extra, **kwargs}
 
         # Maintenance: We can drop this upon Py3.7 EOL. It's a backport for "location" key to work
-        if sys.version_info < (3, 8):
+        if sys.version_info < (3, 8):  # pragma: no cover
             return self._logger.info(msg, *args, exc_info=exc_info, stack_info=stack_info, extra=extra)
         return self._logger.info(
             msg, *args, exc_info=exc_info, stack_info=stack_info, stacklevel=stacklevel, extra=extra
@@ -398,7 +398,7 @@ class Logger(logging.Logger):  # lgtm [py/missing-call-to-init]
         extra = {**extra, **kwargs}
 
         # Maintenance: We can drop this upon Py3.7 EOL. It's a backport for "location" key to work
-        if sys.version_info < (3, 8):
+        if sys.version_info < (3, 8):  # pragma: no cover
             return self._logger.error(msg, *args, exc_info=exc_info, stack_info=stack_info, extra=extra)
         return self._logger.error(
             msg, *args, exc_info=exc_info, stack_info=stack_info, stacklevel=stacklevel, extra=extra
@@ -408,7 +408,7 @@ class Logger(logging.Logger):  # lgtm [py/missing-call-to-init]
         self,
         msg: object,
         *args,
-        exc_info=None,
+        exc_info=True,
         stack_info: bool = False,
         stacklevel: int = 2,
         extra: Optional[Mapping[str, object]] = None,
@@ -418,7 +418,7 @@ class Logger(logging.Logger):  # lgtm [py/missing-call-to-init]
         extra = {**extra, **kwargs}
 
         # Maintenance: We can drop this upon Py3.7 EOL. It's a backport for "location" key to work
-        if sys.version_info < (3, 8):
+        if sys.version_info < (3, 8):  # pragma: no cover
             return self._logger.exception(msg, *args, exc_info=exc_info, stack_info=stack_info, extra=extra)
         return self._logger.exception(
             msg, *args, exc_info=exc_info, stack_info=stack_info, stacklevel=stacklevel, extra=extra
@@ -438,7 +438,7 @@ class Logger(logging.Logger):  # lgtm [py/missing-call-to-init]
         extra = {**extra, **kwargs}
 
         # Maintenance: We can drop this upon Py3.7 EOL. It's a backport for "location" key to work
-        if sys.version_info < (3, 8):
+        if sys.version_info < (3, 8):  # pragma: no cover
             return self._logger.critical(msg, *args, exc_info=exc_info, stack_info=stack_info, extra=extra)
         return self._logger.critical(
             msg, *args, exc_info=exc_info, stack_info=stack_info, stacklevel=stacklevel, extra=extra
@@ -458,7 +458,7 @@ class Logger(logging.Logger):  # lgtm [py/missing-call-to-init]
         extra = {**extra, **kwargs}
 
         # Maintenance: We can drop this upon Py3.7 EOL. It's a backport for "location" key to work
-        if sys.version_info < (3, 8):
+        if sys.version_info < (3, 8):  # pragma: no cover
             return self._logger.warning(msg, *args, exc_info=exc_info, stack_info=stack_info, extra=extra)
         return self._logger.warning(
             msg, *args, exc_info=exc_info, stack_info=stack_info, stacklevel=stacklevel, extra=extra

--- a/aws_lambda_powertools/logging/logger.py
+++ b/aws_lambda_powertools/logging/logger.py
@@ -4,7 +4,7 @@ import logging
 import os
 import random
 import sys
-from typing import IO, Any, Callable, Dict, Iterable, Optional, TypeVar, Union
+from typing import IO, Any, Callable, Dict, Iterable, Mapping, Optional, TypeVar, Union
 
 import jmespath
 
@@ -358,6 +358,101 @@ class Logger(logging.Logger):  # lgtm [py/missing-call-to-init]
             return lambda_handler(event, context, *args, **kwargs)
 
         return decorate
+
+    def info(
+        self,
+        msg: object,
+        *args,
+        exc_info=None,
+        stack_info: bool = False,
+        stacklevel: int = 2,
+        extra: Optional[Mapping[str, object]] = None,
+        **kwargs,
+    ):
+        # NOTE: We need to solve stack frame location for Python <3.8
+        extra = extra or {}
+        extra = {**extra, **kwargs}
+        if sys.version_info < (3, 8):
+            return self._logger.info(msg, *args, exc_info=exc_info, stack_info=stack_info, extra=extra)
+        return self._logger.info(
+            msg, *args, exc_info=exc_info, stack_info=stack_info, stacklevel=stacklevel, extra=extra
+        )
+
+    def error(
+        self,
+        msg: object,
+        *args,
+        exc_info=None,
+        stack_info: bool = False,
+        stacklevel: int = 2,
+        extra: Optional[Mapping[str, object]] = None,
+        **kwargs,
+    ):
+        # NOTE: We need to solve stack frame location for Python <3.8
+        extra = extra or {}
+        extra = {**extra, **kwargs}
+        if sys.version_info < (3, 8):
+            return self._logger.error(msg, *args, exc_info=exc_info, stack_info=stack_info, extra=extra)
+        return self._logger.error(
+            msg, *args, exc_info=exc_info, stack_info=stack_info, stacklevel=stacklevel, extra=extra
+        )
+
+    def exception(
+        self,
+        msg: object,
+        *args,
+        exc_info=None,
+        stack_info: bool = False,
+        stacklevel: int = 2,
+        extra: Optional[Mapping[str, object]] = None,
+        **kwargs,
+    ):
+        # NOTE: We need to solve stack frame location for Python <3.8
+        extra = extra or {}
+        extra = {**extra, **kwargs}
+        if sys.version_info < (3, 8):
+            return self._logger.exception(msg, *args, exc_info=exc_info, stack_info=stack_info, extra=extra)
+        return self._logger.exception(
+            msg, *args, exc_info=exc_info, stack_info=stack_info, stacklevel=stacklevel, extra=extra
+        )
+
+    def critical(
+        self,
+        msg: object,
+        *args,
+        exc_info=None,
+        stack_info: bool = False,
+        stacklevel: int = 2,
+        extra: Optional[Mapping[str, object]] = None,
+        **kwargs,
+    ):
+        # NOTE: We need to solve stack frame location for Python <3.8
+        extra = extra or {}
+        extra = {**extra, **kwargs}
+        if sys.version_info < (3, 8):
+            return self._logger.critical(msg, *args, exc_info=exc_info, stack_info=stack_info, extra=extra)
+        return self._logger.critical(
+            msg, *args, exc_info=exc_info, stack_info=stack_info, stacklevel=stacklevel, extra=extra
+        )
+
+    def warning(
+        self,
+        msg: object,
+        *args,
+        exc_info=None,
+        stack_info: bool = False,
+        stacklevel: int = 2,
+        extra: Optional[Mapping[str, object]] = None,
+        **kwargs,
+    ):
+        # NOTE: We need to solve stack frame location for Python <3.8
+        extra = extra or {}
+        extra = {**extra, **kwargs}
+        if sys.version_info < (3, 8):
+            return self._logger.warning(msg, *args, exc_info=exc_info, stack_info=stack_info, extra=extra)
+        return self._logger.warning(
+            msg, *args, exc_info=exc_info, stack_info=stack_info, stacklevel=stacklevel, extra=extra
+        )
 
     def append_keys(self, **additional_keys):
         self.registered_formatter.append_keys(**additional_keys)

--- a/docs/core/logger.md
+++ b/docs/core/logger.md
@@ -158,7 +158,7 @@ To ease routine tasks like extracting correlation ID from popular event sources,
 You can append additional keys using either mechanism:
 
 * Persist new keys across all future log messages via `append_keys` method
-* Add additional keys on a per log message basis via `extra` parameter
+* Add additional keys on a per log message basis as a keyword=value, or via `extra` parameter
 
 #### append_keys method
 
@@ -184,14 +184,33 @@ You can append your own keys to your existing Logger via `append_keys(**addition
 
     This example will add `order_id` if its value is not empty, and in subsequent invocations where `order_id` might not be present it'll remove it from the Logger.
 
+#### ephemeral metadata
+
+You can pass an arbitrary number of keyword arguments (kwargs) to all log level's methods, e.g. `logger.info, logger.warning`.
+
+Two common use cases for this feature is to enrich log statements with additional metadata, or only add certain keys conditionally.
+
+!!! info "Any keyword argument added will not be persisted in subsequent messages."
+
+=== "append_keys_kwargs.py"
+
+    ```python hl_lines="8"
+    --8<-- "examples/logger/src/append_keys_kwargs.py"
+    ```
+
+=== "append_keys_kwargs_output.json"
+
+    ```json hl_lines="7"
+    --8<-- "examples/logger/src/append_keys_kwargs_output.json"
+    ```
+
 #### extra parameter
 
 Extra parameter is available for all log levels' methods, as implemented in the standard logging library - e.g. `logger.info, logger.warning`.
 
 It accepts any dictionary, and all keyword arguments will be added as part of the root structure of the logs for that log statement.
 
-???+ info
-    Any keyword argument added using `extra` will not be persisted for subsequent messages.
+!!! info "Any keyword argument added using `extra` will not be persisted in subsequent messages."
 
 === "append_keys_extra.py"
 

--- a/examples/logger/src/append_keys_kwargs.py
+++ b/examples/logger/src/append_keys_kwargs.py
@@ -1,0 +1,10 @@
+from aws_lambda_powertools import Logger
+from aws_lambda_powertools.utilities.typing import LambdaContext
+
+logger = Logger()
+
+
+def handler(event: dict, context: LambdaContext) -> str:
+    logger.info("Collecting payment", request_id="1123")
+
+    return "hello world"

--- a/examples/logger/src/append_keys_kwargs_output.json
+++ b/examples/logger/src/append_keys_kwargs_output.json
@@ -1,0 +1,8 @@
+{
+    "level": "INFO",
+    "location": "collect.handler:8",
+    "message": "Collecting payment",
+    "timestamp": "2022-11-26 11:47:12,494+0200",
+    "service": "payment",
+    "request_id": "1123"
+}

--- a/tests/functional/test_logger.py
+++ b/tests/functional/test_logger.py
@@ -415,6 +415,25 @@ def test_logger_extra_kwargs(stdout, service_name):
     assert "request_id" not in no_extra_fields_log
 
 
+def test_logger_kwargs_no_extra(stdout, service_name):
+    # GIVEN Logger is initialized
+    logger = Logger(service=service_name, stream=stdout)
+
+    # WHEN `request_id` is an extra field in a log message to the existing structured log
+    fields = {"request_id": "blah"}
+
+    logger.info("with extra fields", **fields)
+    logger.info("without extra fields")
+
+    extra_fields_log, no_extra_fields_log = capture_multiple_logging_statements_output(stdout)
+
+    # THEN first log should have request_id field in the root structure
+    assert "request_id" in extra_fields_log
+
+    # THEN second log should not have request_id in the root structure
+    assert "request_id" not in no_extra_fields_log
+
+
 def test_logger_log_twice_when_log_filter_isnt_present_and_root_logger_is_setup(monkeypatch, stdout, service_name):
     # GIVEN Lambda configures the root logger with a handler
     root_logger = logging.getLogger()

--- a/tests/functional/test_logger.py
+++ b/tests/functional/test_logger.py
@@ -415,14 +415,14 @@ def test_logger_extra_kwargs(stdout, service_name):
     assert "request_id" not in no_extra_fields_log
 
 
-def test_logger_kwargs_no_extra(stdout, service_name):
+def test_logger_arbitrary_fields_as_kwargs(stdout, service_name):
     # GIVEN Logger is initialized
     logger = Logger(service=service_name, stream=stdout)
 
-    # WHEN `request_id` is an extra field in a log message to the existing structured log
+    # WHEN `request_id` is an arbitrary field in a log message to the existing structured log
     fields = {"request_id": "blah"}
 
-    logger.info("with extra fields", **fields)
+    logger.info("with arbitrary fields", **fields)
     logger.info("without extra fields")
 
     extra_fields_log, no_extra_fields_log = capture_multiple_logging_statements_output(stdout)


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
**Issue number:** #1167

> This supersedes PR #1505 as (1) Noah is busy with his day-to-day work priorities, and (2) the actual solution requires a full rewrite of the original PR

## Summary

This PR [backports the necessary code implemented in CPython 3.8](https://bugs.python.org/issue33165), monkeypatch and adds additional guards to only use the backported code in older Python versions to not impact performance and future improvements.


### Changes

> Please provide a summary of what's being changed

This change allows customers to pass arbitrary and ephemeral keyword=value arguments in log statements.

It addresses one of the oldest issues and makes it a better UX than `extra` argument. Both can coexist. This is a backport feature from Python 3.8.

**Why did it take us so long?**

The reason that this took us so long was that we inject the `location` key in log, so customers know where a logging statement came from in their code. 

```json
{
    "level": "WARNING",
    "location": "warning:465",
    "message": "Testing",
    "timestamp": "2022-10-26 16:22:27,543+0200",
    "service": "payment",
    "request_id": "0c7ff166-3be1-4795-8f0c-b48ca5ce5a95"
}
```

When using a class like `Logger`, we need to override all log statement methods. When doing so, it moves the stack frame location, where the `location` key now points to where the statement was called inside `Logger`, **instead** of the customer log statement location.

```python
def warning(msg, *args, **kwargs):...
def info(msg, *args, **kwargs):
    return self._logger.info(msg, *args, **kwargs)  # <--- location would always show up here
....
```

With this change, the `location` continues to be precise as we move the stack frame location.


```json
{
    "level": "WARNING",
    "location": "<module>:7",
    "message": "Testing",
    "timestamp": "2022-10-26 15:54:34,945+0200",
    "service": "payment",
    "request_id": "c344d8ca-2697-42b1-ad67-2bed036c550d",
}
```


### User experience

> Please share what the user experience looks like before and after this change

**BEFORE**

```python
from aws_lambda_powertools import Logger

from uuid import uuid4

logger = Logger(service="payment")

logger.warning("Testing", extra={"request_id": f"{uuid4()}"})
```

**AFTER**

```python
from aws_lambda_powertools import Logger

from uuid import uuid4

logger = Logger(service="payment")

logger.warning("Testing", request_id=f"{uuid4()}")
```


## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] [Meet tenets criteria](https://awslabs.github.io/aws-lambda-powertools-python/#tenets)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented
* [x] PR title follows [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-python/blob/develop/.github/semantic.yml)

<details>
<summary>Is this a breaking change?</summary>

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
