### PR TITLE
feat(parameters): add get_parameters_by_name for SSM params in distinct paths

### DIFF
--- a/aws_lambda_powertools/shared/functions.py
+++ b/aws_lambda_powertools/shared/functions.py
@@ -4,7 +4,7 @@ import logging
 import os
 import warnings
 from binascii import Error as BinAsciiError
-from typing import Optional, Union, overload
+from typing import Dict, Generator, Optional, Union, overload
 
 from aws_lambda_powertools.shared import constants
 
@@ -118,11 +118,6 @@ def powertools_debug_is_set() -> bool:
     return False
 
 
-def slice_dictionary(data, chunk_size: int):
-    # save CPU cycles if input is already small than chunk_size
-    if len(data) <= chunk_size:
-        yield data
-
-    data_iterator = iter(data)  # we don't know how big this is
+def slice_dictionary(data: Dict, chunk_size: int) -> Generator[Dict, None, None]:
     for _ in range(0, len(data), chunk_size):
-        yield {dict_key: data[dict_key] for dict_key in itertools.islice(data_iterator, chunk_size)}
+        yield {dict_key: data[dict_key] for dict_key in itertools.islice(data, chunk_size)}

--- a/aws_lambda_powertools/shared/functions.py
+++ b/aws_lambda_powertools/shared/functions.py
@@ -1,4 +1,5 @@
 import base64
+import itertools
 import logging
 import os
 import warnings
@@ -115,3 +116,13 @@ def powertools_debug_is_set() -> bool:
         return True
 
     return False
+
+
+def slice_dictionary(data, chunk_size: int):
+    # save CPU cycles if input is already small than chunk_size
+    if len(data) <= chunk_size:
+        yield data
+
+    data_iterator = iter(data)  # we don't know how big this is
+    for _ in range(0, len(data), chunk_size):
+        yield {dict_key: data[dict_key] for dict_key in itertools.islice(data_iterator, chunk_size)}

--- a/aws_lambda_powertools/utilities/feature_flags/appconfig.py
+++ b/aws_lambda_powertools/utilities/feature_flags/appconfig.py
@@ -15,8 +15,6 @@ from ... import Logger
 from .base import StoreProvider
 from .exceptions import ConfigurationStoreError, StoreClientError
 
-TRANSFORM_TYPE = "json"
-
 
 class AppConfigStore(StoreProvider):
     def __init__(
@@ -74,7 +72,7 @@ class AppConfigStore(StoreProvider):
                 dict,
                 self._conf_store.get(
                     name=self.name,
-                    transform=TRANSFORM_TYPE,
+                    transform="json",
                     max_age=self.cache_seconds,
                 ),
             )

--- a/aws_lambda_powertools/utilities/parameters/__init__.py
+++ b/aws_lambda_powertools/utilities/parameters/__init__.py
@@ -9,7 +9,7 @@ from .base import BaseProvider, clear_caches
 from .dynamodb import DynamoDBProvider
 from .exceptions import GetParameterError, TransformParameterError
 from .secrets import SecretsProvider, get_secret
