### PR TITLE
fix(parameters): get_secret correctly return SecretBinary value

### DIFF
--- a/aws_lambda_powertools/utilities/parameters/secrets.py
+++ b/aws_lambda_powertools/utilities/parameters/secrets.py
@@ -96,7 +96,12 @@ class SecretsProvider(BaseProvider):
         # Explicit arguments will take precedence over keyword arguments
         sdk_options["SecretId"] = name
 
-        return self.client.get_secret_value(**sdk_options)["SecretString"]
+        secret_value = self.client.get_secret_value(**sdk_options)
+
+        if "SecretString" in secret_value:
+            return secret_value["SecretString"]
+        else:
+            return secret_value["SecretBinary"]
 
     def _get_multiple(self, path: str, **sdk_options) -> Dict[str, str]:
         """

--- a/aws_lambda_powertools/utilities/parameters/secrets.py
+++ b/aws_lambda_powertools/utilities/parameters/secrets.py
@@ -100,8 +100,8 @@ class SecretsProvider(BaseProvider):
 
         if "SecretString" in secret_value:
             return secret_value["SecretString"]
-        else:
-            return secret_value["SecretBinary"]
+
+        return secret_value["SecretBinary"]
 
     def _get_multiple(self, path: str, **sdk_options) -> Dict[str, str]:
         """


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
**Issue number:** #1713

## Summary

### Changes

`parameters.get_secret` can now fetch Binary Secrets.

### User experience

Before this patch, calling `parameters.get_secret` to get a Binary Secret will throw a `GetParameterError` since it would only try to retrieve the `SecretString` value from the secret value. Ref: #1713 

Now, `get_secret` will correctly fetch Binary Secrets.

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] [Meet tenets criteria](https://awslabs.github.io/aws-lambda-powertools-python/#tenets)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented
* [x] PR title follows [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-python/blob/develop/.github/semantic.yml)

<details>
<summary>Is this a breaking change?</summary>

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
