### PR TITLE
fix(metrics): clarify no-metrics user warning

### DIFF
--- a/aws_lambda_powertools/metrics/base.py
+++ b/aws_lambda_powertools/metrics/base.py
@@ -391,7 +391,11 @@ class MetricManager:
                     self._add_cold_start_metric(context=context)
             finally:
                 if not raise_on_empty_metrics and not self.metric_set:
-                    warnings.warn("No metrics to publish, skipping", stacklevel=2)
+                    warnings.warn(
+                        "No application metrics to publish. The cold-start metric may be published if enabled. "
+                        "If application metrics should never be empty, consider using 'raise_on_empty_metrics'",
+                        stacklevel=2,
+                    )
                 else:
                     metrics = self.serialize_metric_set()
                     self.clear_metrics()

--- a/tests/functional/test_metrics.py
+++ b/tests/functional/test_metrics.py
@@ -728,7 +728,10 @@ def test_log_metrics_decorator_no_metrics_warning(dimensions, namespace, service
         warnings.simplefilter("default")
         lambda_handler({}, {})
         assert len(w) == 1
-        assert str(w[-1].message) == "No metrics to publish, skipping"
+        assert str(w[-1].message) == (
+            "No application metrics to publish. The cold-start metric may be published if enabled. "
+            "If application metrics should never be empty, consider using 'raise_on_empty_metrics'"
+        )
 
 
 def test_log_metrics_with_implicit_dimensions_called_twice(capsys, metric, namespace, service):


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
**Issue number:** #1926

## Summary

### Changes

> Please provide a summary of what's being changed

The user warning message printed when metrics are enabled but there are no application metrics to flush was changed to clarify
the behaviour.

### User experience

> Please share what the user experience looks like before and after this change

Previously, the message was very broad and could lead the user to believe that the cold start metric was not sent.

With this change, the message is now clear that the warning only applies to application metrics, and that the cold 
start metric is still sent if enabled.

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] [Meet tenets criteria](https://awslabs.github.io/aws-lambda-powertools-python/#tenets)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented
* [x] PR title follows [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-python/blob/develop/.github/semantic.yml)

<details>
<summary>Is this a breaking change?</summary>

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
