### PR TITLE
feat(logger): unwrap event from common models if asked to log

### DIFF
--- a/aws_lambda_powertools/logging/logger.py
+++ b/aws_lambda_powertools/logging/logger.py
@@ -26,7 +26,11 @@ from typing import (
 import jmespath
 
 from ..shared import constants
-from ..shared.functions import resolve_env_var_choice, resolve_truthy_env_var_choice
+from ..shared.functions import (
+    extract_event_from_common_models,
+    resolve_env_var_choice,
+    resolve_truthy_env_var_choice,
+)
 from ..shared.types import AnyCallableT
 from .exceptions import InvalidLoggerSamplingRateError
 from .filters import SuppressFilter
@@ -433,7 +437,7 @@ class Logger(logging.Logger):  # lgtm [py/missing-call-to-init]
 
             if log_event:
                 logger.debug("Event received")
-                self.info(getattr(event, "raw_event", event))
+                self.info(extract_event_from_common_models(event))
 
             return lambda_handler(event, context, *args, **kwargs)
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
**Issue number:** #1773

## Summary

### Changes

> Please provide a summary of what's being changed

Uses new `extract_event_from_common_models` so Logger can log incoming events that might be wrapped in common containers such as Event Source Data Classes, Pydantic/Parser BaseModels, and Dataclasses.

Previously, we'd only do so for Event Source Data Classes. The linked discussion led to a confusion due to both `event_source` and `event_parser` decorator mutating the event. This required decorators to be in the right order when using `event_parser`. This PR prevents this common mistake when authoring functions leading to an optimal cognitive load.


### User experience

> Please share what the user experience looks like before and after this change

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] [Meet tenets criteria](https://awslabs.github.io/aws-lambda-powertools-python/#tenets)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented
* [x] PR title follows [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-python/blob/develop/.github/semantic.yml)

<details>
<summary>Is this a breaking change?</summary>

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
