### PR TITLE
chore(ci): replace deprecated set-output commands

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -73,7 +73,7 @@ jobs:
         run: |
           RELEASE_VERSION="${RELEASE_TAG_VERSION:1}"
           echo "RELEASE_VERSION=${RELEASE_VERSION}" >> "$GITHUB_ENV"
-          echo "::set-output name=RELEASE_VERSION::${RELEASE_VERSION}"
+          echo "RELEASE_VERSION=${RELEASE_VERSION}" >> $GITHUB_OUTPUT
       - name: Install dependencies
         run: make dev
       - name: Run all tests, linting and baselines

--- a/.github/workflows/reusable_export_pr_details.yml
+++ b/.github/workflows/reusable_export_pr_details.yml
@@ -71,19 +71,19 @@ jobs:
       # otherwise the parent caller won't see them regardless on how outputs are set.
       - name: "Export Pull Request Number"
         id: prNumber
-        run: echo ::set-output name=prNumber::$(jq -c '.number' ${FILENAME})
+        run: echo "prNumber=$(jq -c '.number' ${FILENAME})" >> $GITHUB_OUTPUT
       - name: "Export Pull Request Title"
         id: prTitle
-        run: echo ::set-output name=prTitle::$(jq -c '.pull_request.title' ${FILENAME})
+        run: echo "prTitle=$(jq -c '.pull_request.title' ${FILENAME})" >> $GITHUB_OUTPUT
       - name: "Export Pull Request Body"
         id: prBody
-        run: echo ::set-output name=prBody::$(jq -c '.pull_request.body' ${FILENAME})
+        run: echo "prBody=$(jq -c '.pull_request.body' ${FILENAME})" >> $GITHUB_OUTPUT
       - name: "Export Pull Request Author"
         id: prAuthor
-        run: echo ::set-output name=prAuthor::$(jq -c '.pull_request.user.login' ${FILENAME})
+        run: echo "prAuthor=$(jq -c '.pull_request.user.login' ${FILENAME})" >> $GITHUB_OUTPUT
       - name: "Export Pull Request Action"
         id: prAction
-        run: echo ::set-output name=prAction::$(jq -c '.action' ${FILENAME})
+        run: echo "prAction=$(jq -c '.action' ${FILENAME})" >> $GITHUB_OUTPUT
       - name: "Export Pull Request Merged status"
         id: prIsMerged
-        run: echo ::set-output name=prIsMerged::$(jq -c '.pull_request.merged' ${FILENAME})
+        run: echo "prIsMerged=$(jq -c '.pull_request.merged' ${FILENAME})" >> $GITHUB_OUTPUT


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->

**Issue number:** #1591

## Summary
Replace deprecated `save-state` and `set-output` commands to the new format: https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-output-parameter

### Changes

> Please provide a summary of what's being changed

### User experience

> Please share what the user experience looks like before and after this change

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] [Meet tenets criteria](https://awslabs.github.io/aws-lambda-powertools-python/#tenets)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [ ] Changes are documented
* [x] PR title follows [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-python/blob/develop/.github/semantic.yml)

<details>
<summary>Is this a breaking change?</summary>

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