-from .ssm import SSMProvider, get_parameter, get_parameters
+from .ssm import SSMProvider, get_parameter, get_parameters, get_parameters_by_name
 
 __all__ = [
     "AppConfigProvider",
@@ -22,6 +22,7 @@ __all__ = [
     "get_app_config",
     "get_parameter",
     "get_parameters",
+    "get_parameters_by_name",
     "get_secret",
     "clear_caches",
 ]

--- a/aws_lambda_powertools/utilities/parameters/appconfig.py
+++ b/aws_lambda_powertools/utilities/parameters/appconfig.py
@@ -9,6 +9,8 @@ from typing import TYPE_CHECKING, Any, Dict, Optional, Union
 import boto3
 from botocore.config import Config
 
+from aws_lambda_powertools.utilities.parameters.types import TransformOptions
+
 if TYPE_CHECKING:
     from mypy_boto3_appconfigdata import AppConfigDataClient
 
@@ -132,7 +134,7 @@ def get_app_config(
     name: str,
     environment: str,
     application: Optional[str] = None,
-    transform: Optional[str] = None,
+    transform: TransformOptions = None,
     force_fetch: bool = False,
     max_age: int = DEFAULT_MAX_AGE_SECS,
     **sdk_options

--- a/aws_lambda_powertools/utilities/parameters/base.py
+++ b/aws_lambda_powertools/utilities/parameters/base.py
@@ -1,6 +1,7 @@
 """
 Base for Parameter providers
 """
+from __future__ import annotations
 
 import base64
 import json
@@ -52,7 +53,7 @@ TRANSFORM_METHOD_MAPPING = {
 
 
 class ExpirableValue(NamedTuple):
-    value: Union[str, bytes, Dict[str, Any]]
+    value: str | bytes | Dict[str, Any]
     ttl: datetime
 
 
@@ -211,7 +212,7 @@ class BaseProvider(ABC):
     def clear_cache(self):
         self.store.clear()
 
-    def _add_to_cache(self, key: Tuple[str, TransformOptions], value: Any, max_age: int):
+    def add_to_cache(self, key: Tuple[str, TransformOptions], value: Any, max_age: int):
         self.store[key] = ExpirableValue(value, datetime.now() + timedelta(seconds=max_age))
 
     @staticmethod

--- a/aws_lambda_powertools/utilities/parameters/base.py
+++ b/aws_lambda_powertools/utilities/parameters/base.py
@@ -213,6 +213,9 @@ class BaseProvider(ABC):
         self.store.clear()
 
     def add_to_cache(self, key: Tuple[str, TransformOptions], value: Any, max_age: int):
+        if max_age <= 0:
+            return
+
         self.store[key] = ExpirableValue(value, datetime.now() + timedelta(seconds=max_age))
 
     @staticmethod

--- a/aws_lambda_powertools/utilities/parameters/base.py
+++ b/aws_lambda_powertools/utilities/parameters/base.py
@@ -71,7 +71,7 @@ class BaseProvider(ABC):
 
         self.store: Dict[Tuple[str, TransformOptions], ExpirableValue] = {}
 
-    def _has_not_expired(self, key: Tuple[str, TransformOptions]) -> bool:
+    def has_not_expired_in_cache(self, key: Tuple[str, TransformOptions]) -> bool:
         return key in self.store and self.store[key].ttl >= datetime.now()
 
     def get(
@@ -121,7 +121,7 @@ class BaseProvider(ABC):
         value: Optional[Union[str, bytes, dict]] = None
         key = (name, transform)
 
-        if not force_fetch and self._has_not_expired(key):
+        if not force_fetch and self.has_not_expired_in_cache(key):
             return self.store[key].value
 
         try:
@@ -186,7 +186,7 @@ class BaseProvider(ABC):
         """
         key = (path, transform)
 
-        if not force_fetch and self._has_not_expired(key):
+        if not force_fetch and self.has_not_expired_in_cache(key):
             return self.store[key].value  # type: ignore # need to revisit entire typing here
 
         try:

--- a/aws_lambda_powertools/utilities/parameters/ssm.py
+++ b/aws_lambda_powertools/utilities/parameters/ssm.py
@@ -407,9 +407,7 @@ class SSMProvider(BaseProvider):
 
             # NOTE: If transform is set, we do it before caching to reduce number of operations
             if transform:
-                value = transform_value(
-                    key=name, value=value, transform=transform, raise_on_transform_error=raise_on_error
-                )  # type: ignore[assignment] # transform dynamism challenge
+                value = transform_value(name, value, transform, raise_on_error)  # type: ignore[assignment]
 
             _cache_key = (name, options["transform"])
             self.add_to_cache(key=_cache_key, value=value, max_age=options["max_age"])

--- a/aws_lambda_powertools/utilities/parameters/ssm.py
+++ b/aws_lambda_powertools/utilities/parameters/ssm.py
@@ -398,17 +398,18 @@ class SSMProvider(BaseProvider):
         self, api_response: GetParametersResultTypeDef, parameters: Dict[str, Any], raise_on_error: bool = True
     ) -> Dict[str, Any]:
         response: Dict[str, Any] = {}
+
         for parameter in api_response["Parameters"]:
             name = parameter["Name"]
             value = parameter["Value"]
             options = parameters[name]
-            transform = options.get("transform", "")
+            transform = options.get("transform")
 
             # NOTE: If transform is set, we do it before caching to reduce number of operations
             if transform:
                 value = transform_value(
                     key=name, value=value, transform=transform, raise_on_transform_error=raise_on_error
-                )
+                )  # type: ignore[assignment] # transform dynamism challenge
 
             _cache_key = (name, options["transform"])
             self.add_to_cache(key=_cache_key, value=value, max_age=options["max_age"])

--- a/aws_lambda_powertools/utilities/parameters/ssm.py
+++ b/aws_lambda_powertools/utilities/parameters/ssm.py
@@ -407,7 +407,7 @@ class SSMProvider(BaseProvider):
 
             # NOTE: If transform is set, we do it before caching to reduce number of operations
             if transform:
-                value = transform_value(name, value, transform, raise_on_error)  # type: ignore[assignment]
+                value = transform_value(name, value, transform, raise_on_error)  # type: ignore
 
             _cache_key = (name, options["transform"])
             self.add_to_cache(key=_cache_key, value=value, max_age=options["max_age"])

--- a/aws_lambda_powertools/utilities/parameters/ssm.py
+++ b/aws_lambda_powertools/utilities/parameters/ssm.py
@@ -403,7 +403,7 @@ def get_parameters_by_name(
     decrypt: bool = False,
     force_fetch: bool = False,
     max_age: int = DEFAULT_MAX_AGE_SECS,
-    parallel: bool = True,
+    parallel: bool = False,
 ) -> Union[Dict[str, str], Dict[str, bytes], Dict[str, dict]]:
     """
     Retrieve multiple parameter values by name from AWS Systems Manager (SSM) Parameter Store
@@ -432,10 +432,8 @@ def get_parameters_by_name(
         When the parameter provider fails to transform a parameter value.
     """
 
-    # NOTE: Need a param for hard failure mode on parameter retrieval
-    # by default, we should return an empty string on failure (ask customer for desired behaviour)
-
-    # NOTE: Decide whether to leave multi-threaded option or not due to slower results (throttling+fork cost)
+    # NOTE: Need a param for hard failure mode on parameter retrieval (asked feature request author)
+    # NOTE: Decide whether to leave multi-threaded option or not due to slower results (throttling+LWP cost)
 
     ret: Dict[str, Any] = {}
     future_to_param: Dict[Future, str] = {}

--- a/aws_lambda_powertools/utilities/parameters/ssm.py
+++ b/aws_lambda_powertools/utilities/parameters/ssm.py
@@ -356,8 +356,13 @@ class SSMProvider(BaseProvider):
             # NOTE: TypeDict later
             _overrides = options or {}
             _overrides["transform"] = _overrides.get("transform") or transform
-            _overrides["decrypt"] = _overrides.get("decrypt") or decrypt
-            _overrides["max_age"] = _overrides.get("max_age") or max_age
+
+            # These values can be falsy (False, 0)
+            if "decrypt" not in _overrides:
+                _overrides["decrypt"] = decrypt
+
+            if "max_age" not in _overrides:
+                _overrides["max_age"] = max_age
 
             # NOTE: Split parameters who have decrypt OR have it global
             if _overrides["decrypt"]:

--- a/aws_lambda_powertools/utilities/parameters/ssm.py
+++ b/aws_lambda_powertools/utilities/parameters/ssm.py
@@ -103,7 +103,7 @@ class SSMProvider(BaseProvider):
         self,
         name: str,
         max_age: int = DEFAULT_MAX_AGE_SECS,
-        transform: Optional[str] = None,
+        transform: TransformOptions = None,
         decrypt: bool = False,
         force_fetch: bool = False,
         **sdk_options,

--- a/aws_lambda_powertools/utilities/parameters/ssm.py
+++ b/aws_lambda_powertools/utilities/parameters/ssm.py
@@ -269,7 +269,7 @@ class SSMProvider(BaseProvider):
         # Check if it's in cache to prevent unnecessary calls
         for name, options in batch.items():
             cache_key = (name, options["transform"])
-            if self._has_not_expired(cache_key):
+            if self.has_not_expired_in_cache(cache_key):
                 ret[name] = self.store[cache_key].value
 
         # Return early if all parameters were in cache OR batch was empty

--- a/aws_lambda_powertools/utilities/parameters/ssm.py
+++ b/aws_lambda_powertools/utilities/parameters/ssm.py
@@ -270,6 +270,7 @@ class SSMProvider(BaseProvider):
             if self._has_not_expired(cache_key):
                 ret[name] = self.store[cache_key].value
 
+        # Return early if all parameters were in cache OR batch was empty
         if len(ret) == len(batch):
             return ret
 
@@ -321,7 +322,7 @@ class SSMProvider(BaseProvider):
                 )
 
             _cache_key = (name, options["transform"])
-            self._add_to_cache(key=_cache_key, value=value, max_age=options["max_age"])
+            self.add_to_cache(key=_cache_key, value=value, max_age=options["max_age"])
 
             ret[name] = value
 

--- a/aws_lambda_powertools/utilities/parameters/ssm.py
+++ b/aws_lambda_powertools/utilities/parameters/ssm.py
@@ -239,6 +239,10 @@ class SSMProvider(BaseProvider):
         """
         response: Dict[str, Any] = {}
 
+        # NOTE: We fail early to avoid unintended graceful errors being replaced with their param values
+        if "_errors" in parameters and not raise_on_error:
+            raise GetParameterError("You cannot fetch a parameter named '_errors' in graceful error mode.")
+
         batch_params, decrypt_params = self._split_batch_and_decrypt_parameters(parameters, transform, max_age, decrypt)
         decrypt_ret, decrypt_err = self._get_parameters_by_name_with_decrypt_option(decrypt_params, raise_on_error)
         batch_ret, batch_err = self._get_parameters_by_name_batch(batch_params, raise_on_error)

--- a/aws_lambda_powertools/utilities/parameters/types.py
+++ b/aws_lambda_powertools/utilities/parameters/types.py
@@ -1,0 +1,3 @@
+from typing_extensions import Literal
+
+TransformOptions = Literal["json", "binary", "auto", None]

--- a/docs/utilities/parameters.md
+++ b/docs/utilities/parameters.md
@@ -24,15 +24,16 @@ This utility requires additional permissions to work as expected.
 ???+ note
     Different parameter providers require different permissions.
 
-| Provider            | Function/Method                                      | IAM Permission                                                               |
-| ------------------- | ---------------------------------------------------- | ---------------------------------------------------------------------------- |
-| SSM Parameter Store | `get_parameter`, `SSMProvider.get`                   | `ssm:GetParameter`                                                           |
-| SSM Parameter Store | `get_parameters`, `SSMProvider.get_multiple`         | `ssm:GetParametersByPath`                                                    |
-| SSM Parameter Store | If using `decrypt=True`                              | You must add an additional permission `kms:Decrypt`                          |
-| Secrets Manager     | `get_secret`, `SecretsManager.get`                   | `secretsmanager:GetSecretValue`                                              |
-| DynamoDB            | `DynamoDBProvider.get`                               | `dynamodb:GetItem`                                                           |
-| DynamoDB            | `DynamoDBProvider.get_multiple`                      | `dynamodb:Query`                                                             |
-| App Config          | `get_app_config`, `AppConfigProvider.get_app_config` | `appconfig:GetLatestConfiguration` and `appconfig:StartConfigurationSession` |
+| Provider  | Function/Method                                                        | IAM Permission                                                                       |
+| --------- | ---------------------------------------------------------------------- | ------------------------------------------------------------------------------------ |
+| SSM       | **`get_parameter`**, **`SSMProvider.get`**                             | **`ssm:GetParameter`**                                                               |
+| SSM       | **`get_parameters`**, **`SSMProvider.get_multiple`**                   | **`ssm:GetParametersByPath`**                                                        |
+| SSM       | **`get_parameters_by_name`**, **`SSMProvider.get_parameters_by_name`** | **`ssm:GetParameter`** and **`ssm:GetParameters`**                                   |
+| SSM       | If using **`decrypt=True`**                                            | You must add an additional permission **`kms:Decrypt`**                              |
+| Secrets   | **`get_secret`**, **`SecretsManager.get`**                             | **`secretsmanager:GetSecretValue`**                                                  |
+| DynamoDB  | **`DynamoDBProvider.get`**                                             | **`dynamodb:GetItem`**                                                               |
+| DynamoDB  | **`DynamoDBProvider.get_multiple`**                                    | **`dynamodb:Query`**                                                                 |
+| AppConfig | **`get_app_config`**, **`AppConfigProvider.get_app_config`**           | **`appconfig:GetLatestConfiguration`** and **`appconfig:StartConfigurationSession`** |
 
 ### Fetching parameters
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -1511,7 +1511,7 @@ validation = ["fastjsonschema"]
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.7.4"
-content-hash = "48a6c11b4ef71716e88efa7ffa474aa73fd7fcb02553ffd49c0d03fe72c1f838"
+content-hash = "e5d33eff22737a00153da107e050d151e6405684d8c4c71f6b8c618152731eb7"
 
 [metadata.files]
 attrs = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ aws-xray-sdk = { version = "^2.8.0", optional = true }
 fastjsonschema = { version = "^2.14.5", optional = true }
 pydantic = { version = "^1.8.2", optional = true }
 boto3 = { version = "^1.20.32", optional = true }
+typing-extensions = "^4.4.0"
 
 [tool.poetry.dev-dependencies]
 coverage = {extras = ["toml"], version = "^6.2"}

--- a/tests/e2e/parameters/handlers/parameter_ssm_get_parameters_by_name.py
+++ b/tests/e2e/parameters/handlers/parameter_ssm_get_parameters_by_name.py
@@ -1,0 +1,15 @@
+import json
+import os
+from typing import Any, Dict, List, cast
+
+from aws_lambda_powertools.utilities.parameters.ssm import get_parameters_by_name
+from aws_lambda_powertools.utilities.typing import LambdaContext
+
+parameters_list: List[str] = cast(List, json.loads(os.getenv("parameters", "")))
+
+
+def lambda_handler(event: dict, context: LambdaContext) -> Dict[str, Any]:
+    parameters_to_fetch: Dict[str, Any] = {param: {} for param in parameters_list}
+
+    # response`{parameter:value}`
+    return get_parameters_by_name(parameters=parameters_to_fetch, max_age=0, parallel=True)

--- a/tests/e2e/parameters/handlers/parameter_ssm_get_parameters_by_name.py
+++ b/tests/e2e/parameters/handlers/parameter_ssm_get_parameters_by_name.py
@@ -12,4 +12,4 @@ def lambda_handler(event: dict, context: LambdaContext) -> Dict[str, Any]:
     parameters_to_fetch: Dict[str, Any] = {param: {} for param in parameters_list}
 
     # response`{parameter:value}`
-    return get_parameters_by_name(parameters=parameters_to_fetch, max_age=0, parallel=True)
+    return get_parameters_by_name(parameters=parameters_to_fetch, max_age=0)

--- a/tests/e2e/parameters/test_ssm.py
+++ b/tests/e2e/parameters/test_ssm.py
@@ -1,0 +1,33 @@
+import json
+from typing import Any, Dict, List
+
+import pytest
+
+from tests.e2e.utils import data_fetcher
+
+
+@pytest.fixture
+def ssm_get_parameters_by_name_fn_arn(infrastructure: dict) -> str:
+    return infrastructure.get("ParameterSsmGetParametersByNameArn", "")
+
+
+@pytest.fixture
+def parameters_list(infrastructure: dict) -> List[str]:
+    param_list = infrastructure.get("ParametersNameList", "[]")
+    return json.loads(param_list)
+
+
+def test_get_parameter_appconfig_freeform(
+    ssm_get_parameters_by_name_fn_arn: str,
+    parameters_list: str,
+):
+    # GIVEN/WHEN
+    function_response, _ = data_fetcher.get_lambda_response(lambda_arn=ssm_get_parameters_by_name_fn_arn)
+    parameter_values: Dict[str, Any] = json.loads(function_response["Payload"].read().decode("utf-8"))
+
+    # THEN
+    for param in parameters_list:
+        try:
+            assert parameter_values[param] is not None
+        except (KeyError, TypeError):
+            pytest.fail(f"Parameter {param} not found in response")

--- a/tests/e2e/parameters/test_ssm.py
+++ b/tests/e2e/parameters/test_ssm.py
@@ -17,7 +17,8 @@ def parameters_list(infrastructure: dict) -> List[str]:
     return json.loads(param_list)
 
 
-def test_get_parameter_appconfig_freeform(
+#
+def test_get_parameters_by_name(
     ssm_get_parameters_by_name_fn_arn: str,
     parameters_list: str,
 ):

--- a/tests/functional/test_utilities_parameters.py
+++ b/tests/functional/test_utilities_parameters.py
@@ -2328,3 +2328,18 @@ def test_base_provider_get_force_update(mock_name, mock_value):
 
     assert isinstance(value, str)
     assert value == mock_value
+
+
+def test_cache_ignores_max_age_zero_or_negative(mock_value):
+    # GIVEN we have two parameters that shouldn't be cached
+    param = "/no_cache"
+    provider = SSMProvider()
+    cache_key = (param, None)
+
+    # WHEN a provider adds them into the cache
+    provider.add_to_cache(key=cache_key, value=mock_value, max_age=0)
+    provider.add_to_cache(key=cache_key, value=mock_value, max_age=-10)
+
+    # THEN they should not be added to the cache
+    assert len(provider.store) == 0
+    assert provider.has_not_expired_in_cache(cache_key) is False

--- a/tests/functional/test_utilities_parameters.py
+++ b/tests/functional/test_utilities_parameters.py
@@ -644,7 +644,7 @@ def test_ssm_provider_clear_cache(mock_name, mock_value, config):
     assert provider.store == {}
 
 
-def test_ssm_provider_get_parameters_by_name_raise_on_failure(mock_name, mock_value, mock_version, config):
+def test_ssm_provider_get_parameters_by_name_raise_on_failure(mock_name, mock_value, config):
     # GIVEN two parameters are requested
     provider = parameters.SSMProvider(config=config)
     success = f"/dev/{mock_name}"
@@ -671,7 +671,7 @@ def test_ssm_provider_get_parameters_by_name_raise_on_failure(mock_name, mock_va
             stubber.deactivate()
 
 
-def test_ssm_provider_get_parameters_by_name_do_not_raise_on_failure(mock_name, mock_value, mock_version, config):
+def test_ssm_provider_get_parameters_by_name_do_not_raise_on_failure(mock_name, mock_value, config):
     # GIVEN two parameters are requested
     success = f"/dev/{mock_name}"
     fail = f"/prod/{mock_name}"
@@ -701,7 +701,7 @@ def test_ssm_provider_get_parameters_by_name_do_not_raise_on_failure(mock_name, 
         stubber.deactivate()
 
 
-def test_ssm_provider_get_parameters_by_name_do_not_raise_on_failure_with_decrypt(mock_name, mock_version, config):
+def test_ssm_provider_get_parameters_by_name_do_not_raise_on_failure_with_decrypt(mock_name, config):
     # GIVEN one parameter requires decryption and an arbitrary SDK error occurs
     param = f"/{mock_name}"
     params = {param: {"decrypt": True}}
@@ -762,6 +762,20 @@ def test_ssm_provider_get_parameters_by_name_do_not_raise_on_failure_batch_decry
         assert decrypt_fail not in ret
     finally:
         stubber.deactivate()
+
+
+def test_ssm_provider_get_parameters_by_name_raise_on_reserved_errors_key(mock_name, mock_value, config):
+    # GIVEN one of the parameters is named `_errors`
+    success = f"/dev/{mock_name}"
+    fail = "_errors"
+
+    params = {success: {}, fail: {}}
+    provider = parameters.SSMProvider(config=config)
+
+    # WHEN using get_parameters_by_name to fetch
+    # THEN raise GetParameterError
+    with pytest.raises(parameters.exceptions.GetParameterError, match="You cannot fetch a parameter named"):
+        provider.get_parameters_by_name(parameters=params, raise_on_error=False)
 
 
 def test_dynamodb_provider_clear_cache(mock_name, mock_value, config):

--- a/tests/functional/test_utilities_parameters.py
+++ b/tests/functional/test_utilities_parameters.py
@@ -59,7 +59,7 @@ def build_get_parameters_stub(params: Dict[str, Any], invalid_parameters: List[s
                 "Selector": f"{param}:{version}",
                 "SourceResult": "string",
                 "LastModifiedDate": datetime(2015, 1, 1),
-                "ARN": f"arn:aws:ssm:us-east-2:111122223333:parameter/{param.removeprefix('/')}",
+                "ARN": f"arn:aws:ssm:us-east-2:111122223333:parameter/{param.lstrip('/')}",
                 "DataType": "string",
             }
             for param, value in params.items()

--- a/tests/functional/test_utilities_parameters.py
+++ b/tests/functional/test_utilities_parameters.py
@@ -14,7 +14,11 @@ from botocore.config import Config
 from botocore.response import StreamingBody
 
 from aws_lambda_powertools.utilities import parameters
-from aws_lambda_powertools.utilities.parameters.base import BaseProvider, ExpirableValue
+from aws_lambda_powertools.utilities.parameters.base import (
+    TRANSFORM_METHOD_MAPPING,
+    BaseProvider,
+    ExpirableValue,
+)
 
 
 @pytest.fixture(scope="function")
@@ -1863,17 +1867,6 @@ def test_transform_value_binary_exception():
     assert "Incorrect padding" in str(excinfo)
 
 
-def test_transform_value_wrong(mock_value):
-    """
-    Test transform_value() with an incorrect transform
-    """
-
-    with pytest.raises(parameters.TransformParameterError) as excinfo:
-        parameters.base.transform_value(mock_value, "INCORRECT")
-
-    assert "Invalid transform type" in str(excinfo)
-
-
 def test_transform_value_ignore_error(mock_value):
     """
     Test transform_value() does not raise errors when raise_on_transform_error is False
@@ -1884,16 +1877,6 @@ def test_transform_value_ignore_error(mock_value):
     assert value is None
 
 
-@pytest.mark.parametrize("original_transform", ["json", "binary", "other", "Auto", None])
-def test_get_transform_method_preserve_original(original_transform):
-    """
-    Check if original transform method is returned for anything other than "auto"
-    """
-    transform = parameters.base.get_transform_method("key", original_transform)
-
-    assert transform == original_transform
-
-
 @pytest.mark.parametrize("extension", ["json", "binary"])
 def test_get_transform_method_preserve_auto(extension, mock_name):
     """
@@ -1901,18 +1884,7 @@ def test_get_transform_method_preserve_auto(extension, mock_name):
     """
     transform = parameters.base.get_transform_method(f"{mock_name}.{extension}", "auto")
 
-    assert transform == extension
-
-
-@pytest.mark.parametrize("key", ["json", "binary", "example", "example.jsonp"])
-def test_get_transform_method_preserve_auto_unhandled(key):
-    """
-    Check if any key that does not end with a supported extension returns None when
-    using the transform="auto"
-    """
-    transform = parameters.base.get_transform_method(key, "auto")
-
-    assert transform is None
+    assert transform == TRANSFORM_METHOD_MAPPING[extension]
 
 
 def test_base_provider_get_multiple_force_update(mock_name, mock_value):

--- a/tests/functional/test_utilities_parameters.py
+++ b/tests/functional/test_utilities_parameters.py
@@ -2347,10 +2347,10 @@ def test_base_provider_get_force_update(mock_name, mock_value):
     assert value == mock_value
 
 
-def test_cache_ignores_max_age_zero_or_negative(mock_value):
+def test_cache_ignores_max_age_zero_or_negative(mock_value, config):
     # GIVEN we have two parameters that shouldn't be cached
     param = "/no_cache"
-    provider = SSMProvider()
+    provider = SSMProvider(config=config)
     cache_key = (param, None)
 
     # WHEN a provider adds them into the cache

--- a/tests/functional/test_utilities_parameters.py
+++ b/tests/functional/test_utilities_parameters.py
@@ -1814,6 +1814,50 @@ def test_appconf_get_app_config_new(monkeypatch, mock_name, mock_value):
     assert value == mock_value
 
 
+def test_transform_value_auto(mock_value: str):
+    # GIVEN
+    json_data = json.dumps({"A": mock_value})
+    mock_binary = mock_value.encode()
+    binary_data = base64.b64encode(mock_binary).decode()
+
+    # WHEN
+    json_value = parameters.base.transform_value(key="/a.json", value=json_data, transform="auto")
+    binary_value = parameters.base.transform_value(key="/a.binary", value=binary_data, transform="auto")
+
+    # THEN
+    assert isinstance(json_value, dict)
+    assert isinstance(binary_value, bytes)
+    assert json_value["A"] == mock_value
+    assert binary_value == mock_binary
+
+
+def test_transform_value_auto_incorrect_key(mock_value: str):
+    # GIVEN
+    mock_key = "/missing/json/suffix"
+    json_data = json.dumps({"A": mock_value})
+
+    # WHEN
+    value = parameters.base.transform_value(key=mock_key, value=json_data, transform="auto")
+
+    # THEN it should echo back its value
+    assert isinstance(value, str)
+    assert value == json_data
+
+
+def test_transform_value_auto_unsupported_transform(mock_value: str):
+    # GIVEN
+    mock_key = "/a.does_not_exist"
+    mock_dict = {"hello": "world"}
+
+    # WHEN
+    value = parameters.base.transform_value(key=mock_key, value=mock_value, transform="auto")
+    dict_value = parameters.base.transform_value(key=mock_key, value=mock_dict, transform="auto")
+
+    # THEN it should echo back its value
+    assert value == mock_value
+    assert dict_value == mock_dict
+
+
 def test_transform_value_json(mock_value):
     """
     Test transform_value() with a json transform


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
**Issue number:** #1040

## Summary

Today, customers can fetch multiple SSM parameters recursively by using a `path`. This happens server-side.

As described in the issue, customers may need to fetch multiple parameters in distinct paths. As of now, this requires additional boilerplate to get it done properly.

### Changes

> Please provide a summary of what's being changed

This PR introduces `get_parameter_by_name` high-level function that accepts a dictionary containing:

* A parameter to fetch
* A dict optionally containing overrides for a parameter (e.g., `max_age`, `transform`, `decrypt`, etc.)

#### Non-related but necessary changes

* Adds `typing-extensions` as a dependency to provide strict typing for this feature. Depending on the `transform` value, the return type is precise.
* Refactored `transform_method` and `transform_value` to better support strict typing and related bugs
* Created `add_to_cache` method to support refactoring and handle `max_age=0, max_age=-1` scenarios we didn't cover before
* Exposed `has_not_expired_in_cache` method to ease testing


### User experience

> Please share what the user experience looks like before and after this change

```python
from typing import Any

from aws_lambda_powertools.utilities import get_parameters_by_name

parameters = {
  "/develop/service/commons/telemetry/config": {"max_age": 300, "transform": "json"},
  "/no_cache_param": {"max_age": 0},
  # inherit default values
  "/develop/service/payment/api/capture/url": {},
}

def handler(event, context):
    # This returns a dict with the parameter name as key
    response: dict[str, Any] = parameters.get_parameters_by_name(parameters=parameters, max_age=60)
    for parameter, value in response.items():
        print(f"{parameter}: {value}")
```

**Overrides fail-fast to support graceful error handling**

```python
from typing import Any

from aws_lambda_powertools.utilities import get_parameters_by_name

parameters = {
  "/develop/service/commons/telemetry/config": {"max_age": 300, "transform": "json"},
  # it would fail by default
  "/this/param/does/not/exist"
}

def handler(event, context):
    values: dict[str, Any] = parameters.get_parameters_by_name(parameters=parameters, raise_on_error=False)
    errors: list[str] = values.get("_errors", [])

    # Handle gracefully, since '/this/param/does/not/exist' will only be available in `_errors`
    if errors:
        ...

    for parameter, value in values.items():
        print(f"{parameter}: {value}")
```


## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] [Meet tenets criteria](https://awslabs.github.io/aws-lambda-powertools-python/#tenets)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented
* [x] PR title follows [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-python/blob/develop/.github/semantic.yml)
* [x] Test whether threads can be faster or not (Nope due to CPU slicing in Lambda + LWP)
* [x] Test whether async can be faster or not (Nope due to event loop setup + aioboto need)
* [x] Use `GetParameters` as default. Use `GetParameter` when `decrypt` is set on a per parameter
* [x] Functional test for options override
* [x] Functional test for partial failure

<details>
<summary>Is this a breaking change?</summary>

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
