### PR TITLE
feat(parser): export Pydantic.errors through escape hatch

### DIFF
--- a/aws_lambda_powertools/utilities/parser/pydantic.py
+++ b/aws_lambda_powertools/utilities/parser/pydantic.py
@@ -6,3 +6,4 @@
 # to use `from aws_lambda_powertools.utilities.parser.pydantic import <anything>`
 
 from pydantic import *  # noqa: F403,F401
+from pydantic.errors import *  # noqa: F403,F401


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
**Issue number:** #1687

## Summary

### Changes

> Please provide a summary of what's being changed

This PR exports all errors available in `pydantic.errors` through parser's pydantic escape hatch.

### User experience

> Please share what the user experience looks like before and after this change

<img width="1132" alt="image" src="https://user-images.githubusercontent.com/3340292/202201766-158d9d93-721a-49d0-b7f8-7ce7771733c0.png">


## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [ ] [Meet tenets criteria](https://awslabs.github.io/aws-lambda-powertools-python/#tenets)
* [ ] I have performed a self-review of this change
* [ ] Changes have been tested
* [ ] Changes are documented
* [ ] PR title follows [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-python/blob/develop/.github/semantic.yml)

<details>
<summary>Is this a breaking change?</summary>

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
