### PR TITLE
feat(batch): add support to SQS FIFO queues (SqsFifoPartialProcessor)

### DIFF
--- a/aws_lambda_powertools/utilities/batch/__init__.py
+++ b/aws_lambda_powertools/utilities/batch/__init__.py
@@ -17,7 +17,7 @@ from aws_lambda_powertools.utilities.batch.base import (
 )
 from aws_lambda_powertools.utilities.batch.exceptions import ExceptionInfo
 from aws_lambda_powertools.utilities.batch.sqs_fifo_partial_processor import (
-    SQSFifoPartialProcessor,
+    SqsFifoPartialProcessor,
 )
 from aws_lambda_powertools.utilities.batch.types import BatchTypeModels
 
@@ -31,7 +31,7 @@ __all__ = (
     "EventType",
     "FailureResponse",
     "SuccessResponse",
-    "SQSFifoPartialProcessor",
+    "SqsFifoPartialProcessor",
     "batch_processor",
     "async_batch_processor",
 )

--- a/aws_lambda_powertools/utilities/batch/__init__.py
+++ b/aws_lambda_powertools/utilities/batch/__init__.py
@@ -16,6 +16,9 @@ from aws_lambda_powertools.utilities.batch.base import (
     batch_processor,
 )
 from aws_lambda_powertools.utilities.batch.exceptions import ExceptionInfo
