### PR TITLE
docs(homepage): set url for end-of-support in announce block

### DIFF
--- a/docs/overrides/main.html
+++ b/docs/overrides/main.html
@@ -2,7 +2,7 @@
 
 {% block announce %}
 👋 Powertools for Python v1 will no longer receive updates or releases after 31/03/2023!
-We encourage you to read our <a href="/upgrade/#end-of-support-v1">upgrade guide on how to migrate to v2</a>.
+We encourage you to read our <a href="{{ base_url }}/upgrade/#end-of-support-v1">upgrade guide on how to migrate to v2</a>.
 {% endblock %}
 
 {% block outdated %}


### PR DESCRIPTION
**Issue number:** #1891 

chore(homepage): set url for end-of-support in announce block

I was working my way through the docs and I saw that the link for end-of-support-v1 was not working, I fixed it.

Signed-off-by: Luis Valdés <luis@valdes.com.br>