### PR TITLE
docs(event-source):  fix incorrect method in example CloudWatch Logs

### DIFF
--- a/docs/utilities/data_classes.md
+++ b/docs/utilities/data_classes.md
@@ -491,7 +491,7 @@ decompress and parse json data from the event.
 
     @event_source(data_class=CloudWatchLogsEvent)
     def lambda_handler(event: CloudWatchLogsEvent, context):
-        decompressed_log: CloudWatchLogsDecodedData = event.parse_logs_data
+        decompressed_log: CloudWatchLogsDecodedData = event.parse_logs_data()
         log_events = decompressed_log.log_events
         for event in log_events:
             do_something_with(event.timestamp, event.message)


### PR DESCRIPTION
Signed-off-by: Ashutosh Ojha <ashutoshojha5@gmail.com>

<!-- markdownlint-disable MD041 MD043 -->
**Issue number:** #1867 

## Summary

### Changes

>event.parse_logs_data is used in CloudWatch Logs section as an object, but it is method and should be like event.parse_logs_data()

### User experience

> Please share what the user experience looks like before and after this change

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [ ] [Meet tenets criteria](https://awslabs.github.io/aws-lambda-powertools-python/#tenets)
* [ ] I have performed a self-review of this change
* [ ] Changes have been tested
* [x] Changes are documented
* [x] PR title follows [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-python/blob/develop/.github/semantic.yml)

<details>
<summary>Is this a breaking change?</summary>

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
