### PR TITLE
docs(appsync): add mutation example and infrastructure fix

### DIFF
--- a/docs/core/event_handler/appsync.md
+++ b/docs/core/event_handler/appsync.md
@@ -61,25 +61,25 @@ Here's an example with two separate functions to resolve `getTodo` and `listTodo
 
 === "getting_started_graphql_api_resolver.py"
 
-    ```python hl_lines="14 20 30 32-33 42 44 55"
+    ```python hl_lines="14 21 31 33-34 43 45 53 55 70"
     --8<-- "examples/event_handler_graphql/src/getting_started_graphql_api_resolver.py"
     ```
 
 === "getting_started_schema.graphql"
 
-    ```typescript hl_lines="6-7"
+    ```typescript hl_lines="6-8 12"
     --8<-- "examples/event_handler_graphql/src/getting_started_schema.graphql"
     ```
 
 === "getting_started_get_todo.json"
 
-    ```json hl_lines="2-3"
+    ```json hl_lines="2-3 42"
     --8<-- "examples/event_handler_graphql/src/getting_started_get_todo.json"
     ```
 
 === "getting_started_list_todos.json"
 
-    ```json hl_lines="2 40 42"
+    ```json hl_lines="2 40"
     --8<-- "examples/event_handler_graphql/src/getting_started_list_todos.json"
     ```
 

--- a/docs/core/event_handler/appsync.md
+++ b/docs/core/event_handler/appsync.md
@@ -87,7 +87,7 @@ Here's an example with two separate functions to resolve `getTodo` and `listTodo
 
     === "getting_started_create_todo.json"
 
-        ```json
+        ```json hl_lines="2 48 49"
         --8<-- "examples/event_handler_graphql/src/getting_started_create_todo.json"
         ```
 

--- a/docs/core/event_handler/appsync.md
+++ b/docs/core/event_handler/appsync.md
@@ -67,7 +67,7 @@ Here's an example with two separate functions to resolve `getTodo` and `listTodo
 
 === "getting_started_schema.graphql"
 
-    ```typescript hl_lines="6-8 12"
+    ```typescript hl_lines="7-9 13"
     --8<-- "examples/event_handler_graphql/src/getting_started_schema.graphql"
     ```
 
@@ -81,6 +81,12 @@ Here's an example with two separate functions to resolve `getTodo` and `listTodo
 
     ```json hl_lines="2 40"
     --8<-- "examples/event_handler_graphql/src/getting_started_list_todos.json"
+    ```
+
+=== "getting_started_create_todo.json"
+
+    ```json
+    --8<-- "examples/event_handler_graphql/src/getting_started_create_todo.json"
     ```
 
 ### Scalar functions

--- a/docs/core/event_handler/appsync.md
+++ b/docs/core/event_handler/appsync.md
@@ -71,23 +71,25 @@ Here's an example with two separate functions to resolve `getTodo` and `listTodo
     --8<-- "examples/event_handler_graphql/src/getting_started_schema.graphql"
     ```
 
-=== "getting_started_get_todo.json"
+=== "sample events"
 
-    ```json hl_lines="2-3 42"
-    --8<-- "examples/event_handler_graphql/src/getting_started_get_todo.json"
-    ```
+    === "getting_started_get_todo.json"
 
-=== "getting_started_list_todos.json"
+        ```json hl_lines="2-3 42"
+        --8<-- "examples/event_handler_graphql/src/getting_started_get_todo.json"
+        ```
 
-    ```json hl_lines="2 40"
-    --8<-- "examples/event_handler_graphql/src/getting_started_list_todos.json"
-    ```
+    === "getting_started_list_todos.json"
 
-=== "getting_started_create_todo.json"
+        ```json hl_lines="2 40"
+        --8<-- "examples/event_handler_graphql/src/getting_started_list_todos.json"
+        ```
 
-    ```json
-    --8<-- "examples/event_handler_graphql/src/getting_started_create_todo.json"
-    ```
+    === "getting_started_create_todo.json"
+
+        ```json
+        --8<-- "examples/event_handler_graphql/src/getting_started_create_todo.json"
+        ```
 
 ### Scalar functions
 

--- a/docs/core/event_handler/appsync.md
+++ b/docs/core/event_handler/appsync.md
@@ -61,7 +61,7 @@ Here's an example with two separate functions to resolve `getTodo` and `listTodo
 
 === "getting_started_graphql_api_resolver.py"
 
