### PR TITLE
feat(metrics) - add support for high resolution metrics

### DIFF
--- a/aws_lambda_powertools/metrics/__init__.py
+++ b/aws_lambda_powertools/metrics/__init__.py
@@ -1,7 +1,12 @@
 """CloudWatch Embedded Metric Format utility
 """
-from .base import MetricUnit
-from .exceptions import MetricUnitError, MetricValueError, SchemaValidationError
+from .base import MetricResolution, MetricUnit
+from .exceptions import (
+    MetricResolutionError,
+    MetricUnitError,
+    MetricValueError,
+    SchemaValidationError,
+)
 from .metric import single_metric
 from .metrics import EphemeralMetrics, Metrics
 
@@ -11,6 +16,8 @@ __all__ = [
     "single_metric",
     "MetricUnit",
     "MetricUnitError",
+    "MetricResolution",
+    "MetricResolutionError",
     "SchemaValidationError",
     "MetricValueError",
 ]

--- a/aws_lambda_powertools/metrics/base.py
+++ b/aws_lambda_powertools/metrics/base.py
@@ -516,7 +516,7 @@ class SingleMetric(MetricManager):
         name: str,
         unit: Union[MetricUnit, str],
         value: float,
-        resolution: Optional[Union[MetricResolution, int]] = 60,
+        resolution: Union[MetricResolution, int] = 60,
     ) -> None:
         """Method to prevent more than one metric being created
 

--- a/aws_lambda_powertools/metrics/base.py
+++ b/aws_lambda_powertools/metrics/base.py
@@ -421,17 +421,14 @@ class MetricManager:
             When metric resolution is not supported by CloudWatch
         """
 
-        if isinstance(resolution, int):
-            if resolution in self._metric_resolution_valid_options:
-                resolution = MetricResolution[str(resolution)].value
-
-            if resolution not in self._metric_resolutions:
-                raise MetricResolutionError(
-                    f"Invalid metric resolution '{resolution}', expected either option: {self._metric_resolution_valid_options}"  # noqa: E501
-                )
-
         if isinstance(resolution, MetricResolution):
             resolution = resolution.value
+            return resolution
+
+        if isinstance(resolution, int) and resolution not in self._metric_resolutions:
+            raise MetricResolutionError(
+                f"Invalid metric resolution '{resolution}', expected either option: {self._metric_resolution_valid_options}"  # noqa: E501
+            )
 
         return resolution
 

--- a/aws_lambda_powertools/metrics/base.py
+++ b/aws_lambda_powertools/metrics/base.py
@@ -108,7 +108,6 @@ class MetricManager:
         self._metric_units = [unit.value for unit in MetricUnit]
         self._metric_unit_valid_options = list(MetricUnit.__members__)
         self._metric_resolutions = [resolution.value for resolution in MetricResolution]