+from aws_lambda_powertools.utilities.batch.sqs_fifo_partial_processor import (
+    SQSFifoPartialProcessor,
+)
 
 __all__ = (
     "BatchProcessor",
@@ -26,6 +29,7 @@ __all__ = (
     "EventType",
     "FailureResponse",
     "SuccessResponse",
+    "SQSFifoPartialProcessor",
     "batch_processor",
     "async_batch_processor",
 )

--- a/aws_lambda_powertools/utilities/batch/__init__.py
+++ b/aws_lambda_powertools/utilities/batch/__init__.py
@@ -19,12 +19,14 @@ from aws_lambda_powertools.utilities.batch.exceptions import ExceptionInfo
 from aws_lambda_powertools.utilities.batch.sqs_fifo_partial_processor import (
     SQSFifoPartialProcessor,
 )
+from aws_lambda_powertools.utilities.batch.types import BatchTypeModels
 
 __all__ = (
     "BatchProcessor",
     "AsyncBatchProcessor",
     "BasePartialProcessor",
     "BasePartialBatchProcessor",
+    "BatchTypeModels",
     "ExceptionInfo",
     "EventType",
     "FailureResponse",

--- a/aws_lambda_powertools/utilities/batch/base.py
+++ b/aws_lambda_powertools/utilities/batch/base.py
@@ -19,7 +19,6 @@ from typing import (
     List,
     Optional,
     Tuple,
-    Type,
     Union,
     overload,
 )
@@ -30,6 +29,7 @@ from aws_lambda_powertools.utilities.batch.exceptions import (
     BatchProcessingError,
     ExceptionInfo,
 )
+from aws_lambda_powertools.utilities.batch.types import BatchTypeModels
 from aws_lambda_powertools.utilities.data_classes.dynamo_db_stream_event import (
     DynamoDBRecord,
 )
@@ -47,24 +47,6 @@ class EventType(Enum):
     KinesisDataStreams = "KinesisDataStreams"
     DynamoDBStreams = "DynamoDBStreams"
 
-
-#
-# type specifics
-#
-has_pydantic = "pydantic" in sys.modules
-
-# For IntelliSense and Mypy to work, we need to account for possible SQS, Kinesis and DynamoDB subclasses
-# We need them as subclasses as we must access their message ID or sequence number metadata via dot notation
-if has_pydantic:
-    from aws_lambda_powertools.utilities.parser.models import DynamoDBStreamRecordModel
-    from aws_lambda_powertools.utilities.parser.models import (
-        KinesisDataStreamRecord as KinesisDataStreamRecordModel,
-    )
-    from aws_lambda_powertools.utilities.parser.models import SqsRecordModel
-
-    BatchTypeModels = Optional[
-        Union[Type[SqsRecordModel], Type[DynamoDBStreamRecordModel], Type[KinesisDataStreamRecordModel]]
-    ]
 
 # When using processor with default arguments, records will carry EventSourceDataClassTypes
 # and depending on what EventType it's passed it'll correctly map to the right record

--- a/aws_lambda_powertools/utilities/batch/sqs_fifo_partial_processor.py
+++ b/aws_lambda_powertools/utilities/batch/sqs_fifo_partial_processor.py
@@ -1,0 +1,101 @@
+import sys
+from typing import List, Optional, Tuple, Type
+
+from aws_lambda_powertools.utilities.batch import BatchProcessor, EventType
+from aws_lambda_powertools.utilities.parser.models import SqsRecordModel
+
+#
+# type specifics
+#
+has_pydantic = "pydantic" in sys.modules
+
+# For IntelliSense and Mypy to work, we need to account for possible SQS subclasses
+# We need them as subclasses as we must access their message ID or sequence number metadata via dot notation
+if has_pydantic:
+    BatchTypeModels = Optional[Type[SqsRecordModel]]
+
+
+class SQSFifoCircuitBreakerError(Exception):
+    """
+    Signals a record not processed due to the SQS FIFO processing being interrupted
+    """
+
+    pass
+
+
+class SQSFifoPartialProcessor(BatchProcessor):
+    """Specialized BatchProcessor subclass that handles FIFO SQS batch records.
+
+    As soon as the processing of the first record fails, the remaining records
+    are marked as failed without processing, and returned as native partial responses.
+
+    Example
+    _______
+
+    ## Process batch triggered by a FIFO SQS
+
+    ```python
+    import json
+
+    from aws_lambda_powertools import Logger, Tracer
+    from aws_lambda_powertools.utilities.batch import SQSFifoPartialProcessor, EventType, batch_processor
+    from aws_lambda_powertools.utilities.data_classes.sqs_event import SQSRecord
+    from aws_lambda_powertools.utilities.typing import LambdaContext
+
+
+    processor = SQSFifoPartialProcessor()
+    tracer = Tracer()
+    logger = Logger()
+
+
+    @tracer.capture_method
+    def record_handler(record: SQSRecord):
+        payload: str = record.body
+        if payload:
+            item: dict = json.loads(payload)
+        ...
+
+    @logger.inject_lambda_context
+    @tracer.capture_lambda_handler
+    @batch_processor(record_handler=record_handler, processor=processor)
+    def lambda_handler(event, context: LambdaContext):
+        return processor.response()
+    ```
+    """
+
+    circuitBreakerError = SQSFifoCircuitBreakerError("A previous record failed processing.")
+
+    def __init__(self, model: Optional["BatchTypeModels"] = None):
+        super().__init__(EventType.SQS, model)
+
+    def process(self) -> List[Tuple]:
+        result: List[Tuple] = []
+
+        for i, record in enumerate(self.records):
+            """
+            If we have failed messages, it means that the last message failed.
+            We then short circuit the process, failing the remaining messages
+            """
+            if self.fail_messages:
+                return self._short_circuit_processing(i, result)
+
+            """
+            Otherwise, process the message normally
+            """
+            result.append(self._process_record(record))
+
+        return result
+
+    def _short_circuit_processing(self, first_failure_index: int, result: List[Tuple]) -> List[Tuple]:
+        remaining_records = self.records[first_failure_index:]
+        for remaining_record in remaining_records:
+            data = self._to_batch_type(record=remaining_record, event_type=self.event_type, model=self.model)
+            result.append(
+                self.failure_handler(
+                    record=data, exception=(type(self.circuitBreakerError), self.circuitBreakerError, None)
+                )
+            )
+        return result
+
+    async def _async_process_record(self, record: dict):
+        raise NotImplementedError()

--- a/aws_lambda_powertools/utilities/batch/sqs_fifo_partial_processor.py
+++ b/aws_lambda_powertools/utilities/batch/sqs_fifo_partial_processor.py
@@ -12,7 +12,7 @@ class SQSFifoCircuitBreakerError(Exception):
     pass
 
 
-class SQSFifoPartialProcessor(BatchProcessor):
+class SqsFifoPartialProcessor(BatchProcessor):
     """Process native partial responses from SQS FIFO queues.
 
     Stops processing records when the first record fails. The remaining records are reported as failed items.
@@ -26,12 +26,12 @@ class SQSFifoPartialProcessor(BatchProcessor):
     import json
 
     from aws_lambda_powertools import Logger, Tracer
-    from aws_lambda_powertools.utilities.batch import SQSFifoPartialProcessor, EventType, batch_processor
+    from aws_lambda_powertools.utilities.batch import SqsFifoPartialProcessor, EventType, batch_processor
     from aws_lambda_powertools.utilities.data_classes.sqs_event import SQSRecord
     from aws_lambda_powertools.utilities.typing import LambdaContext
 
 
-    processor = SQSFifoPartialProcessor()
+    processor = SqsFifoPartialProcessor()
     tracer = Tracer()
     logger = Logger()
 

--- a/aws_lambda_powertools/utilities/batch/types.py
+++ b/aws_lambda_powertools/utilities/batch/types.py
@@ -1,0 +1,24 @@
+#
+# type specifics
+#
+import sys
+from typing import Optional, Type, Union
+
+has_pydantic = "pydantic" in sys.modules
+
+# For IntelliSense and Mypy to work, we need to account for possible SQS subclasses
+# We need them as subclasses as we must access their message ID or sequence number metadata via dot notation
+if False and has_pydantic:
+    from aws_lambda_powertools.utilities.parser.models import DynamoDBStreamRecordModel
+    from aws_lambda_powertools.utilities.parser.models import (
+        KinesisDataStreamRecord as KinesisDataStreamRecordModel,
+    )
+    from aws_lambda_powertools.utilities.parser.models import SqsRecordModel
+
+    BatchTypeModels = Optional[
+        Union[Type[SqsRecordModel], Type[DynamoDBStreamRecordModel], Type[KinesisDataStreamRecordModel]]
+    ]
+    BatchSqsTypeModel = Optional[Type[SqsRecordModel]]
+else:
+    BatchTypeModels = Optional  # type: ignore
+    BatchSqsTypeModel = Optional  # type: ignore

--- a/aws_lambda_powertools/utilities/batch/types.py
+++ b/aws_lambda_powertools/utilities/batch/types.py
@@ -20,5 +20,5 @@ if has_pydantic:
     ]
     BatchSqsTypeModel = Optional[Type[SqsRecordModel]]
 else:
-    BatchTypeModels = Optional  # type: ignore
-    BatchSqsTypeModel = Optional  # type: ignore
+    BatchTypeModels = "BatchTypeModels"  # type: ignore
+    BatchSqsTypeModel = "BatchSqsTypeModel"  # type: ignore

--- a/aws_lambda_powertools/utilities/batch/types.py
+++ b/aws_lambda_powertools/utilities/batch/types.py
@@ -8,7 +8,7 @@ has_pydantic = "pydantic" in sys.modules
 
 # For IntelliSense and Mypy to work, we need to account for possible SQS subclasses
 # We need them as subclasses as we must access their message ID or sequence number metadata via dot notation
-if False and has_pydantic:
+if has_pydantic:
     from aws_lambda_powertools.utilities.parser.models import DynamoDBStreamRecordModel
     from aws_lambda_powertools.utilities.parser.models import (
         KinesisDataStreamRecord as KinesisDataStreamRecordModel,

--- a/docs/utilities/batch.md
+++ b/docs/utilities/batch.md
@@ -349,8 +349,7 @@ Processing batches from SQS works in four stages:
 
 #### FIFO queues
 
-When using [SQS FIFO queues](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/FIFO-queues.html){target="_blank"},
-We will stop processing messages after the first failure, and return all failed and unprocessed messages in `batchItemFailures`.
+When using [SQS FIFO queues](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/FIFO-queues.html){target="_blank"}, we will stop processing messages after the first failure, and return all failed and unprocessed messages in `batchItemFailures`.
 This helps preserve the ordering of messages in your queue.
 
 === "As a decorator"

--- a/docs/utilities/batch.md
+++ b/docs/utilities/batch.md
@@ -349,8 +349,8 @@ Processing batches from SQS works in four stages:
 
 #### FIFO queues
 
-If you're using this feature with a FIFO queue, you should use the `SQSFifoPartialProcessor` class instead. We will
-stop processing messages after the first failure, and return all failed and unprocessed messages in `batchItemFailures`.
+When using [SQS FIFO queues](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/FIFO-queues.html){target="_blank"},
+We will stop processing messages after the first failure, and return all failed and unprocessed messages in `batchItemFailures`.
 This helps preserve the ordering of messages in your queue.
 
 === "As a decorator"

--- a/docs/utilities/batch.md
+++ b/docs/utilities/batch.md
@@ -347,6 +347,24 @@ Processing batches from SQS works in four stages:
     }
     ```
 
+#### FIFO queues
+
+If you're using this feature with a FIFO queue, you should use the `SQSFifoPartialProcessor` class instead. We will
+stop processing messages after the first failure, and return all failed and unprocessed messages in `batchItemFailures`.
+This helps preserve the ordering of messages in your queue.
+
+=== "As a decorator"
+
+    ```python hl_lines="5 11"
+    --8<-- "examples/batch_processing/src/sqs_fifo_batch_processor.py"
+    ```
+
+=== "As a context manager"
+
+    ```python hl_lines="4 8"
+    --8<-- "examples/batch_processing/src/sqs_fifo_batch_processor_context_manager.py"
+    ```
+
 ### Processing messages from Kinesis
 
 Processing batches from Kinesis works in four stages:

--- a/examples/batch_processing/src/sqs_fifo_batch_processor.py
+++ b/examples/batch_processing/src/sqs_fifo_batch_processor.py
@@ -1,12 +1,12 @@
 from aws_lambda_powertools import Logger, Tracer
 from aws_lambda_powertools.utilities.batch import (
-    SQSFifoPartialProcessor,
+    SqsFifoPartialProcessor,
     batch_processor,
 )
 from aws_lambda_powertools.utilities.data_classes.sqs_event import SQSRecord
 from aws_lambda_powertools.utilities.typing import LambdaContext
 
-processor = SQSFifoPartialProcessor()
+processor = SqsFifoPartialProcessor()
 tracer = Tracer()
 logger = Logger()
 

--- a/examples/batch_processing/src/sqs_fifo_batch_processor.py
+++ b/examples/batch_processing/src/sqs_fifo_batch_processor.py
@@ -1,0 +1,23 @@
+from aws_lambda_powertools import Logger, Tracer
+from aws_lambda_powertools.utilities.batch import (
+    SQSFifoPartialProcessor,
+    batch_processor,
+)
+from aws_lambda_powertools.utilities.data_classes.sqs_event import SQSRecord
+from aws_lambda_powertools.utilities.typing import LambdaContext
+
+processor = SQSFifoPartialProcessor()
+tracer = Tracer()
+logger = Logger()
+
+
+@tracer.capture_method
+def record_handler(record: SQSRecord):
+    ...
+
+
+@logger.inject_lambda_context
+@tracer.capture_lambda_handler
+@batch_processor(record_handler=record_handler, processor=processor)
+def lambda_handler(event, context: LambdaContext):
+    return processor.response()

--- a/examples/batch_processing/src/sqs_fifo_batch_processor_context_manager.py
+++ b/examples/batch_processing/src/sqs_fifo_batch_processor_context_manager.py
@@ -1,9 +1,9 @@
 from aws_lambda_powertools import Logger, Tracer
-from aws_lambda_powertools.utilities.batch import SQSFifoPartialProcessor
+from aws_lambda_powertools.utilities.batch import SqsFifoPartialProcessor
 from aws_lambda_powertools.utilities.data_classes.sqs_event import SQSRecord
 from aws_lambda_powertools.utilities.typing import LambdaContext
 
-processor = SQSFifoPartialProcessor()
+processor = SqsFifoPartialProcessor()
 tracer = Tracer()
 logger = Logger()
 

--- a/examples/batch_processing/src/sqs_fifo_batch_processor_context_manager.py
+++ b/examples/batch_processing/src/sqs_fifo_batch_processor_context_manager.py
@@ -1,0 +1,23 @@
+from aws_lambda_powertools import Logger, Tracer
+from aws_lambda_powertools.utilities.batch import SQSFifoPartialProcessor
+from aws_lambda_powertools.utilities.data_classes.sqs_event import SQSRecord
+from aws_lambda_powertools.utilities.typing import LambdaContext
+
+processor = SQSFifoPartialProcessor()
+tracer = Tracer()
+logger = Logger()
+
+
+@tracer.capture_method
+def record_handler(record: SQSRecord):
+    ...
+
+
+@logger.inject_lambda_context
+@tracer.capture_lambda_handler
+def lambda_handler(event, context: LambdaContext):
+    batch = event["Records"]
+    with processor(records=batch, handler=record_handler):
+        processor.process()  # kick off processing, return List[Tuple]
+
+    return processor.response()

--- a/tests/functional/test_utilities_batch.py
+++ b/tests/functional/test_utilities_batch.py
@@ -42,7 +42,7 @@ from tests.functional.utils import b64_to_str, str_to_b64
 def sqs_event_factory() -> Callable:
     def factory(body: str):
         return {
-            "messageId": str(uuid.uuid4()),
+            "messageId": f"{uuid.uuid4()}",
             "receiptHandle": "AQEBwJnKyrHigUMZj6rYigCgxlaS3SLy0a",
             "body": body,
             "attributes": {


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
**Issue number:** #1927

## Summary

### Changes

> Please provide a summary of what's being changed

This PR adds support for SQS FIFO queues on the Batch Processing utility.

From [docs](https://docs.aws.amazon.com/lambda/latest/dg/with-sqs.html#services-sqs-batchfailurereporting):

> If you're using this feature with a FIFO queue, your function should stop processing messages after the first failure and return all failed and unprocessed messages in `batchItemFailures`. This helps preserve the ordering of messages in your queue.

### User experience

> Please share what the user experience looks like before and after this change

Before this change, using the `BatchProcessor` with an SQS FIFO would result into undefined behaviour, as we were still continuing to process records after the first failure.

Using the new specialized class `SqsFifoPartialProcessor` makes the utility safe to use with SQS FIFO.

![carbon (37)](https://user-images.githubusercontent.com/10713/220101632-26b6b5e9-7d8b-44a8-9331-7b4f2f58d685.png)

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] [Meet tenets criteria](https://awslabs.github.io/aws-lambda-powertools-python/#tenets)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented
* [x] PR title follows [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-python/blob/develop/.github/semantic.yml)

<details>
<summary>Is this a breaking change?</summary>

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
