### PR TITLE
docs(idempotency): fix register_lambda_context order

### DIFF
--- a/docs/utilities/idempotency.md
+++ b/docs/utilities/idempotency.md
@@ -136,7 +136,7 @@ When using `idempotent_function`, you must tell us which keyword parameter in yo
 
     This example also demonstrates how you can integrate with [Batch utility](batch.md), so you can process each record in an idempotent manner.
 
-    ```python hl_lines="4-5 16 21 29"
+    ```python hl_lines="4-5 16 21 30"
     from aws_lambda_powertools.utilities.batch import (BatchProcessor, EventType,
                                                        batch_processor)
     from aws_lambda_powertools.utilities.data_classes.sqs_event import SQSRecord
@@ -164,9 +164,9 @@ When using `idempotent_function`, you must tell us which keyword parameter in yo
 
     @batch_processor(record_handler=record_handler, processor=processor)
     def lambda_handler(event, context):
+		config.register_lambda_context(context) # see Lambda timeouts section
         # `data` parameter must be called as a keyword argument to work
         dummy("hello", "universe", data="test")
-		config.register_lambda_context(context) # see Lambda timeouts section
         return processor.response()
     ```
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
**Issue number:** #1745

## Summary

### Changes

> Please provide a summary of what's being changed

Fix the order of `register_lambda_context` so timeout can be handled correctly.

### User experience

> Please share what the user experience looks like before and after this change

<img width="1206" alt="image" src="https://user-images.githubusercontent.com/3340292/203761498-fc025207-3b38-4fe1-a1d0-5ef21853a136.png">

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] [Meet tenets criteria](https://awslabs.github.io/aws-lambda-powertools-python/#tenets)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented
* [x] PR title follows [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-python/blob/develop/.github/semantic.yml)

<details>
<summary>Is this a breaking change?</summary>

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.


-----
[View rendered docs/utilities/idempotency.md](https://github.com/heitorlessa/aws-lambda-powertools-python/blob/docs/batch-idempotency-integration/docs/utilities/idempotency.md)