### PR TITLE
docs(event-handler): Fix REST API - HTTP Methods documentation

### DIFF
--- a/docs/core/event_handler/api_gateway.md
+++ b/docs/core/event_handler/api_gateway.md
@@ -166,7 +166,7 @@ You can also combine nested paths with greedy regex to catch in between routes.
 
 ### HTTP Methods
 
-You can use named decorators to specify the HTTP method that should be handled in your functions. That is, `app.<http_method>`, where the HTTP method could be `get`, `post`, `put`, `patch`, `delete`, and `options`.
+You can use named decorators to specify the HTTP method that should be handled in your functions. That is, `app.<http_method>`, where the HTTP method could be `get`, `post`, `put`, `patch` and `delete`.
 
 === "http_methods.py"
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
**Issue number:** #1922 

## Summary

### Changes

Removed HTTP options from the documentation. Since we are not implementing this HTTP Method, the documentation was wrong.

### User experience

Before
![image](https://user-images.githubusercontent.com/4295173/219424412-0293e763-7927-4a24-91d7-c1679507588e.png)

After
![image](https://user-images.githubusercontent.com/4295173/219424604-6cb14581-44c3-413b-b971-7202b30b00b0.png)

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [ ] [Meet tenets criteria](https://awslabs.github.io/aws-lambda-powertools-python/#tenets)
* [ ] I have performed a self-review of this change
* [ ] Changes have been tested
* [x] Changes are documented
* [x] PR title follows [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-python/blob/develop/.github/semantic.yml)

<details>
<summary>Is this a breaking change?</summary>

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
