### PR TITLE
fix(logger): support exception and exception_name fields at any log level

### DIFF
--- a/aws_lambda_powertools/logging/formatter.py
+++ b/aws_lambda_powertools/logging/formatter.py
@@ -152,7 +152,9 @@ class LambdaPowertoolsFormatter(BasePowertoolsFormatter):
         """Format logging record as structured JSON str"""
         formatted_log = self._extract_log_keys(log_record=record)
         formatted_log["message"] = self._extract_log_message(log_record=record)
-        formatted_log["exception"], formatted_log["exception_name"] = self._extract_log_exception(log_record=record)
+        extracted_exception, extracted_exception_name = self._extract_log_exception(log_record=record)
+        formatted_log["exception"] = formatted_log.get("exception", extracted_exception)
+        formatted_log["exception_name"] = formatted_log.get("exception_name", extracted_exception_name)
         formatted_log["xray_trace_id"] = self._get_latest_trace_id()
         formatted_log = self._strip_none_records(records=formatted_log)
 

--- a/aws_lambda_powertools/logging/formatter.py
+++ b/aws_lambda_powertools/logging/formatter.py
@@ -152,6 +152,8 @@ class LambdaPowertoolsFormatter(BasePowertoolsFormatter):
         """Format logging record as structured JSON str"""
         formatted_log = self._extract_log_keys(log_record=record)
         formatted_log["message"] = self._extract_log_message(log_record=record)
+        # exception and exception_name fields can be added as extra key
+        # in any log level, we try to extract and use them first
         extracted_exception, extracted_exception_name = self._extract_log_exception(log_record=record)
         formatted_log["exception"] = formatted_log.get("exception", extracted_exception)
         formatted_log["exception_name"] = formatted_log.get("exception_name", extracted_exception_name)

--- a/tests/functional/test_logger.py
+++ b/tests/functional/test_logger.py
@@ -253,12 +253,10 @@ def test_logger_append_duplicated(stdout, service_name):
 
 def test_logger_honors_given_exception_keys(stdout, service_name):
     # GIVEN Logger is initialized with exception and exception_name fields
-    logger = Logger(
-        service=service_name, stream=stdout, exception="exception_value", exception_name="exception_name_value"
-    )
+    logger = Logger(service=service_name, stream=stdout)
 
     # WHEN log level info
-    logger.info("log")
+    logger.info("log", exception="exception_value", exception_name="exception_name_value")
 
     # THEN log statements should have these keys
     log = capture_logging_output(stdout)

--- a/tests/functional/test_logger.py
+++ b/tests/functional/test_logger.py
@@ -251,6 +251,20 @@ def test_logger_append_duplicated(stdout, service_name):
     assert "new_value" == log["request_id"]
 
 
+def test_logger_honors_given_exception_keys(stdout, service_name):
+    # GIVEN Logger is initialized with exception and exception_name fields
+    logger = Logger(
+        service=service_name, stream=stdout, exception="exception_value", exception_name="exception_name_value"
+    )
+
+    logger.info("log")
+
+    # THEN log statements should have these keys
+    log = capture_logging_output(stdout)
+    assert "exception_value" == log["exception"]
+    assert "exception_name_value" == log["exception_name"]
+
+
 def test_logger_invalid_sampling_rate(service_name):
     # GIVEN Logger is initialized
     # WHEN sampling_rate non-numeric value

--- a/tests/functional/test_logger.py
+++ b/tests/functional/test_logger.py
@@ -257,6 +257,7 @@ def test_logger_honors_given_exception_keys(stdout, service_name):
         service=service_name, stream=stdout, exception="exception_value", exception_name="exception_name_value"
     )
 
+    # WHEN log level info
     logger.info("log")
 
     # THEN log statements should have these keys


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
**Issue number:** #1923 

## Summary
Providing fix for reporting entry logs with custom exception and exception_name fields 

### Changes

Changed format log to honor `exception` and `exception_name` fields

### User experience

given:

```python
logger.info("Report", extra={"exception": "Oops!  That was not valid", "exception_name": "ValueError" })
```

before:

```json
{
        "level": "INFO",
        "message": "Report"
}
```

after:

```json
{
        "level": "INFO",
        "message": "Report",
        "exception": "Oops!  That was not valid",
        "exception_name": "ValueError",
}
```

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] [Meet tenets criteria](https://awslabs.github.io/aws-lambda-powertools-python/#tenets)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [ ] Changes are documented
* [ ] PR title follows [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-python/blob/develop/.github/semantic.yml)

<details>
<summary>Is this a breaking change?</summary>
no
</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