-        self._metric_resolution_valid_options = list(MetricResolution.__members__)
 
     def add_metric(
         self,
@@ -427,7 +426,7 @@ class MetricManager:
 
         if isinstance(resolution, int) and resolution not in self._metric_resolutions:
             raise MetricResolutionError(
-                f"Invalid metric resolution '{resolution}', expected either option: {self._metric_resolution_valid_options}"  # noqa: E501
+                f"Invalid metric resolution '{resolution}', expected either option: {self._metric_resolutions}"  # noqa: E501
             )
 
         return resolution

--- a/aws_lambda_powertools/metrics/base.py
+++ b/aws_lambda_powertools/metrics/base.py
@@ -542,7 +542,7 @@ def single_metric(
     name: str,
     unit: MetricUnit,
     value: float,
-    resolution: Optional[Union[MetricResolution, int]] = 60,
+    resolution: Union[MetricResolution, int] = 60,
     namespace: Optional[str] = None,
     default_dimensions: Optional[Dict[str, str]] = None,
 ) -> Generator[SingleMetric, None, None]:

--- a/aws_lambda_powertools/metrics/base.py
+++ b/aws_lambda_powertools/metrics/base.py
@@ -419,17 +419,15 @@ class MetricManager:
         MetricResolutionError
             When metric resolution is not supported by CloudWatch
         """
-
         if isinstance(resolution, MetricResolution):
-            resolution = resolution.value
+            return resolution.value
+
+        if isinstance(resolution, int) and resolution in self._metric_resolutions:
             return resolution
 
-        if isinstance(resolution, int) and resolution not in self._metric_resolutions:
-            raise MetricResolutionError(
-                f"Invalid metric resolution '{resolution}', expected either option: {self._metric_resolutions}"  # noqa: E501
-            )
-
-        return resolution
+        raise MetricResolutionError(
+            f"Invalid metric resolution '{resolution}', expected either option: {self._metric_resolutions}"  # noqa: E501
+        )
 
     def _extract_metric_unit_value(self, unit: Union[str, MetricUnit]) -> str:
         """Return metric value from metric unit whether that's str or MetricUnit enum

--- a/aws_lambda_powertools/metrics/exceptions.py
+++ b/aws_lambda_powertools/metrics/exceptions.py
@@ -4,6 +4,12 @@ class MetricUnitError(Exception):
     pass
 
 
+class MetricResolutionError(Exception):
+    """When metric resolution is not supported by CloudWatch"""
+
+    pass
+
+
 class SchemaValidationError(Exception):
     """When serialization fail schema validation"""
 

--- a/aws_lambda_powertools/metrics/metrics.py
+++ b/aws_lambda_powertools/metrics/metrics.py
@@ -50,7 +50,9 @@ class Metrics(MetricManager):
     Raises
     ------
     MetricUnitError
-        When metric metric isn't supported by CloudWatch
+        When metric unit isn't supported by CloudWatch
+    MetricResolutionError
+        When metric resolution isn't supported by CloudWatch
     MetricValueError
         When metric value isn't a number
     SchemaValidationError

--- a/aws_lambda_powertools/metrics/types.py
+++ b/aws_lambda_powertools/metrics/types.py
@@ -1,0 +1,7 @@
+from typing_extensions import NotRequired, TypedDict
+
+
+class MetricNameUnitResolution(TypedDict):
+    Name: str
+    Unit: str
+    StorageResolution: NotRequired[int]

--- a/docs/core/metrics.md
+++ b/docs/core/metrics.md
@@ -20,6 +20,9 @@ If you're new to Amazon CloudWatch, there are two terminologies you must be awar
 
 * **Namespace**. It's the highest level container that will group multiple metrics from multiple services for a given application, for example `ServerlessEcommerce`.
 * **Dimensions**. Metrics metadata in key-value format. They help you slice and dice metrics visualization, for example `ColdStart` metric by Payment `service`.
+* **Metric**. It's the name of the metric, for example: `SuccessfulBooking` or `UpdatedBooking`.
+* **Unit**. It's a value representing the unit of measure for the corresponding metric, for example: `Count` or `Seconds`.
+* **Resolution**. It's a value representing the storage resolution for the corresponding metric. Metrics can be either Standard or High resolution. Read more [here](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/publishingMetrics.html#high-resolution-metrics).
 
 <figure>
   <img src="../../media/metrics_terminology.png" />
@@ -82,9 +85,12 @@ You can create metrics using `add_metric`, and you can create dimensions for all
 
 You can create [high-resolution metrics](https://aws.amazon.com/pt/about-aws/whats-new/2023/02/amazon-cloudwatch-high-resolution-metric-extraction-structured-logs/) passing `resolution` parameter to `add_metric`.
 
+???+ tip "High-resolution metrics - when is it useful?"
+    High-resolution metrics are data with a granularity of one second and are very useful in several situations such as telemetry, time series, real-time incident management, and others.
+
 === "add_high_resolution_metrics.py"
 
-    ```python hl_lines="14-15"
+    ```python hl_lines="10"
     --8<-- "examples/metrics/src/add_high_resolution_metric.py"
     ```
 

--- a/docs/core/metrics.md
+++ b/docs/core/metrics.md
@@ -78,6 +78,19 @@ You can create metrics using `add_metric`, and you can create dimensions for all
 ???+ warning "Warning: Do not create metrics or dimensions outside the handler"
     Metrics or dimensions added in the global scope will only be added during cold start. Disregard if you that's the intended behavior.
 
+### Adding high-resolution metrics
+
+You can create [high-resolution metrics](https://aws.amazon.com/pt/about-aws/whats-new/2023/02/amazon-cloudwatch-high-resolution-metric-extraction-structured-logs/) passing `resolution` parameter to `add_metric`.
+
+=== "add_high_resolution_metrics.py"
+
+    ```python hl_lines="14-15"
+    --8<-- "examples/metrics/src/add_high_resolution_metric.py"
+    ```
+
+???+ tip "Tip: Autocomplete Metric Resolutions"
+    `MetricResolution` enum facilitates finding a supported metric resolution by CloudWatch. Alternatively, you can pass the values 1 or 60 (must be one of them) as an integer _e.g. `resolution=1`_.
+
 ### Adding multi-value metrics
 
 You can call `add_metric()` with the same metric name multiple times. The values will be grouped together in a list.

--- a/examples/metrics/src/add_high_resolution_metric.py
+++ b/examples/metrics/src/add_high_resolution_metric.py
@@ -1,0 +1,10 @@
+from aws_lambda_powertools import Metrics
+from aws_lambda_powertools.metrics import MetricResolution, MetricUnit
+from aws_lambda_powertools.utilities.typing import LambdaContext
+
+metrics = Metrics()
+
+
+@metrics.log_metrics  # ensures metrics are flushed upon request completion/failure
+def lambda_handler(event: dict, context: LambdaContext):
+    metrics.add_metric(name="SuccessfulBooking", unit=MetricUnit.Count, value=1, resolution=MetricResolution.High)

--- a/tests/e2e/metrics/test_metrics.py
+++ b/tests/e2e/metrics/test_metrics.py
@@ -49,6 +49,26 @@ def test_basic_lambda_metric_is_visible(basic_handler_fn: str, basic_handler_fn_
 
 
 @pytest.mark.xdist_group(name="metrics")
+def test_metric_with_high_resolution(basic_handler_fn: str, basic_handler_fn_arn: str):
+    # GIVEN
+    metric_name = data_builder.build_metric_name()
+    service = data_builder.build_service_name()
+    dimensions = data_builder.build_add_dimensions_input(service=service)
+    metrics = data_builder.build_multiple_add_metric_input(metric_name=metric_name, value=1, quantity=3, resolution=1)
+
+    # WHEN
+    event = json.dumps({"metrics": metrics, "service": service, "namespace": METRIC_NAMESPACE})
+    _, execution_time = data_fetcher.get_lambda_response(lambda_arn=basic_handler_fn_arn, payload=event)
+
+    metric_values = data_fetcher.get_metrics(
+        namespace=METRIC_NAMESPACE, start_date=execution_time, metric_name=metric_name, dimensions=dimensions
+    )
+
+    # THEN
+    assert metric_values == [3.0]
+
+
+@pytest.mark.xdist_group(name="metrics")
 def test_cold_start_metric(cold_start_fn_arn: str, cold_start_fn: str):
     # GIVEN
     metric_name = "ColdStart"

--- a/tests/e2e/metrics/test_metrics.py
+++ b/tests/e2e/metrics/test_metrics.py
@@ -49,26 +49,6 @@ def test_basic_lambda_metric_is_visible(basic_handler_fn: str, basic_handler_fn_
 
 
 @pytest.mark.xdist_group(name="metrics")
-def test_metric_with_high_resolution(basic_handler_fn: str, basic_handler_fn_arn: str):
-    # GIVEN
-    metric_name = data_builder.build_metric_name()
-    service = data_builder.build_service_name()
-    dimensions = data_builder.build_add_dimensions_input(service=service)
-    metrics = data_builder.build_multiple_add_metric_input(metric_name=metric_name, value=1, quantity=3, resolution=1)
-
-    # WHEN
-    event = json.dumps({"metrics": metrics, "service": service, "namespace": METRIC_NAMESPACE})
-    _, execution_time = data_fetcher.get_lambda_response(lambda_arn=basic_handler_fn_arn, payload=event)
-
-    metric_values = data_fetcher.get_metrics(
-        namespace=METRIC_NAMESPACE, start_date=execution_time, metric_name=metric_name, dimensions=dimensions
-    )
-
-    # THEN
-    assert metric_values == [3.0]
-
-
-@pytest.mark.xdist_group(name="metrics")
 def test_cold_start_metric(cold_start_fn_arn: str, cold_start_fn: str):
     # GIVEN
     metric_name = "ColdStart"

--- a/tests/functional/test_metrics.py
+++ b/tests/functional/test_metrics.py
@@ -163,6 +163,22 @@ def test_single_metric_logs_one_metric_only_with_high_resolution(capsys, metric_
     assert expected == output
 
 
+def test_single_metric_logs_with_high_resolution_integer(capsys, metric_with_resolution, dimension, namespace):
+    # GIVEN we have a metric with high resolution as integer
+    metric_with_resolution["resolution"] = MetricResolution.High.value
+
+    # WHEN using single_metric context manager
+    with single_metric(namespace=namespace, **metric_with_resolution) as my_metric:
+        my_metric.add_dimension(**dimension)
+
+    # THEN we should only have the first metric added
+    output = capture_metrics_output(capsys)
+    expected = serialize_single_metric(metric=metric_with_resolution, dimension=dimension, namespace=namespace)
+
+    remove_timestamp(metrics=[output, expected])
+    assert expected == output
+
+
 def test_single_metric_logs_one_metric_only(capsys, metric, dimension, namespace):
     # GIVEN we try adding more than one metric
     # WHEN using single_metric context manager

--- a/tests/functional/test_metrics.py
+++ b/tests/functional/test_metrics.py
@@ -391,6 +391,18 @@ def test_schema_validation_incorrect_metric_resolution(metric, dimension):
             my_metric.add_dimension(**dimension)
 
 
+@pytest.mark.parametrize("resolution", ["sixty", False, [], {}, object])
+def test_schema_validation_incorrect_metric_resolution_non_integer_enum(metric, dimension, resolution, namespace):
+    # GIVEN we pass a metric resolution that is not supported by CloudWatch
+    metric["resolution"] = resolution  # metric resolution must be 1 (High) or 60 (Standard)
+
+    # WHEN we try adding a new metric
+    # THEN it should fail metric unit validation
+    with pytest.raises(MetricResolutionError, match="Invalid metric resolution.*60"):
+        with single_metric(namespace=namespace, **metric) as my_metric:
+            my_metric.add_dimension(**dimension)
+
+
 def test_schema_validation_incorrect_metric_unit(metric, dimension, namespace):
     # GIVEN we pass a metric unit that is not supported by CloudWatch
     metric["unit"] = "incorrect_unit"

--- a/tests/functional/test_metrics.py
+++ b/tests/functional/test_metrics.py
@@ -148,17 +148,16 @@ def capture_metrics_output_multiple_emf_objects(capsys):
     return [json.loads(line.strip()) for line in capsys.readouterr().out.split("\n") if line]
 
 
-def test_single_metric_logs_one_metric_only_with_high_resolution(capsys, metric_with_resolution, dimension, namespace):
-    # GIVEN we try adding more than one metric
+def test_single_metric_logs_with_high_resolution_enum(capsys, metric_with_resolution, dimension, namespace):
+    # GIVEN we have a metric with high resolution as enum
     # WHEN using single_metric context manager
     with single_metric(namespace=namespace, **metric_with_resolution) as my_metric:
-        my_metric.add_metric(name="second_metric", unit="Count", value=1, resolution=1)
         my_metric.add_dimension(**dimension)
 
+    # THEN we should only have the first metric added
     output = capture_metrics_output(capsys)
     expected = serialize_single_metric(metric=metric_with_resolution, dimension=dimension, namespace=namespace)
 
-    # THEN we should only have the first metric added
     remove_timestamp(metrics=[output, expected])
     assert expected == output
 

--- a/tests/functional/test_metrics.py
+++ b/tests/functional/test_metrics.py
@@ -380,13 +380,13 @@ def test_log_metrics_decorator_call_decorated_function(metric, namespace, servic
     assert lambda_handler({}, {}) is True
 
 
-def test_schema_validation_incorrect_metric_resolution(metric, dimension, namespace):
+def test_schema_validation_incorrect_metric_resolution(metric, dimension):
     # GIVEN we pass a metric resolution that is not supported by CloudWatch
     metric["resolution"] = 10  # metric resolution must be 1 (High) or 60 (Standard)
 
     # WHEN we try adding a new metric
     # THEN it should fail metric unit validation
-    with pytest.raises(MetricResolutionError):
+    with pytest.raises(MetricResolutionError, match="Invalid metric resolution.*60"):
         with single_metric(**metric) as my_metric:
             my_metric.add_dimension(**dimension)
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
**Issue number:** #1908 

## Summary

### Changes

Added new parameter to [Metrics.add_metric](https://github.com/awslabs/aws-lambda-powertools-python/blob/develop/aws_lambda_powertools/metrics/base.py?rgh-link-date=2023-02-08T10%3A51%3A51Z#L98) to support high resolution metrics, the latest Amazon Cloudwatch feature - https://aws.amazon.com/en/about-aws/whats-new/2023/02/amazon-cloudwatch-high-resolution-metric-extraction-structured-logs/

If the user does not send the resolution parameter, the default value (**60**) will be assumed according to [AWS documentation](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch_Embedded_Metric_Format_Specification.html).

> StorageResolution— An OPTIONAL integer value representing the storage resolution for the corresponding metric. Setting this to 1 specifies this metric as a high-resolution metric, so that CloudWatch stores the metric with sub-minute resolution down to one second. Setting this to 60 specifies this metric as standard-resolution, which CloudWatch stores at 1-minute resolution. Values SHOULD be valid CloudWatch supported resolutions, 1 or 60. If a value is not provided, then a default value of 60 is assumed.

### User experience

Before
```python
from aws_lambda_powertools import Metrics
from aws_lambda_powertools.metrics import MetricUnit
from aws_lambda_powertools.utilities.typing import LambdaContext

metrics = Metrics()


@metrics.log_metrics  # ensures metrics are flushed upon request completion/failure
def lambda_handler(event: dict, context: LambdaContext):
    metrics.add_metric(name="SuccessfulUpgrade", unit=MetricUnit.Count, value=1)
```

After
```python
from aws_lambda_powertools import Metrics
from aws_lambda_powertools.metrics import MetricUnit, MetricResolution
from aws_lambda_powertools.utilities.typing import LambdaContext

metrics = Metrics()


@metrics.log_metrics  # ensures metrics are flushed upon request completion/failure
def lambda_handler(event: dict, context: LambdaContext):
    # Publish a metric with standard resolution i.e. StorageResolution = 60
    metrics.add_metric(name="SuccessfulBooking", unit=MetricUnit.Count, value=1, resolution=MetricResolution.Standard)

    # Publish a metric with high resolution i.e. StorageResolution = 1
    metrics.add_metric(name="FailedBooking", unit=MetricUnit.Count, value=1, resolution=MetricResolution.High)

    # The last parameter (storage resolution) is optional
    metrics.add_metric(name="SuccessfulUpgrade", unit=MetricUnit.Count, value=1)
```

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] [Meet tenets criteria](https://awslabs.github.io/aws-lambda-powertools-python/#tenets)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [ ] Changes are documented
* [x] PR title follows [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-python/blob/develop/.github/semantic.yml)

<details>
<summary>Is this a breaking change?</summary>

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
