### PR TITLE
fix(feature-flags): revert RuleAction Enum inheritance on str

### DIFF
--- a/aws_lambda_powertools/utilities/feature_flags/schema.py
+++ b/aws_lambda_powertools/utilities/feature_flags/schema.py
@@ -23,7 +23,7 @@ TIME_RANGE_RE_PATTERN = re.compile(r"2[0-3]:[0-5]\d|[0-1]\d:[0-5]\d")  # 24 hour
 HOUR_MIN_SEPARATOR = ":"
 
 
-class RuleAction(Enum):
+class RuleAction(str, Enum):
     EQUALS = "EQUALS"
     NOT_EQUALS = "NOT_EQUALS"
     KEY_GREATER_THAN_VALUE = "KEY_GREATER_THAN_VALUE"


### PR DESCRIPTION
Signed-off-by: royygael <116807865+royygael@users.noreply.github.com>

<!-- markdownlint-disable MD041 MD043 -->
**Issue number:** #1909 

## Summary
The PR #1846 added a breaking change to RuleAction which not serializes the enum thus when used as an enum it breaks.

### Changes
RuleAction should inherent str first to be dict serilizable 


### User experience
Breaking changes that now throws due to dict() func keeps the enum and not gives its value

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [ ] [Meet tenets criteria](https://awslabs.github.io/aws-lambda-powertools-python/#tenets)
* [X] I have performed a self-review of this change
* [X] Changes have been tested
* [ ] Changes are documented
* [x] PR title follows [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-python/blob/develop/.github/semantic.yml)

<details>
<summary>Is this a breaking change?</summary>

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
