### PR TITLE
fix(license): correction to MIT + MIT-0 (no proprietary anymore)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,8 @@ classifiers=[
 repository="https://github.com/awslabs/aws-lambda-powertools-python"
 readme = "README.md"
 keywords = ["aws_lambda_powertools", "aws", "tracing", "logging", "lambda", "powertools", "feature_flags", "idempotency", "middleware"]
-# MIT-0 is not recognized as an existing license from poetry
+# MIT-0 is not recognized as an existing license from poetry.
+# By using `MIT` as a license value, a `License :: OSI Approved :: MIT License` classifier is added to the classifiers list.
 license = "MIT"
 
 [tool.poetry.dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ include = ["aws_lambda_powertools/py.typed", "THIRD-PARTY-LICENSES"]
 classifiers=[
     "Development Status :: 5 - Production/Stable",
     "Intended Audience :: Developers",
-    "License :: OSI Approved :: MIT License",
+    "License :: OSI Approved :: MIT No Attribution License (MIT-0)",
     "Natural Language :: English",
     "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
@@ -16,7 +16,8 @@ classifiers=[
 repository="https://github.com/awslabs/aws-lambda-powertools-python"
 readme = "README.md"
 keywords = ["aws_lambda_powertools", "aws", "tracing", "logging", "lambda", "powertools", "feature_flags", "idempotency", "middleware"]
-license = "MIT-0"
+# MIT-0 is not recognized as an existing license from poetry
+license = "MIT"
 
 [tool.poetry.dependencies]
 python = "^3.7.4"


### PR DESCRIPTION
Poetry generates license classifiers based on a [licenses.json@b5d1934](https://github.com/python-poetry/poetry-core/blob/b5d1934fed190bbfd1a303b44d5e2ef9a600efed/src/poetry/core/spdx/data/licenses.json).

At the moment `MIT-0` is not recognized as an existing license and a `Classifier: License :: Other/Proprietary License` is added to the list of classifiers which leads to unexpected behavior from license checkers.

Signed-off-by: Martin <meckhardt@users.noreply.github.com>

<!-- markdownlint-disable MD041 MD043 -->
**Issue number:**

[Maintenance: Add header to LICENSE #1881](https://github.com/awslabs/aws-lambda-powertools-python/issues/1881)

## Summary

### Changes

Updated poetry configuration.

### User experience

License checkers should not complain about proprietary licenses. PyPi will signal a MIT and MIT-0 license instead of the proprietary license. 

See current state:

![pic](https://user-images.githubusercontent.com/827666/216032858-8641007e-fb6a-4f69-b304-dd98de2c3835.png)
Source https://pypi.org/project/aws-lambda-powertools/

The resulting PKG-INFO should look like

```plain
# PKG-INFO
Metadata-Version: 2.1
Name: aws-lambda-powertools
Version: 2.7.0
Summary: A suite of utilities for AWS Lambda functions to ease adopting best practices such as tracing, structured logging, custom metrics, batching, idempotency, feature flags, and more.
Home-page: https://github.com/awslabs/aws-lambda-powertools-python
License: MIT
...
Classifier: License :: OSI Approved :: MIT License
Classifier: License :: OSI Approved :: MIT No Attribution License (MIT-0)
...
```

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] [Meet tenets criteria](https://awslabs.github.io/aws-lambda-powertools-python/#tenets)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented
* [x] PR title follows [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-python/blob/develop/.github/semantic.yml)

<details>
<summary>Is this a breaking change?</summary>

Yes. The PKG-INFO in the distribution package will change. The `Classifier: License :: Other/Proprietary License` classifier will be removed and besides the `Classifier: License :: OSI Approved :: MIT License` classifier an additional `License :: OSI Approved :: MIT No Attribution License (MIT-0)` will be added through the use of trove_classifiers.

However, from my point of view, it should match with other distributions of the Lambda Power Tools, e.g. https://www.npmjs.com/package/@aws-lambda-powertools/metrics and should not raise any issues from other users, as the license becomes more relaxed.

However, when Poetry / Poetry Core will support MIT-0, this breaking change would implicitly occur without any notification.

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
