### PR TITLE
fix(api_gateway): fixed custom metrics issue when using debug mode

### DIFF
--- a/aws_lambda_powertools/event_handler/api_gateway.py
+++ b/aws_lambda_powertools/event_handler/api_gateway.py
@@ -531,7 +531,7 @@ class ApiGatewayResolver(BaseRouter):
             event = event.raw_event
 
         if self._debug:
-            print(self._json_dump(event), end="")
+            print(self._json_dump(event))
 
         # Populate router(s) dependencies without keeping a reference to each registered router
         BaseRouter.current_event = self._to_proxy_event(event)

--- a/tests/functional/event_handler/test_api_gateway.py
+++ b/tests/functional/event_handler/test_api_gateway.py
@@ -829,6 +829,7 @@ def test_debug_print_event(capsys):
 
     # THEN print the event
     out, err = capsys.readouterr()
+    assert "\n" in out
     assert json.loads(out) == event
 
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
**Issue number:** #1805  

## Summary

### Changes

Newlines are now emitted at the end of api_gateway debug JSON events. This resolves an issue where the debug events would be combined with CloudWatch EMF metrics, resulting in the metrics being ignored.

### User experience

Before, if debug mode was enabled in the api_gateway router, custom EMF metrics would be appended to the end of the debug JSON in the same line in standard out. This would result in the custom metrics being ignored by the CloudWatch agent. With this change, the two JSON objects are separated by newlines and CloudWatch recognizes the metrics data and uploads it.

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] [Meet tenets criteria](https://awslabs.github.io/aws-lambda-powertools-python/#tenets)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [ ] Changes are documented
* [x] PR title follows [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-python/blob/develop/.github/semantic.yml)

<details>
<summary>Is this a breaking change?</summary>
This is not a breaking change.

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.

