### PR TITLE
feat(parser): extract CloudWatch Logs in Kinesis streams

### DIFF
--- a/aws_lambda_powertools/utilities/parser/models/kinesis.py
+++ b/aws_lambda_powertools/utilities/parser/models/kinesis.py
@@ -1,8 +1,13 @@
-from typing import List, Type, Union
+import json
+import zlib
+from typing import Dict, List, Type, Union
 
 from pydantic import BaseModel, validator
 
 from aws_lambda_powertools.shared.functions import base64_decode
+from aws_lambda_powertools.utilities.parser.models.cloudwatch import (
+    CloudWatchLogsDecode,
+)
 from aws_lambda_powertools.utilities.parser.types import Literal
 
 
@@ -28,6 +33,21 @@ class KinesisDataStreamRecord(BaseModel):
     eventSourceARN: str
     kinesis: KinesisDataStreamRecordPayload
 
+    def decompress_zlib_record_data_as_json(self) -> Dict:
+        """Decompress Kinesis Record bytes data zlib compressed to JSON"""
+        if not isinstance(self.kinesis.data, bytes):
+            raise ValueError("We can only decompress bytes data, not custom models.")
+
+        return json.loads(zlib.decompress(self.kinesis.data, zlib.MAX_WBITS | 32))
+
 
 class KinesisDataStreamModel(BaseModel):
     Records: List[KinesisDataStreamRecord]
+
+
+def extract_cloudwatch_logs_from_event(event: KinesisDataStreamModel) -> List[CloudWatchLogsDecode]:
+    return [CloudWatchLogsDecode(**record.decompress_zlib_record_data_as_json()) for record in event.Records]
+
+
+def extract_cloudwatch_logs_from_record(record: KinesisDataStreamRecord) -> CloudWatchLogsDecode:
+    return CloudWatchLogsDecode(**record.decompress_zlib_record_data_as_json())


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
**Issue number:** #1725

## Summary

### Changes

> Please provide a summary of what's being changed

This PR introduces two functions to decode, decompress, and extract `CloudWatchLogsDecode` from Kinesis Data Streams.

* **extract_cloudwatch_logs_from_event**. Returns a list of `CloudWatchLogsDecode` from `KinesisDataStreamModel`. Useful for simple processing.
* **extract_cloudwatch_logs_from_record**. Returns `CloudWatchLogsDecode` from `KinesisDataStreamRecord`. Useful for robust batch processing and seamless integration with [Batch Processing](https://awslabs.github.io/aws-lambda-powertools-python/latest/utilities/batch/)

### User experience

> Please share what the user experience looks like before and after this change

**Simple processing**

```python

from aws_lambda_powertools.utilities.parser.models.cloudwatch import CloudWatchLogsDecode
from aws_lambda_powertools.utilities.parser.models import KinesisDataStreamModel
from aws_lambda_powertools.utilities.parser.models.kinesis import extract_cloudwatch_logs_from_record
from aws_lambda_powertools.utilities.typing import LambdaContext


@event_parser(model=KinesisDataStreamModel)
def lambda_handler(event: KinesisDataStreamModel, context: LambdaContext):
    logs: CloudWatchLogsDecode = extract_cloudwatch_logs_from_event(event)
    for log in logs:
        if log.messageType == "DATA_MESSAGE":
            return "success"
    return "success"
```

**Processing batch of logs**

```python
from aws_lambda_powertools.utilities.batch import (BatchProcessor, EventType,
                                                   batch_processor)
from aws_lambda_powertools.utilities.parser.models import (
    KinesisDataStreamModel, KinesisDataStreamRecord)
from aws_lambda_powertools.utilities.parser.models.kinesis import \
    extract_cloudwatch_logs_from_record

processor = BatchProcessor(event_type=EventType.KinesisDataStreams, model=KinesisDataStreamModel)


def record_handler(record: KinesisDataStreamRecord):
    log = extract_cloudwatch_logs_from_record(record)
    return log.messageType == "DATA_MESSAGE"


@batch_processor(record_handler=record_handler, processor=processor)
def lambda_handler(event, context):
    return processor.response()
```

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] [Meet tenets criteria](https://awslabs.github.io/aws-lambda-powertools-python/#tenets)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [ ] Changes are documented (depends on Parser docs refactoring to make it more explicit)
* [x] PR title follows [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-python/blob/develop/.github/semantic.yml)

<details>
<summary>Is this a breaking change?</summary>

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
