### PR TITLE
fix(apigateway): support nested router decorators

### DIFF
--- a/aws_lambda_powertools/event_handler/api_gateway.py
+++ b/aws_lambda_powertools/event_handler/api_gateway.py
@@ -793,6 +793,7 @@ class Router(BaseRouter):
             # Convert methods to tuple. It needs to be hashable as its part of the self._routes dict key
             methods = (method,) if isinstance(method, str) else tuple(method)
             self._routes[(rule, methods, cors, compress, cache_control)] = func
+            return func
 
         return register_route
 

--- a/tests/events/apiGatewayProxyEventAnotherPath.json
+++ b/tests/events/apiGatewayProxyEventAnotherPath.json
@@ -1,0 +1,80 @@
+{
+  "version": "1.0",
+  "resource": "/my/anotherPath",
+  "path": "/my/anotherPath",
+  "httpMethod": "GET",
+  "headers": {
+    "Header1": "value1",
+    "Header2": "value2"
+  },
+  "multiValueHeaders": {
+    "Header1": [
+      "value1"
+    ],
+    "Header2": [
+      "value1",
+      "value2"
+    ]
+  },
+  "queryStringParameters": {
+    "parameter1": "value1",
+    "parameter2": "value"
+  },
+  "multiValueQueryStringParameters": {
+    "parameter1": [
+      "value1",
+      "value2"
+    ],
+    "parameter2": [
+      "value"
+    ]
+  },
+  "requestContext": {
+    "accountId": "123456789012",
+    "apiId": "id",
+    "authorizer": {
+      "claims": null,
+      "scopes": null
+    },
+    "domainName": "id.execute-api.us-east-1.amazonaws.com",
+    "domainPrefix": "id",
+    "extendedRequestId": "request-id",
+    "httpMethod": "GET",
+    "identity": {
+      "accessKey": null,
+      "accountId": null,
+      "caller": null,
+      "cognitoAuthenticationProvider": null,
+      "cognitoAuthenticationType": null,
+      "cognitoIdentityId": null,
+      "cognitoIdentityPoolId": null,
+      "principalOrgId": null,
+      "sourceIp": "192.168.0.1/32",
+      "user": null,
+      "userAgent": "user-agent",
+      "userArn": null,
+      "clientCert": {
+        "clientCertPem": "CERT_CONTENT",
+        "subjectDN": "www.example.com",
+        "issuerDN": "Example issuer",
+        "serialNumber": "a1:a1:a1:a1:a1:a1:a1:a1:a1:a1:a1:a1:a1:a1:a1:a1",
+        "validity": {
+          "notBefore": "May 28 12:30:02 2019 GMT",
+          "notAfter": "Aug  5 09:36:04 2021 GMT"
+        }
+      }
+    },
+    "path": "/my/anotherPath",
+    "protocol": "HTTP/1.1",
+    "requestId": "id=",
+    "requestTime": "04/Mar/2020:19:15:17 +0000",
+    "requestTimeEpoch": 1583349317135,
+    "resourceId": null,
+    "resourcePath": "/my/anotherPath",
+    "stage": "$default"
+  },
+  "pathParameters": null,
+  "stageVariables": null,
+  "body": "Hello from Lambda!",
+  "isBase64Encoded": true
+}

--- a/tests/functional/event_handler/test_api_gateway.py
+++ b/tests/functional/event_handler/test_api_gateway.py
@@ -1480,6 +1480,7 @@ def test_include_router_merges_context():
 
 def test_nested_app_decorator():
     # GIVEN a Http API V1 proxy type event
+    # with a function registered with two distinct routes
     app = APIGatewayRestResolver()
 
     @app.get("/my/path")
@@ -1499,6 +1500,7 @@ def test_nested_app_decorator():
 
 def test_nested_router_decorator():
     # GIVEN a Http API V1 proxy type event
+    # with a function registered with two distinct routes
     app = APIGatewayRestResolver()
     router = Router()
 
@@ -1509,7 +1511,6 @@ def test_nested_router_decorator():
 
     app.include_router(router)
 
-    # WHEN calling the event handler
     # WHEN calling the event handler
     result = app(LOAD_GW_EVENT, {})
     result2 = app(load_event("apiGatewayProxyEventAnotherPath.json"), {})


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
**Issue number:**  #1712

## Summary

### Changes

> Please provide a summary of what's being changed

This PR fixes a bug router decorator cannot be nested.

### User experience

> Please share what the user experience looks like before and after this change

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] [Meet tenets criteria](https://awslabs.github.io/aws-lambda-powertools-python/#tenets)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented
* [x] PR title follows [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-python/blob/develop/.github/semantic.yml)

<details>
<summary>Is this a breaking change?</summary>

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
