### PR TITLE
fix(ci): add auth to API HTTP Gateway and Lambda Function Url

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -90,6 +90,26 @@ publication = ">=0.0.3"
 typeguard = ">=2.13.3,<2.14.0"
 
 [[package]]
+name = "aws-cdk-aws-apigatewayv2-authorizers-alpha"
+version = "2.62.2a0"
+description = "Authorizers for AWS APIGateway V2"
+category = "dev"
+optional = false
+python-versions = "~=3.7"
+files = [
+    {file = "aws-cdk.aws-apigatewayv2-authorizers-alpha-2.62.2a0.tar.gz", hash = "sha256:9a4ba121c49e4ba866b985495b87e9ecaec50c1f26e0d8cb116e15492196c042"},
+    {file = "aws_cdk.aws_apigatewayv2_authorizers_alpha-2.62.2a0-py3-none-any.whl", hash = "sha256:9cfb1495b618880b395d6ecbd45c3c524c67013f2567eae6e19e6f06586b9a38"},
+]
+
+[package.dependencies]
+"aws-cdk.aws-apigatewayv2-alpha" = "2.62.2.a0"
+aws-cdk-lib = ">=2.62.2,<3.0.0"
+constructs = ">=10.0.0,<11.0.0"
+jsii = ">=1.73.0,<2.0.0"
+publication = ">=0.0.3"
+typeguard = ">=2.13.3,<2.14.0"
+
+[[package]]
 name = "aws-cdk-aws-apigatewayv2-integrations-alpha"
 version = "2.62.2a0"
 description = "Integrations for AWS APIGateway V2"
@@ -129,6 +149,21 @@ constructs = ">=10.0.0,<11.0.0"
 jsii = ">=1.73.0,<2.0.0"
 publication = ">=0.0.3"
 typeguard = ">=2.13.3,<2.14.0"
+
+[[package]]
+name = "aws-requests-auth"
+version = "0.4.3"
+description = "AWS signature version 4 signing process for the python requests module"
+category = "dev"
+optional = false
+python-versions = "*"
+files = [
+    {file = "aws-requests-auth-0.4.3.tar.gz", hash = "sha256:33593372018b960a31dbbe236f89421678b885c35f0b6a7abfae35bb77e069b2"},
+    {file = "aws_requests_auth-0.4.3-py2.py3-none-any.whl", hash = "sha256:646bc37d62140ea1c709d20148f5d43197e6bd2d63909eb36fa4bb2345759977"},
+]
+
+[package.dependencies]
+requests = ">=0.14.0"
 
 [[package]]
 name = "aws-sam-translator"
@@ -2796,4 +2831,4 @@ validation = ["fastjsonschema"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.7.4"
-content-hash = "3a1013eb7ad5ff7a4a1bcf3be36eda55135bae69aae74cd91c1fde062805e154"
+content-hash = "b897ddb6a5d83dd5acce3c612c912af40b6c6c7821abc4804a93037e2f26639b"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,6 +59,7 @@ pytest-xdist = "^3.1.0"
 aws-cdk-lib = "^2.62.2"
 "aws-cdk.aws-apigatewayv2-alpha" = "^2.38.1-alpha.0"
 "aws-cdk.aws-apigatewayv2-integrations-alpha" = "^2.38.1-alpha.0"
+"aws-cdk.aws-apigatewayv2-authorizers-alpha" = "^2.38.1-alpha.0"
 pytest-benchmark = "^4.0.0"
 python-snappy = "^0.6.1"
 mypy-boto3-appconfig = "^1.26.0"
@@ -81,6 +82,7 @@ importlib-metadata = "^6.0"
 ijson = "^3.2.0"
 typed-ast = { version = "^1.5.4", python = "< 3.8"}
 hvac = "^1.0.2"
+aws-requests-auth = "^0.4.3"
 
 [tool.poetry.extras]
 parser = ["pydantic"]

--- a/tests/e2e/event_handler/test_header_serializer.py
+++ b/tests/e2e/event_handler/test_header_serializer.py
@@ -5,7 +5,7 @@ from requests import Request
 
 from aws_lambda_powertools.shared.cookies import Cookie
 from tests.e2e.utils import data_fetcher
-from tests.e2e.utils.auth import iam_auth
+from tests.e2e.utils.auth import build_iam_auth
 
 
 @pytest.fixture
@@ -169,7 +169,7 @@ def test_api_gateway_http_headers_serializer(apigw_http_endpoint):
             method="POST",
             url=url,
             json={"body": body, "status_code": status_code, "headers": headers, "cookies": list(map(str, cookies))},
-            auth=iam_auth(url, "execute-api"),
+            auth=build_iam_auth(url=url, aws_service="execute-api"),
         )
     )
 
@@ -206,7 +206,7 @@ def test_lambda_function_url_headers_serializer(lambda_function_url_endpoint):
             method="POST",
             url=url,
             json={"body": body, "status_code": status_code, "headers": headers, "cookies": list(map(str, cookies))},
-            auth=iam_auth(url, "lambda"),
+            auth=build_iam_auth(url=url, aws_service="lambda"),
         )
     )
 

--- a/tests/e2e/event_handler/test_header_serializer.py
+++ b/tests/e2e/event_handler/test_header_serializer.py
@@ -5,6 +5,7 @@ from requests import Request
 
 from aws_lambda_powertools.shared.cookies import Cookie
 from tests.e2e.utils import data_fetcher
+from tests.e2e.utils.auth import iam_auth
 
 
 @pytest.fixture
