### PR TITLE
docs(homepage): add banner for end-of-support v1

### DIFF
--- a/docs/overrides/main.html
+++ b/docs/overrides/main.html
@@ -1,5 +1,10 @@
 {% extends "base.html" %}
 
+{% block announce %}
+👋 Powertools for Python v1 will no longer receive updates or releases after 31/03/2023!
+We encourage you to read important information's <a href="/upgrade/#end-of-support-v1">here</a>.
+{% endblock %}
+
 {% block outdated %}
   You're not viewing the latest version.
   <a href="{{ '../' ~ base_url }}">

--- a/docs/overrides/main.html
+++ b/docs/overrides/main.html
@@ -2,7 +2,7 @@
 
 {% block announce %}
 👋 Powertools for Python v1 will no longer receive updates or releases after 31/03/2023!
-We encourage you to read important information's <a href="/upgrade/#end-of-support-v1">here</a>.
+We encourage you to read our <a href="/upgrade/#end-of-support-v1">upgrade guide on how to migrate to v2</a>.
 {% endblock %}
 
 {% block outdated %}

--- a/docs/upgrade.md
+++ b/docs/upgrade.md
@@ -7,9 +7,9 @@ description: Guide to update between major Powertools versions
 
 ## End of support v1
 
-On March 31, 2023, AWS Lambda Powertools for Python version 1 will reach end of support. After that, AWS Lambda Powertools for Python version 1 will no longer receive updates or releases. If you are still using v1, we encourage you to read our upgrade guide and update to the latest version.
+On March 31st, AWS Lambda Powertools for Python v1 will reach end of support. After that, Powertools v1 will no longer receive updates or releases. If you are still using v1, we encourage you to read our upgrade guide and update to the latest version.
 
-Given our commitment to all of our customers using AWS Lambda Powertools for Python, we won't remove old package versions from [Pypi](https://pypi.org/project/aws-lambda-powertools/) and will also leave old tags active, so you can read the documentation for v1 version.
+Given our commitment to all of our customers using AWS Lambda Powertools for Python, we will keep [Pypi](https://pypi.org/project/aws-lambda-powertools/) v1 releases and documentation 1.x versions to prevent any disruption.
 
 ## Migrate to v2 from v1
 

--- a/docs/upgrade.md
+++ b/docs/upgrade.md
@@ -5,6 +5,12 @@ description: Guide to update between major Powertools versions
 
 <!-- markdownlint-disable MD043 -->
 
+## End of support v1
+
+On March 31, 2023, AWS Lambda Powertools for Python version 1 will reach end of support. After that, AWS Lambda Powertools for Python version 1 will no longer receive updates or releases. If you are still using v1, we encourage you to read our upgrade guide and update to the latest version.
+
+Given our commitment to all of our customers using AWS Lambda Powertools for Python, we won't remove old package versions from [Pypi](https://pypi.org/project/aws-lambda-powertools/) and will also leave old tags active, so you can read the documentation for v1 version.
+
 ## Migrate to v2 from v1
 
 We've made minimal breaking changes to make your transition to v2 as smooth as possible.


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
**Issue number:** #1864 

## Summary

Update documentation to stating that version 1.x will no longer be supported as of 31/03/2023.

### Changes

Documentation updated

### User experience

![image](https://user-images.githubusercontent.com/4295173/216048794-fc4282f6-0b39-4d46-bdc9-9aa766083b41.png)

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] [Meet tenets criteria](https://awslabs.github.io/aws-lambda-powertools-python/#tenets)
* [x] I have performed a self-review of this change
* [ ] Changes have been tested
* [x] Changes are documented
* [x] PR title follows [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-python/blob/develop/.github/semantic.yml)

<details>
<summary>Is this a breaking change?</summary>

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
