### PR TITLE
docs(idempotency): add missing Lambda Context; note on thread-safe

### DIFF
--- a/docs/utilities/idempotency.md
+++ b/docs/utilities/idempotency.md
@@ -125,8 +125,12 @@ When using `idempotent_function`, you must tell us which keyword parameter in yo
 
 !!! info "We support JSON serializable data, [Python Dataclasses](https://docs.python.org/3.7/library/dataclasses.html){target="_blank"}, [Parser/Pydantic Models](parser.md){target="_blank"}, and our [Event Source Data Classes](./data_classes.md){target="_blank"}."
 
-???+ warning
-    Make sure to call your decorated function using keyword arguments
+???+ warning "Limitations"
+    Make sure to call your decorated function using keyword arguments.
+
+    Decorated functions with `idempotent_function` are not thread-safe, if the caller uses threading, not the function computation itself.
+
+    DynamoDB Persistency layer uses a Resource client [which is not thread-safe](https://boto3.amazonaws.com/v1/documentation/api/latest/guide/resources.html?highlight=multithreading#multithreading-or-multiprocessing-with-resources){target="_blank"}.
 
 === "batch_sample.py"
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
**Issue number:** #1718

## Summary

### Changes

> Please provide a summary of what's being changed

Add missing LambdaContext for `Testing your code section`, and a note on thread-safety limitation when calling functions decorated with `idempotent_function` via threading.

### User experience

> Please share what the user experience looks like before and after this change

<img width="1180" alt="image" src="https://user-images.githubusercontent.com/3340292/202435484-12e6e522-e16c-4266-b206-34e492b5e7fc.png">

<img width="1186" alt="image" src="https://user-images.githubusercontent.com/3340292/202435518-9f9134bd-bc1d-4a2c-9ac4-05d54776abd5.png">


## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] [Meet tenets criteria](https://awslabs.github.io/aws-lambda-powertools-python/#tenets)
* [x] I have performed a self-review of this change
* [ ] Changes have been tested
* [x] Changes are documented
* [x] PR title follows [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-python/blob/develop/.github/semantic.yml)

<details>
<summary>Is this a breaking change?</summary>

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.


-----
[View rendered docs/utilities/idempotency.md](https://github.com/heitorlessa/aws-lambda-powertools-python/blob/docs/idempotency-testing-and-thread/docs/utilities/idempotency.md)