### PR TITLE
docs(logger): fix incorrect field names in example structured logs

### DIFF
--- a/examples/logger/src/bring_your_own_formatter_from_scratch_output.json
+++ b/examples/logger/src/bring_your_own_formatter_from_scratch_output.json
@@ -3,8 +3,8 @@
     "timestamp": "2021-05-03 11:47:12,494",
     "my_default_key": "test",
     "cold_start": true,
-    "lambda_function_name": "test",
-    "lambda_function_memory_size": 128,
-    "lambda_function_arn": "arn:aws:lambda:eu-west-1:12345678910:function:test",
-    "lambda_request_id": "52fdfc07-2182-154f-163f-5f0f9a621d72"
+    "function_name": "test",
+    "function_memory_size": 128,
+    "function_arn": "arn:aws:lambda:eu-west-1:12345678910:function:test",
+    "function_request_id": "52fdfc07-2182-154f-163f-5f0f9a621d72"
 }

--- a/examples/logger/src/clear_state_event_one.json
+++ b/examples/logger/src/clear_state_event_one.json
@@ -6,8 +6,8 @@
     "service": "payment",
     "special_key": "debug_key",
     "cold_start": true,
-    "lambda_function_name": "test",
-    "lambda_function_memory_size": 128,
-    "lambda_function_arn": "arn:aws:lambda:eu-west-1:12345678910:function:test",
-    "lambda_request_id": "52fdfc07-2182-154f-163f-5f0f9a621d72"
+    "function_name": "test",
+    "function_memory_size": 128,
+    "function_arn": "arn:aws:lambda:eu-west-1:12345678910:function:test",
+    "function_request_id": "52fdfc07-2182-154f-163f-5f0f9a621d72"
 }

--- a/examples/logger/src/clear_state_event_two.json
+++ b/examples/logger/src/clear_state_event_two.json
@@ -5,8 +5,8 @@
     "timestamp": "2021-05-03 11:47:12,494+0200",
     "service": "payment",
     "cold_start": false,
-    "lambda_function_name": "test",
-    "lambda_function_memory_size": 128,
-    "lambda_function_arn": "arn:aws:lambda:eu-west-1:12345678910:function:test",
-    "lambda_request_id": "52fdfc07-2182-154f-163f-5f0f9a621d72"
+    "function_name": "test",
+    "function_memory_size": 128,
+    "function_arn": "arn:aws:lambda:eu-west-1:12345678910:function:test",
+    "function_request_id": "52fdfc07-2182-154f-163f-5f0f9a621d72"
 }

--- a/examples/logger/src/inject_lambda_context_output.json
+++ b/examples/logger/src/inject_lambda_context_output.json
@@ -6,10 +6,10 @@
         "timestamp": "2021-05-03 11:47:12,494+0200",
         "service": "payment",
         "cold_start": true,
-        "lambda_function_name": "test",
-        "lambda_function_memory_size": 128,
-        "lambda_function_arn": "arn:aws:lambda:eu-west-1:12345678910:function:test",
-        "lambda_request_id": "52fdfc07-2182-154f-163f-5f0f9a621d72"
+        "function_name": "test",
+        "function_memory_size": 128,
+        "function_arn": "arn:aws:lambda:eu-west-1:12345678910:function:test",
+        "function_request_id": "52fdfc07-2182-154f-163f-5f0f9a621d72"
     },
     {
         "level": "INFO",
@@ -21,9 +21,9 @@
         "timestamp": "2021-05-03 11:47:12,494+0200",
         "service": "payment",
         "cold_start": true,
-        "lambda_function_name": "test",
-        "lambda_function_memory_size": 128,
-        "lambda_function_arn": "arn:aws:lambda:eu-west-1:12345678910:function:test",
-        "lambda_request_id": "52fdfc07-2182-154f-163f-5f0f9a621d72"
+        "function_name": "test",
+        "function_memory_size": 128,
+        "function_arn": "arn:aws:lambda:eu-west-1:12345678910:function:test",
+        "function_request_id": "52fdfc07-2182-154f-163f-5f0f9a621d72"
     }
 ]

--- a/examples/logger/src/logger_reuse_output.json
+++ b/examples/logger/src/logger_reuse_output.json
@@ -5,9 +5,9 @@
     "timestamp": "2021-05-03 11:47:12,494+0200",
     "service": "payment",
     "cold_start": true,
