### PR TITLE
docs(logger): Add warning of uncaught exceptions

### DIFF
--- a/docs/core/logger.md
+++ b/docs/core/logger.md
@@ -293,6 +293,8 @@ Use `logger.exception` method to log contextual information about exceptions. Lo
 
 #### Uncaught exceptions
 
+!!! warning "CAUTION: some users reported a problem that causes this functionality not to work in the Lambda runtime. We recommend that you don't use this feature for the time being."
+
 Logger can optionally log uncaught exceptions by setting `log_uncaught_exceptions=True` at initialization.
 
 !!! info "Logger will replace any exception hook previously registered via [sys.excepthook](https://docs.python.org/3/library/sys.html#sys.excepthook){target='_blank'}."


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
**Issue number:** #1825 

## Summary

### Changes

Update [Uncaught exceptions](https://awslabs.github.io/aws-lambda-powertools-python/2.5.0/core/logger/#uncaught-exceptions) documentation

### User experience

> Please share what the user experience looks like before and after this change

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] [Meet tenets criteria](https://awslabs.github.io/aws-lambda-powertools-python/#tenets)
* [x] I have performed a self-review of this change
* [ ] Changes have been tested
* [x] Changes are documented
* [x] PR title follows [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-python/blob/develop/.github/semantic.yml)

<details>
<summary>Is this a breaking change?</summary>

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
