### PR TITLE
add route kwargs - event & context

### DIFF
--- a/aws_lambda_powertools/event_handler/api_gateway.py
+++ b/aws_lambda_powertools/event_handler/api_gateway.py
@@ -667,7 +667,8 @@ class ApiGatewayResolver(BaseRouter):
     def _call_route(self, route: Route, args: Dict[str, str]) -> ResponseBuilder:
         """Actually call the matching route with any provided keyword arguments."""
         try:
-            return ResponseBuilder(self._to_response(route.func(**args)), route)
+            kwargs = {"event": self.current_event, "context": self.context}
+            return ResponseBuilder(self._to_response(route.func(**args, **kwargs)), route)
         except Exception as exc:
             response_builder = self._call_exception_handler(exc, route)
             if response_builder:

--- a/tests/functional/event_handler/test_lambda_function_url.py
+++ b/tests/functional/event_handler/test_lambda_function_url.py
@@ -5,6 +5,7 @@ from aws_lambda_powertools.event_handler import (
 )
 from aws_lambda_powertools.shared.cookies import Cookie
 from aws_lambda_powertools.utilities.data_classes import LambdaFunctionUrlEvent
+from aws_lambda_powertools.utilities.typing.lambda_context import LambdaContext
 from tests.functional.utils import load_event
 
 
@@ -13,7 +14,7 @@ def test_lambda_function_url_event():
     app = LambdaFunctionUrlResolver()
 
     @app.post("/my/path")
-    def foo():
+    def foo(event: LambdaFunctionUrlEvent, context: LambdaContext):
         assert isinstance(app.current_event, LambdaFunctionUrlEvent)
         assert app.lambda_context == {}
         assert app.current_event.request_context.stage is not None
@@ -35,7 +36,7 @@ def test_lambda_function_url_event_path_trailing_slash():
     app = LambdaFunctionUrlResolver()
 
     @app.post("/my/path")
-    def foo():
+    def foo(event: LambdaFunctionUrlEvent, context: LambdaContext):
         return Response(200, content_types.TEXT_HTML, "foo")
 
     # WHEN calling the event handler with an event with a trailing slash
@@ -52,7 +53,7 @@ def test_lambda_function_url_event_with_cookies():
     cookie = Cookie(name="CookieMonster", value="MonsterCookie")
 
     @app.get("/")
-    def foo():
+    def foo(event: LambdaFunctionUrlEvent, context: LambdaContext):
         assert isinstance(app.current_event, LambdaFunctionUrlEvent)
         assert app.lambda_context == {}
         return Response(200, content_types.TEXT_PLAIN, "foo", cookies=[cookie])
@@ -71,7 +72,7 @@ def test_lambda_function_url_no_matches():
     app = LambdaFunctionUrlResolver()
 
     @app.post("/no_match")
-    def foo():
+    def foo(event: LambdaFunctionUrlEvent, context: LambdaContext):
         raise RuntimeError()
 
     # WHEN calling the event handler

--- a/tests/functional/event_handler/test_router.py
+++ b/tests/functional/event_handler/test_router.py
@@ -17,6 +17,7 @@ from aws_lambda_powertools.utilities.data_classes import (
     APIGatewayProxyEventV2,
     LambdaFunctionUrlEvent,
 )
+from aws_lambda_powertools.utilities.typing.lambda_context import LambdaContext
 from tests.functional.utils import load_event
 
 
@@ -25,7 +26,7 @@ def test_alb_router_event_type():
     router = ALBRouter()
 
     @router.route(rule="/lambda", method=["GET"])
-    def foo():
+    def foo(event: ALBEvent, context: LambdaContext):
         assert type(router.current_event) is ALBEvent
         return Response(status_code=200, body="routed")
 
@@ -39,7 +40,7 @@ def test_apigateway_router_event_type():
     router = APIGatewayRouter()
 
     @router.route(rule="/my/path", method=["GET"])
-    def foo():
+    def foo(event: APIGatewayProxyEvent, context: LambdaContext):
         assert type(router.current_event) is APIGatewayProxyEvent
         return Response(status_code=200, body="routed")
 
@@ -53,7 +54,7 @@ def test_apigatewayhttp_router_event_type():
     router = APIGatewayHttpRouter()
 
     @router.route(rule="/my/path", method=["POST"])
-    def foo():
+    def foo(event: APIGatewayProxyEventV2, context: LambdaContext):
         assert type(router.current_event) is APIGatewayProxyEventV2
         return Response(status_code=200, body="routed")
 
@@ -67,7 +68,7 @@ def test_lambda_function_url_router_event_type():
     router = LambdaFunctionUrlRouter()
 
     @router.route(rule="/", method=["GET"])
-    def foo():
+    def foo(event: LambdaFunctionUrlEvent, context: LambdaContext):
         assert type(router.current_event) is LambdaFunctionUrlEvent
         return Response(status_code=200, body="routed")
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
**Issue number:** #1955

## Summary
app.resolve invokes the route as shown [here](https://github.com/awslabs/aws-lambda-powertools-python/blob/develop/aws_lambda_powertools/event_handler/api_gateway.py#L667-L670), made changes in the PR, so that it can pass `event` & `context` as `kwargs` to the router function:

def _call_route(self, route: Route, args: Dict[str, str]) -> ResponseBuilder:
        """Actually call the matching route with any provided keyword arguments."""
        try:
             kwargs = {"event": self.current_event, "context": self.context}
             return ResponseBuilder(self._to_response(route.func(**args, **kwargs)), route)

### Changes

> Please provide a summary of what's being changed

* api_gateway.py `_call_route` method updated to pass `kwargs` for - `context` & `event`
* all tests tied to this functionality have been updated and are passing
* TBD - docs to be checked, waiting for feedback

### User experience

> Please share what the user experience looks like before and after this change

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] [Meet tenets criteria](https://awslabs.github.io/aws-lambda-powertools-python/#tenets)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [ ] Changes are documented
* [ ] PR title follows [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-python/blob/develop/.github/semantic.yml)

<details>
<summary>Is this a breaking change?</summary>
No

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