-    "lambda_function_name": "test",
-    "lambda_function_memory_size": 128,
-    "lambda_function_arn": "arn:aws:lambda:eu-west-1:12345678910:function:test",
-    "lambda_request_id": "52fdfc07-2182-154f-163f-5f0f9a621d72",
+    "function_name": "test",
+    "function_memory_size": 128,
+    "function_arn": "arn:aws:lambda:eu-west-1:12345678910:function:test",
+    "function_request_id": "52fdfc07-2182-154f-163f-5f0f9a621d72",
     "payment_id": "968adaae-a211-47af-bda3-eed3ca2c0ed0"
 }

--- a/examples/logger/src/sampling_debug_logs_output.json
+++ b/examples/logger/src/sampling_debug_logs_output.json
@@ -6,10 +6,10 @@
         "timestamp": "2021-05-03 11:47:12,494+0200",
         "service": "payment",
         "cold_start": true,
-        "lambda_function_name": "test",
-        "lambda_function_memory_size": 128,
-        "lambda_function_arn": "arn:aws:lambda:eu-west-1:12345678910:function:test",
-        "lambda_request_id": "52fdfc07-2182-154f-163f-5f0f9a621d72",
+        "function_name": "test",
+        "function_memory_size": 128,
+        "function_arn": "arn:aws:lambda:eu-west-1:12345678910:function:test",
+        "function_request_id": "52fdfc07-2182-154f-163f-5f0f9a621d72",
         "sampling_rate": 0.1
     },
     {
@@ -19,10 +19,10 @@
         "timestamp": "2021-05-03 11:47:12,494+0200",
         "service": "payment",
         "cold_start": true,
-        "lambda_function_name": "test",
-        "lambda_function_memory_size": 128,
-        "lambda_function_arn": "arn:aws:lambda:eu-west-1:12345678910:function:test",
-        "lambda_request_id": "52fdfc07-2182-154f-163f-5f0f9a621d72",
+        "function_name": "test",
+        "function_memory_size": 128,
+        "function_arn": "arn:aws:lambda:eu-west-1:12345678910:function:test",
+        "function_request_id": "52fdfc07-2182-154f-163f-5f0f9a621d72",
         "sampling_rate": 0.1
     }
 ]

--- a/examples/logger/src/set_correlation_id_jmespath_output.json
+++ b/examples/logger/src/set_correlation_id_jmespath_output.json
@@ -5,9 +5,9 @@
     "timestamp": "2021-05-03 11:47:12,494+0200",
     "service": "payment",
     "cold_start": true,
-    "lambda_function_name": "test",
-    "lambda_function_memory_size": 128,
-    "lambda_function_arn": "arn:aws:lambda:eu-west-1:12345678910:function:test",
-    "lambda_request_id": "52fdfc07-2182-154f-163f-5f0f9a621d72",
+    "function_name": "test",
+    "function_memory_size": 128,
+    "function_arn": "arn:aws:lambda:eu-west-1:12345678910:function:test",
+    "function_request_id": "52fdfc07-2182-154f-163f-5f0f9a621d72",
     "correlation_id": "correlation_id_value"
 }

--- a/examples/logger/src/set_correlation_id_output.json
+++ b/examples/logger/src/set_correlation_id_output.json
@@ -5,9 +5,9 @@
     "timestamp": "2021-05-03 11:47:12,494+0200",
     "service": "payment",
     "cold_start": true,
-    "lambda_function_name": "test",
-    "lambda_function_memory_size": 128,
-    "lambda_function_arn": "arn:aws:lambda:eu-west-1:12345678910:function:test",
-    "lambda_request_id": "52fdfc07-2182-154f-163f-5f0f9a621d72",
+    "function_name": "test",
+    "function_memory_size": 128,
+    "function_arn": "arn:aws:lambda:eu-west-1:12345678910:function:test",
+    "function_request_id": "52fdfc07-2182-154f-163f-5f0f9a621d72",
     "correlation_id": "correlation_id_value"
 }


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
**Issue number:** #1828

## Summary

This addresses incorrect examples of structured logs in the documentation. The docs now match the current behaviour of the library.

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [ ] [Meet tenets criteria](https://awslabs.github.io/aws-lambda-powertools-python/#tenets)
* [ ] I have performed a self-review of this change
* [ ] Changes have been tested
* [ ] Changes are documented
* [x] PR title follows [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-python/blob/develop/.github/semantic.yml)

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