@@ -168,6 +169,7 @@ def test_api_gateway_http_headers_serializer(apigw_http_endpoint):
             method="POST",
             url=url,
             json={"body": body, "status_code": status_code, "headers": headers, "cookies": list(map(str, cookies))},
+            auth=iam_auth(url, "execute-api"),
         )
     )
 
@@ -204,6 +206,7 @@ def test_lambda_function_url_headers_serializer(lambda_function_url_endpoint):
             method="POST",
             url=url,
             json={"body": body, "status_code": status_code, "headers": headers, "cookies": list(map(str, cookies))},
+            auth=iam_auth(url, "lambda"),
         )
     )
 

--- a/tests/e2e/event_handler/test_paths_ending_with_slash.py
+++ b/tests/e2e/event_handler/test_paths_ending_with_slash.py
@@ -2,7 +2,7 @@ import pytest
 from requests import HTTPError, Request
 
 from tests.e2e.utils import data_fetcher
-from tests.e2e.utils.auth import iam_auth
+from tests.e2e.utils.auth import build_iam_auth
 
 
 @pytest.fixture
@@ -46,7 +46,7 @@ def test_api_gateway_rest_trailing_slash(apigw_rest_endpoint):
             method="POST",
             url=url,
             json={"body": body},
-            auth=iam_auth(url, "lambda"),
+            auth=build_iam_auth(url=url, aws_service="lambda"),
         )
     )
 
@@ -67,7 +67,7 @@ def test_api_gateway_http_trailing_slash(apigw_http_endpoint):
                 method="POST",
                 url=url,
                 json={"body": body},
-                auth=iam_auth(url, "lambda"),
+                auth=build_iam_auth(url=url, aws_service="lambda"),
             )
         )
 
@@ -85,7 +85,7 @@ def test_lambda_function_url_trailing_slash(lambda_function_url_endpoint):
                 method="POST",
                 url=url,
                 json={"body": body},
-                auth=iam_auth(url, "lambda"),
+                auth=build_iam_auth(url=url, aws_service="lambda"),
             )
         )
 
@@ -103,6 +103,6 @@ def test_alb_url_trailing_slash(alb_multi_value_header_listener_endpoint):
                 method="POST",
                 url=url,
                 json={"body": body},
-                auth=iam_auth(url, "lambda"),
+                auth=build_iam_auth(url=url, aws_service="lambda"),
             )
         )

--- a/tests/e2e/event_handler/test_paths_ending_with_slash.py
+++ b/tests/e2e/event_handler/test_paths_ending_with_slash.py
@@ -2,6 +2,7 @@ import pytest
 from requests import HTTPError, Request
 
 from tests.e2e.utils import data_fetcher
+from tests.e2e.utils.auth import iam_auth
 
 
 @pytest.fixture
@@ -45,6 +46,7 @@ def test_api_gateway_rest_trailing_slash(apigw_rest_endpoint):
             method="POST",
             url=url,
             json={"body": body},
+            auth=iam_auth(url, "lambda"),
         )
     )
 
@@ -65,6 +67,7 @@ def test_api_gateway_http_trailing_slash(apigw_http_endpoint):
                 method="POST",
                 url=url,
                 json={"body": body},
+                auth=iam_auth(url, "lambda"),
             )
         )
 
@@ -82,6 +85,7 @@ def test_lambda_function_url_trailing_slash(lambda_function_url_endpoint):
                 method="POST",
                 url=url,
                 json={"body": body},
+                auth=iam_auth(url, "lambda"),
             )
         )
 
@@ -99,5 +103,6 @@ def test_alb_url_trailing_slash(alb_multi_value_header_listener_endpoint):
                 method="POST",
                 url=url,
                 json={"body": body},
+                auth=iam_auth(url, "lambda"),
             )
         )

--- a/tests/e2e/utils/auth.py
+++ b/tests/e2e/utils/auth.py
@@ -4,7 +4,7 @@ import boto3
 from aws_requests_auth.boto_utils import BotoAWSRequestsAuth
 
 
-def iam_auth(url: str, aws_service: str) -> BotoAWSRequestsAuth:
+def build_iam_auth(url: str, aws_service: str) -> BotoAWSRequestsAuth:
     """Generates IAM auth keys for a given hostname and service.
     This can be directly passed on to the requests library to authenticate the request.
     """

--- a/tests/e2e/utils/auth.py
+++ b/tests/e2e/utils/auth.py
@@ -1,0 +1,13 @@
+from urllib.parse import urlparse
+
+import boto3
+from aws_requests_auth.boto_utils import BotoAWSRequestsAuth
+
+
+def iam_auth(url: str, aws_service: str) -> BotoAWSRequestsAuth:
+    """Generates IAM auth keys for a given hostname and service.
+    This can be directly passed on to the requests library to authenticate the request.
+    """
+    hostname = urlparse(url).hostname
+    region = boto3.Session().region_name
+    return BotoAWSRequestsAuth(aws_host=hostname, aws_region=region, aws_service=aws_service)


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
**Issue number:** #1877

## Summary

### Changes

> Please provide a summary of what's being changed

This PR adds the aws-requests-auth library and uses it to authenticate requests to API Gateway HTTP, and 
Lambda Functions urls during e2e testing.

### User experience

> Please share what the user experience looks like before and after this change

Before this change E2E could fail for internal compliance reasons.

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] [Meet tenets criteria](https://awslabs.github.io/aws-lambda-powertools-python/#tenets)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented
* [x] PR title follows [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-python/blob/develop/.github/semantic.yml)

<details>
<summary>Is this a breaking change?</summary>

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
