### PR TITLE
docs(homepage): Replace poetry command to add group parameter

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -49,7 +49,7 @@ Powertools relies on the AWS SDK bundled in the Lambda runtime. This helps us ac
 This means you need to add AWS SDK as a development dependency (not as a production dependency).
 
 * **Pip**: `pip install "aws-lambda-powertools[aws-sdk]"`
-* **Poetry**: `poetry add "aws-lambda-powertools[aws-sdk]" --dev`
+* **Poetry**: `poetry add "aws-lambda-powertools[aws-sdk] --group dev"`
 * **Pipenv**: `pipenv install --dev "aws-lambda-powertools[aws-sdk]"`
 
 ???+ note "Local emulation"

--- a/docs/index.md
+++ b/docs/index.md
@@ -49,7 +49,7 @@ Powertools relies on the AWS SDK bundled in the Lambda runtime. This helps us ac
 This means you need to add AWS SDK as a development dependency (not as a production dependency).
 
 * **Pip**: `pip install "aws-lambda-powertools[aws-sdk]"`
-* **Poetry**: `poetry add "aws-lambda-powertools[aws-sdk] --group dev"`
+* **Poetry**: `poetry add "aws-lambda-powertools[aws-sdk]" --group dev`
 * **Pipenv**: `pipenv install --dev "aws-lambda-powertools[aws-sdk]"`
 
 ???+ note "Local emulation"


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
**Issue number:** #1920 

## Summary

### Changes

Poetry changed and deprecated the `--dev` subcommand to define dev dependencies.

Now, they recommend using:

```
poetry add <deps_name> --group <group_name>
```

### User experience

Before:
```
poetry add ... --dev
```
after
```
poetry add ... --group dev
```

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [ ] [Meet tenets criteria](https://awslabs.github.io/aws-lambda-powertools-python/#tenets)
* [ ] I have performed a self-review of this change
* [ ] Changes have been tested
* [ ] Changes are documented
* [x] PR title follows [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-python/blob/develop/.github/semantic.yml)

<details>
<summary>Is this a breaking change?</summary>

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
