### PR TITLE
fix(logger): fix unknown attributes being ignored by mypy

### DIFF
--- a/aws_lambda_powertools/logging/logger.py
+++ b/aws_lambda_powertools/logging/logger.py
@@ -8,6 +8,7 @@ import sys
 import traceback
 from typing import (
     IO,
+    TYPE_CHECKING,
     Any,
     Callable,
     Dict,
@@ -241,10 +242,14 @@ class Logger(logging.Logger):  # lgtm [py/missing-call-to-init]
 
         self._init_logger(formatter_options=formatter_options, **kwargs)
 
-    def __getattr__(self, name):
-        # Proxy attributes not found to actual logger to support backward compatibility
-        # https://github.com/awslabs/aws-lambda-powertools-python/issues/97
-        return getattr(self._logger, name)
+    # Prevent __getattr__ from shielding unknown attribute errors in type checkers
+    # https://github.com/awslabs/aws-lambda-powertools-python/issues/1660
+    if not TYPE_CHECKING:
+
+        def __getattr__(self, name):
+            # Proxy attributes not found to actual logger to support backward compatibility
+            # https://github.com/awslabs/aws-lambda-powertools-python/issues/97
+            return getattr(self._logger, name)
 
     def _get_logger(self):
         """Returns a Logger named {self.service}, or {self.service.filename} for child loggers"""


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
**Issue number:** #1660

## Summary

### Changes

Hides the `__getattr__` function in `Logger` from mypy and other type checkers

### User experience

Unknown attributes were not being flagged by mypy (e.g. `logger.foobar()` appeared as valid). Now, they appear as undefined attributes.

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] [Meet tenets criteria](https://awslabs.github.io/aws-lambda-powertools-python/#tenets)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [ ] Changes are documented
* [x] PR title follows [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-python/blob/develop/.github/semantic.yml)

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
