### PR TITLE
fix(tests): make logs fetching more robust

### DIFF
--- a/tests/e2e/logger/test_logger.py
+++ b/tests/e2e/logger/test_logger.py
@@ -30,7 +30,7 @@ def test_basic_lambda_logs_visible(basic_handler_fn, basic_handler_fn_arn):
     data_fetcher.get_lambda_response(lambda_arn=basic_handler_fn_arn, payload=payload)
 
     # THEN
-    logs = data_fetcher.get_logs(function_name=basic_handler_fn, start_time=execution_time)
+    logs = data_fetcher.get_logs(function_name=basic_handler_fn, start_time=execution_time, expected_number_of_logs=2)
 
     assert len(logs) == 2
     assert len(logs.get_cold_start_log()) == 1

--- a/tests/e2e/logger/test_logger.py
+++ b/tests/e2e/logger/test_logger.py
@@ -30,7 +30,7 @@ def test_basic_lambda_logs_visible(basic_handler_fn, basic_handler_fn_arn):
     data_fetcher.get_lambda_response(lambda_arn=basic_handler_fn_arn, payload=payload)
 
     # THEN
-    logs = data_fetcher.get_logs(function_name=basic_handler_fn, start_time=execution_time, expected_number_of_logs=2)
+    logs = data_fetcher.get_logs(function_name=basic_handler_fn, start_time=execution_time, minimum_log_entries=2)
 
     assert len(logs) == 2
     assert len(logs.get_cold_start_log()) == 1

--- a/tests/e2e/utils/data_fetcher/logs.py
+++ b/tests/e2e/utils/data_fetcher/logs.py
@@ -122,6 +122,7 @@ class LogFetcher:
 def get_logs(
     function_name: str,
     start_time: datetime,
+    expected_number_of_logs: Optional[int],
     filter_expression: Optional[str] = None,
     log_client: Optional[CloudWatchLogsClient] = None,
 ) -> LogFetcher:
@@ -133,6 +134,8 @@ def get_logs(
         Name of Lambda function to fetch logs for
     start_time : datetime
         Start date range to filter traces
+    expected_number_of_logs : Optional[int]
+        Retry fetching logs until this number of log lines are obtained
     log_client : Optional[CloudWatchLogsClient], optional
         Amazon CloudWatch Logs Client, by default boto3.client('logs)
     filter_expression : Optional[str], optional
@@ -143,6 +146,11 @@ def get_logs(
     LogFetcher
         LogFetcher instance with logs available as properties and methods
     """
-    return LogFetcher(
+    log_fetcher = LogFetcher(
         function_name=function_name, start_time=start_time, filter_expression=filter_expression, log_client=log_client
     )
+
+    if expected_number_of_logs is not None and len(log_fetcher) < expected_number_of_logs:
+        raise ValueError(f"expected {expected_number_of_logs} logs but only got ${len(log_fetcher)}")
+
+    return log_fetcher

--- a/tests/e2e/utils/data_fetcher/logs.py
+++ b/tests/e2e/utils/data_fetcher/logs.py
@@ -134,7 +134,7 @@ def get_logs(
         Name of Lambda function to fetch logs for
     start_time : datetime
         Start date range to filter traces
-    expected_number_of_logs : Optional[int]
+    minimum_log_entries : Optional[int]
         Retry fetching logs until this number of log lines are obtained
     log_client : Optional[CloudWatchLogsClient], optional
         Amazon CloudWatch Logs Client, by default boto3.client('logs)

--- a/tests/e2e/utils/data_fetcher/logs.py
+++ b/tests/e2e/utils/data_fetcher/logs.py
@@ -150,7 +150,7 @@ def get_logs(
         function_name=function_name, start_time=start_time, filter_expression=filter_expression, log_client=log_client
     )
 
-    if expected_number_of_logs is not None and len(log_fetcher) < expected_number_of_logs:
+    if minimum_log_entries < len(log_fetcher):
         raise ValueError(f"expected {expected_number_of_logs} logs but only got ${len(log_fetcher)}")
 
     return log_fetcher


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
**Issue number:** #1877

## Summary

### Changes

> Please provide a summary of what's being changed

This PR adds an optional field to the logger fetcher, where we could indicate how many 
lines of logging we are expecting. If we fail to fetch that number, we use the existing
retry mechanism to try multiple times, before bailing out.

### User experience

> Please share what the user experience looks like before and after this change

This should help with some of the flaky e2e tests.

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] [Meet tenets criteria](https://awslabs.github.io/aws-lambda-powertools-python/#tenets)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented
* [x] PR title follows [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-python/blob/develop/.github/semantic.yml)

<details>
<summary>Is this a breaking change?</summary>

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