-    ```python hl_lines="14 21 31 33-34 43 45 53 55 70"
+    ```python hl_lines="14 21 31 33-34 43 45 53 55 66"
     --8<-- "examples/event_handler_graphql/src/getting_started_graphql_api_resolver.py"
     ```
 

--- a/docs/core/event_handler/appsync.md
+++ b/docs/core/event_handler/appsync.md
@@ -46,7 +46,10 @@ This is the sample infrastructure we are using for the initial examples with a A
 
 You can define your functions to match GraphQL types and fields with the `app.resolver()` decorator.
 
-Here's an example where we have two separate functions to resolve `getTodo` and `listTodos` fields within the `Query` type. For completion, we use Scalar type utilities to generate the right output based on our schema definition.
+???+ question "What is a type and field?"
+    A type would be a top-level **GraphQL Type** like `Query`, `Mutation`, `Todo`. A **GraphQL Field** would be `listTodos` under `Query`, or `createTodo` under `Mutation`, or `title` under `Todo`.
+
+Here's an example with two separate functions to resolve `getTodo` and `listTodos` fields within the `Query` type. For completion, we use [Scalar type utilities](#scalar-functions) to generate the right output based on our schema definition.
 
 ???+ important
     GraphQL arguments are passed as function keyword arguments.

--- a/docs/core/event_handler/appsync.md
+++ b/docs/core/event_handler/appsync.md
@@ -47,7 +47,7 @@ This is the sample infrastructure we are using for the initial examples with a A
 You can define your functions to match GraphQL types and fields with the `app.resolver()` decorator.
 
 ???+ question "What is a type and field?"
-    A type would be a top-level **GraphQL Type** like `Query`, `Mutation`, `Todo`. A **GraphQL Field** would be `listTodos` under `Query`, or `createTodo` under `Mutation`, or `title` under `Todo`.
+    A type would be a top-level **GraphQL Type** like `Query`, `Mutation`, `Todo`. A **GraphQL Field** would be `listTodos` under `Query`, `createTodo` under `Mutation`, etc.
 
 Here's an example with two separate functions to resolve `getTodo` and `listTodos` fields within the `Query` type. For completion, we use [Scalar type utilities](#scalar-functions) to generate the right output based on our schema definition.
 

--- a/examples/event_handler_graphql/sam/samconfig.toml
+++ b/examples/event_handler_graphql/sam/samconfig.toml
@@ -1,0 +1,10 @@
+version = 0.1
+[default]
+[default.deploy]
+[default.deploy.parameters]
+stack_name = "pt-graphql-getting-started"
+s3_bucket = "aws-sam-cli-managed-default-samclisourcebucket-1pssy5gdxqcao"
+s3_prefix = "pt-graphql-getting-started"
+region = "eu-west-1"
+capabilities = "CAPABILITY_IAM"
+image_repositories = []

--- a/examples/event_handler_graphql/sam/template.yaml
+++ b/examples/event_handler_graphql/sam/template.yaml
@@ -80,6 +80,10 @@ Resources:
             listTodos: [Todo]
         }
 
+        type Mutation {
+            createTodo(title: String!): Todo
+        }
+
         type Todo {
             id: ID!
             userId: String
@@ -113,6 +117,14 @@ Resources:
       ApiId: !GetAtt TodosApi.ApiId
       TypeName: "Query"
       FieldName: "getTodo"
+      DataSourceName: !GetAtt TodosFunctionDataSource.Name
+
+  CreateTodoResolver:
+    Type: "AWS::AppSync::Resolver"
+    Properties:
+      ApiId: !GetAtt TodosApi.ApiId
+      TypeName: "Mutation"
+      FieldName: "createTodo"
       DataSourceName: !GetAtt TodosFunctionDataSource.Name
 
 Outputs:

--- a/examples/event_handler_graphql/sam/template.yaml
+++ b/examples/event_handler_graphql/sam/template.yaml
@@ -70,26 +70,12 @@ Resources:
     Type: "AWS::AppSync::GraphQLSchema"
     Properties:
       ApiId: !GetAtt TodosApi.ApiId
-      Definition: |
-        schema {
-            query:Query
-        }
-
-        type Query {
-            getTodo(id: ID!): Todo
-            listTodos: [Todo]
-        }
-
-        type Mutation {
-            createTodo(title: String!): Todo
-        }
-
-        type Todo {
-            id: ID!
-            userId: String
-            title: String
-            completed: Boolean
-        }
+      DefinitionS3Location: ../src/getting_started_schema.graphql
+    Metadata:
+      cfn-lint:
+        config:
+          ignore_checks:
+            - W3002  # allow relative path in DefinitionS3Location
 
   # Lambda Direct Data Source and Resolver
 
@@ -133,4 +119,4 @@ Outputs:
     Value: !GetAtt TodosFunction.Arn
 
   TodosApi:
-    Value: !GetAtt TodosApi.Arn
+    Value: !GetAtt TodosApi.GraphQLUrl

--- a/examples/event_handler_graphql/src/getting_started_create_todo.json
+++ b/examples/event_handler_graphql/src/getting_started_create_todo.json
@@ -1,0 +1,53 @@
+ {
+    "arguments": {
+      "title": "Sample todo mutation"
+    },
+    "identity": null,
+    "source": null,
+    "request": {
+      "headers": {
+        "x-forwarded-for": "203.0.113.1, 203.0.113.18",
+        "cloudfront-viewer-country": "NL",
+        "cloudfront-is-tablet-viewer": "false",
+        "x-amzn-requestid": "fdc4f30b-44c2-475d-b2f9-9da0778d5275",
+        "via": "2.0 f655cacd0d6f7c5dc935ea687af6f3c0.cloudfront.net (CloudFront)",
+        "cloudfront-forwarded-proto": "https",
+        "origin": "https://eu-west-1.console.aws.amazon.com",
+        "content-length": "166",
+        "x-forwarded-proto": "https",
+        "accept-language": "en-US,en;q=0.5",
+        "host": "kiuqayvn4jhhzio6whpnk7xj3a.appsync-api.eu-west-1.amazonaws.com",
+        "user-agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:102.0) Gecko/20100101 Firefox/102.0",
+        "cloudfront-is-mobile-viewer": "false",
+        "accept": "application/json, text/plain, */*",
+        "cloudfront-viewer-asn": "1136",
+        "cloudfront-is-smarttv-viewer": "false",
+        "accept-encoding": "gzip, deflate, br",
+        "referer": "https://eu-west-1.console.aws.amazon.com/",
+        "content-type": "application/json",
+        "x-api-key": "da2-vsqnxwyzgzf4nh6kvoaidtvs7y",
+        "sec-fetch-mode": "cors",
+        "x-amz-cf-id": "0kxqijFPsbGSWJ1u3Z_sUS4Wu2hRoG_2T77aJPuoh_Q4bXAB3x0a3g==",
+        "x-amzn-trace-id": "Root=1-63fef2cf-6d566e9f4a35b99e6212388e",
+        "sec-fetch-dest": "empty",
+        "x-amz-user-agent": "AWS-Console-AppSync/",
+        "cloudfront-is-desktop-viewer": "true",
+        "sec-fetch-site": "cross-site",
+        "x-forwarded-port": "443"
+      },
+      "domainName": null
+    },
+    "prev": null,
+    "info": {
+      "selectionSetList": [
+        "id",
+        "title",
+        "completed"
+      ],
+      "selectionSetGraphQL": "{\n  id\n  title\n  completed\n}",
+      "fieldName": "createTodo",
+      "parentTypeName": "Mutation",
+      "variables": {}
+    },
+    "stash": {}
+}

--- a/examples/event_handler_graphql/src/getting_started_graphql_api_resolver.py
+++ b/examples/event_handler_graphql/src/getting_started_graphql_api_resolver.py
@@ -57,7 +57,7 @@ def create_todo(title: str) -> Todo:
     todo: Response = requests.post("https://jsonplaceholder.typicode.com/todos", json=payload)
     todo.raise_for_status()
 
-    return todo.json()["0"]
+    return todo.json()
 
 
 @logger.inject_lambda_context(correlation_id_path=correlation_paths.APPSYNC_RESOLVER)

--- a/examples/event_handler_graphql/src/getting_started_graphql_api_resolver.py
+++ b/examples/event_handler_graphql/src/getting_started_graphql_api_resolver.py
@@ -53,7 +53,7 @@ def list_todos() -> List[Todo]:
 @app.resolver(type_name="Mutation", field_name="createTodo")
 @tracer.capture_method
 def create_todo(title: str) -> Todo:
-    payload = ({"userId": scalar_types_utils.make_id(), "title": title, "completed": False},)  # dummy UUID str
+    payload = {"userId": scalar_types_utils.make_id(), "title": title, "completed": False}  # dummy UUID str
     todo: Response = requests.post("https://jsonplaceholder.typicode.com/todos", json=payload)
     todo.raise_for_status()
 

--- a/examples/event_handler_graphql/src/getting_started_graphql_api_resolver.py
+++ b/examples/event_handler_graphql/src/getting_started_graphql_api_resolver.py
@@ -13,6 +13,7 @@ from requests import Response
 from aws_lambda_powertools import Logger, Tracer
 from aws_lambda_powertools.event_handler import AppSyncResolver
 from aws_lambda_powertools.logging import correlation_paths
+from aws_lambda_powertools.utilities.data_classes.appsync import scalar_types_utils
 from aws_lambda_powertools.utilities.typing import LambdaContext
 
 tracer = Tracer()
@@ -47,6 +48,16 @@ def list_todos() -> List[Todo]:
 
     # for brevity, we'll limit to the first 10 only
     return todos.json()[:10]
+
+
+@app.resolver(type_name="Mutation", field_name="createTodo")
+@tracer.capture_method
+def create_todo(title: str) -> Todo:
+    payload = ({"userId": scalar_types_utils.make_id(), "title": title, "completed": False},)  # dummy UUID str
+    todo: Response = requests.post("https://jsonplaceholder.typicode.com/todos", json=payload)
+    todo.raise_for_status()
+
+    return todo.json()["0"]
 
 
 @logger.inject_lambda_context(correlation_id_path=correlation_paths.APPSYNC_RESOLVER)

--- a/examples/event_handler_graphql/src/getting_started_schema.graphql
+++ b/examples/event_handler_graphql/src/getting_started_schema.graphql
@@ -1,5 +1,6 @@
 schema {
     query: Query
+    mutation: Mutation
 }
 
 type Query {

--- a/examples/event_handler_graphql/src/getting_started_schema.graphql
+++ b/examples/event_handler_graphql/src/getting_started_schema.graphql
@@ -3,8 +3,13 @@ schema {
 }
 
 type Query {
+    # these are fields you can attach resolvers to (field: Query, field: getTodo)
     getTodo(id: ID!): Todo
     listTodos: [Todo]
+}
+
+type Mutation {
+    createTodo(title: String!): Todo
 }
 
 type Todo {

--- a/examples/event_handler_graphql/src/requirements.txt
+++ b/examples/event_handler_graphql/src/requirements.txt
@@ -1,0 +1,2 @@
+aws-lambda-powertools[tracer]
+requests


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
**Issue number:** #1953

## Summary

### Changes

> Please provide a summary of what's being changed

This PR extends the getting started example by adding a mutation. Previously, we only had queries, making it harder to work with mutations for newcomers of Event Handler AppSync.

* [x] Add `createTodo` mutation in the schema
* [x] Enable mutations in the GraphQL Schema (`schema { mutation: Mutation }`)
* [x] Updated code snippet to include a mutation event resolution (`getting_started_graphql_api_resolver.py`)
* [x] Improved documentation experience when viewing multiple sample events with a new tab (`Sample events`)

It also improves the example infrastructure to ease reproducing it in the future:

* [x] Replace `Definition` with `DefinitionS3Location` within `TodosApiSchema` AppSync API resource. This removes schema duplication and prevent error-prone updates by centralizing in a single source of truth
* [x] Add cfn-lint exception since `DefinitionS3Location` only works with SAM CLI
* [x] Add `requirements.txt` with dependencies used so it can be built with `sam build --use-container`
* [x] Add `samconfig.toml` to ease deploying next time (`sam deploy`, or `sam deploy -g` in other accounts). On the fence about this one as someone else deploying will change the file; will keep it for now as it doesn't harm


### User experience

> Please share what the user experience looks like before and after this change

**Schema extended**

<img width="1175" alt="image" src="https://user-images.githubusercontent.com/3340292/222076433-77c1b180-5f14-4c58-934e-0bb4da7e9c44.png">

**New Sample events tab**

<img width="1159" alt="image" src="https://user-images.githubusercontent.com/3340292/222077530-38679f83-0004-4c83-a30a-85a2ba43b74d.png">


**Sample resolver extended**

<img width="1146" alt="image" src="https://user-images.githubusercontent.com/3340292/221926037-0d2a7eca-6c43-440c-ad88-46a63a7d8264.png">


## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] [Meet tenets criteria](https://awslabs.github.io/aws-lambda-powertools-python/#tenets)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented
* [x] PR title follows [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-python/blob/develop/.github/semantic.yml)

<details>
<summary>Is this a breaking change?</summary>

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
