### PR TITLE
fix(event_handlers): omit explicit None HTTP header values

### DIFF
--- a/aws_lambda_powertools/shared/headers_serializer.py
+++ b/aws_lambda_powertools/shared/headers_serializer.py
@@ -44,7 +44,8 @@ class HttpApiHeadersSerializer(BaseHeadersSerializer):
             if isinstance(values, str):
                 combined_headers[key] = values
             else:
-                combined_headers[key] = ", ".join(values)
+                if values:
+                    combined_headers[key] = ", ".join(values)
 
         return {"headers": combined_headers, "cookies": list(map(str, cookies))}
 
@@ -65,8 +66,9 @@ class MultiValueHeadersSerializer(BaseHeadersSerializer):
             if isinstance(values, str):
                 payload[key].append(values)
             else:
-                for value in values:
-                    payload[key].append(value)
+                if values:
+                    for value in values:
+                        payload[key].append(value)
 
         if cookies:
             payload.setdefault("Set-Cookie", [])
@@ -101,13 +103,14 @@ class SingleValueHeadersSerializer(BaseHeadersSerializer):
             if isinstance(values, str):
                 payload["headers"][key] = values
             else:
-                if len(values) > 1:
-                    warnings.warn(
-                        f"Can't encode more than one header value for the same key ('{key}') in the response. "
-                        "Did you enable multiValueHeaders on the ALB Target Group?"
-                    )
+                if values:
+                    if len(values) > 1:
+                        warnings.warn(
+                            f"Can't encode more than one header value for the same key ('{key}') in the response. "
+                            "Did you enable multiValueHeaders on the ALB Target Group?"
+                        )
 
-                # We can only set one header per key, send the last one
-                payload["headers"][key] = values[-1]
+                    # We can only set one header per key, send the last one
+                    payload["headers"][key] = values[-1]
 
         return payload

--- a/tests/functional/test_headers_serializer.py
+++ b/tests/functional/test_headers_serializer.py
@@ -145,3 +145,21 @@ def test_single_value_headers_with_multiple_header_values_warning():
         payload = serializer.serialize(cookies=[], headers=headers)
 
     assert payload["headers"]["Foo"] == headers["Foo"][-1]
+
+
+def test_http_api_headers_serializer_with_null_values():
+    serializer = HttpApiHeadersSerializer()
+    payload = serializer.serialize(headers={"Foo": None}, cookies=[])
+    assert payload == {"headers": {}, "cookies": []}
+
+
+def test_multi_value_headers_serializer_with_null_values():
+    serializer = MultiValueHeadersSerializer()
+    payload = serializer.serialize(headers={"Foo": None}, cookies=[])
+    assert payload == {"multiValueHeaders": {}}
+
+
+def test_single_value_headers_serializer_with_null_values():
+    serializer = SingleValueHeadersSerializer()
+    payload = serializer.serialize(headers={"Foo": None}, cookies=[])
+    assert payload["headers"] == {}


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
**Issue number:** #1791 

## Summary

### Changes

Add a fix for when header is None and avoid iterator or len issues

### User experience

Although not recommended by the RFC that defines headers in the HTTP protocol, the user can force a header with a value of None. To avoid this problem the header which has value None will be omitted from the response

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] [Meet tenets criteria](https://awslabs.github.io/aws-lambda-powertools-python/#tenets)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [ ] Changes are documented
* [x] PR title follows [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-python/blob/develop/.github/semantic.yml)

<details>
<summary>Is this a breaking change?</summary>

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
