### PR TITLE
docs(homepage): fix the link in the end-of-support v1 banner

### DIFF
--- a/docs/overrides/main.html
+++ b/docs/overrides/main.html
@@ -2,7 +2,7 @@
 
 {% block announce %}
 👋 Powertools for Python v1 will no longer receive updates or releases after 31/03/2023!
-We encourage you to read our <a href="/upgrade/#end-of-support-v1">upgrade guide on how to migrate to v2</a>.
+We encourage you to read our <a href="https://awslabs.github.io/aws-lambda-powertools-python/2.7.1/upgrade/#end-of-support-v1">upgrade guide on how to migrate to v2</a>.
 {% endblock %}
 
 {% block outdated %}

--- a/docs/overrides/main.html
+++ b/docs/overrides/main.html
@@ -2,7 +2,7 @@
 
 {% block announce %}
 👋 Powertools for Python v1 will no longer receive updates or releases after 31/03/2023!
-We encourage you to read our <a href="https://awslabs.github.io/aws-lambda-powertools-python/2.7.1/upgrade/#end-of-support-v1">upgrade guide on how to migrate to v2</a>.
+We encourage you to read our <a href="https://awslabs.github.io/aws-lambda-powertools-python/latest/upgrade/#end-of-support-v1">upgrade guide on how to migrate to v2</a>.
 {% endblock %}
 
 {% block outdated %}


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
**Issue number:** #1891  

## Summary

### Changes

The link has a problem when the user is browsing a page outside the homepage

### User experience

> Please share what the user experience looks like before and after this change

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] [Meet tenets criteria](https://awslabs.github.io/aws-lambda-powertools-python/#tenets)
* [x] I have performed a self-review of this change
* [ ] Changes have been tested
* [x] Changes are documented
* [x] PR title follows [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-python/blob/develop/.github/semantic.yml)

<details>
<summary>Is this a breaking change?</summary>

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
