### PR TITLE
feat(apigateway): multiple exceptions in exception_handler

### DIFF
--- a/aws_lambda_powertools/event_handler/api_gateway.py
+++ b/aws_lambda_powertools/event_handler/api_gateway.py
@@ -689,7 +689,7 @@ class ApiGatewayResolver(BaseRouter):
             return self.exception_handler(NotFoundError)
         return self.exception_handler(NotFoundError)(func)
 
-    def exception_handler(self, exc_class: Union[Type[Exception], List[Exception]]):
+    def exception_handler(self, exc_class: Union[Type[Exception], List[Type[Exception]]]):
         def register_exception_handler(func: Callable):
             if isinstance(exc_class, list):
                 for exp in exc_class:

--- a/aws_lambda_powertools/event_handler/api_gateway.py
+++ b/aws_lambda_powertools/event_handler/api_gateway.py
@@ -689,9 +689,14 @@ class ApiGatewayResolver(BaseRouter):
             return self.exception_handler(NotFoundError)
         return self.exception_handler(NotFoundError)(func)
 
-    def exception_handler(self, exc_class: Type[Exception]):
+    def exception_handler(self, exc_class: Union[Type[Exception], List[Exception]]):
         def register_exception_handler(func: Callable):
-            self._exception_handlers[exc_class] = func
+            if isinstance(exc_class, list):
+                for exp in exc_class:
+                    self._exception_handlers[exp] = func
+            else:
+                self._exception_handlers[exc_class] = func
+            return func
 
         return register_exception_handler
 

--- a/docs/core/event_handler/api_gateway.md
+++ b/docs/core/event_handler/api_gateway.md
@@ -226,6 +226,9 @@ You can use **`exception_handler`** decorator with any Python exception. This al
 --8<-- "examples/event_handler_rest/src/exception_handling.py"
 ```
 
+???+ info
+    The `exception_handler` also supports passing a list of exception types you wish to handle with one handler.
+
 ### Raising HTTP errors
 
 You can easily raise any HTTP Error back to the client using `ServiceError` exception. This ensures your Lambda function doesn't fail but return the correct HTTP response signalling the error.


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
**Issue number:** #1706

## Summary

### Changes

Adds support for handling multiple exceptions with one handler

### User experience

Previously only the first exception decorator would work. Others would result in Internal Server Error response and a lambda error. With this change users can specify multiple errors in one decorator, or stack decorators on one function

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] [Meet tenets criteria](https://awslabs.github.io/aws-lambda-powertools-python/#tenets)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented
* [x] PR title follows [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-python/blob/develop/.github/semantic.yml)

<details>
<summary>Is this a breaking change?</summary>

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
