### PR TITLE
fix(idempotency): idempotent_function should support standalone falsy values

### DIFF
--- a/aws_lambda_powertools/utilities/idempotency/idempotency.py
+++ b/aws_lambda_powertools/utilities/idempotency/idempotency.py
@@ -134,13 +134,13 @@ def idempotent_function(
         if os.getenv(constants.IDEMPOTENCY_DISABLED_ENV):
             return function(*args, **kwargs)
 
-        payload = kwargs.get(data_keyword_argument)
-
-        if not payload:
+        if data_keyword_argument not in kwargs:
             raise RuntimeError(
                 f"Unable to extract '{data_keyword_argument}' from keyword arguments."
                 f" Ensure this exists in your function's signature as well as the caller used it as a keyword argument"
             )
+
+        payload = kwargs.get(data_keyword_argument)
 
         idempotency_handler = IdempotencyHandler(
             function=function,

--- a/tests/functional/idempotency/test_idempotency.py
+++ b/tests/functional/idempotency/test_idempotency.py
@@ -72,7 +72,7 @@ def test_idempotent_lambda_already_completed(
     lambda_context,
 ):
     """
-    Test idempotent decorator where event with matching event key has already been succesfully processed
+    Test idempotent decorator where event with matching event key has already been successfully processed
     """
 
     stubber = stub.Stubber(persistence_store.table.meta.client)
@@ -1245,6 +1245,29 @@ def test_idempotent_function_and_lambda_handler(lambda_context):
     # THEN we expect the function and lambda handler to execute successfully
     assert fn_result == expected_result
     assert handler_result == expected_result
+
+
+@pytest.mark.parametrize("data", [None, 0, False])
+def test_idempotent_function_falsy_values(data):
+    # Scenario to validate we can use idempotent_function with any function
+    # receiving a falsy value (`None`, `False`, `0`, etc.)
+    # shouldn't cause a RuntimeError
+    mock_event = data
+    idempotency_key = f"{TESTS_MODULE_PREFIX}.test_idempotent_function_falsy_values.<locals>.record_handler#{hash_idempotency_key(mock_event)}"  # noqa: E501
+
+    # 'test-func.functional.idempotency.test_idempotency.test_idempotent_function_falsy_values.<locals>.record_handler#37a6259cc0c1dae299a7866489dff0bd'
+
+    persistence_layer = MockPersistenceLayer(expected_idempotency_key=idempotency_key)
+    expected_result = {"message": "Foo"}
+
+    @idempotent_function(persistence_store=persistence_layer, data_keyword_argument="record")
+    def record_handler(record):
+        return expected_result
+
+    # WHEN calling the function
+    result = record_handler(record=mock_event)
+    # THEN we expect the function to execute successfully
+    assert result == expected_result
 
 
 def test_idempotent_data_sorting():


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
**Issue number:** #1663

## Summary

When using `idempotent_function` for any synchronous Python function (different from Lambda Handler), customers set which keyword argument we should use to hash data as an idempotency key.

We raise `RuntimeError` for cases where the keyword argument wasn't used correctly to prevent hashing the incorrect data. For example, function was called without the keyword argument (`function()`, instead of `function(data=data)`).

However, the current logic incorrectly checks the value available in the keyword argument, rather than the keyword argument was used. The following code leads to a `RuntimeError` when we should be serializing `None->null` just fine.

```python
...

import random

@idemp_f(data_keyword_argument="key")
def echo(key: str = None):
    return random.randint(1, 1000000)

echo(key=None)
```

### Changes

> Please provide a summary of what's being changed

This PR corrects the logic and only raises `RuntimeError` if the keyword argument specified for hashing isn't in the list of keyword arguments available at the function call.


### User experience

> Please share what the user experience looks like before and after this change

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] [Meet tenets criteria](https://awslabs.github.io/aws-lambda-powertools-python/#tenets)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented
* [x] PR title follows [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-python/blob/develop/.github/semantic.yml)

<details>
<summary>Is this a breaking change?</summary>

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
