### PR TITLE
fix(idempotency): revert dict mutation that impacted static_pk_value feature

### DIFF
--- a/tests/functional/idempotency/conftest.py
+++ b/tests/functional/idempotency/conftest.py
@@ -262,43 +262,22 @@ def static_pk_value():
 
 @pytest.fixture
 def expected_params_update_item_compound_key_static_pk_value(
-    serialized_lambda_response, hashed_idempotency_key, static_pk_value
+    expected_params_update_item, hashed_idempotency_key, static_pk_value
 ):
     return {
-        "ExpressionAttributeNames": {
-            "#expiry": "expiration",
-            "#response_data": "data",
-            "#status": "status",
-        },
-        "ExpressionAttributeValues": {
-            ":expiry": {"N": stub.ANY},
-            ":response_data": {"S": serialized_lambda_response},
-            ":status": {"S": "COMPLETED"},
-        },
+        # same as in any update_item transaction except the `Key` due to composite key value
+        **expected_params_update_item,
         "Key": {"id": {"S": static_pk_value}, "sk": {"S": hashed_idempotency_key}},
-        "TableName": "TEST_TABLE",
-        "UpdateExpression": "SET #response_data = :response_data, " "#expiry = :expiry, #status = :status",
     }
 
 
 @pytest.fixture
-def expected_params_put_item_compound_key_static_pk_value(hashed_idempotency_key, static_pk_value):
+def expected_params_put_item_compound_key_static_pk_value(
+    expected_params_put_item, hashed_idempotency_key, static_pk_value
+):
     return {
-        "ConditionExpression": (
-            "attribute_not_exists(#id) OR #expiry < :now OR "
-            "(#status = :inprogress AND attribute_exists(#in_progress_expiry) AND #in_progress_expiry < :now_in_millis)"
-        ),
-        "ExpressionAttributeNames": {
-            "#id": "id",
-            "#expiry": "expiration",
-            "#status": "status",
-            "#in_progress_expiry": "in_progress_expiration",
-        },
-        "ExpressionAttributeValues": {
-            ":now": {"N": stub.ANY},
-            ":now_in_millis": {"N": stub.ANY},
-            ":inprogress": {"S": "INPROGRESS"},
-        },
+        # same as in any put_item transaction except the `Item` due to composite key value
+        **expected_params_put_item,
         "Item": {
             "expiration": {"N": stub.ANY},
             "in_progress_expiration": {"N": stub.ANY},


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
**Issue number:** #1968

> **NOTE**: This is literally a contribution from @Tankanow. Had to cut a PR to get it merged quicker due to the regression.

## Summary

### Changes

> Please provide a summary of what's being changed

Reverts a regression added in #1899 when making DynamoDB client thread-safe.

`static_pk_value` is used by customers using Single Table design pattern with DynamoDB, where a composite key is used with a static value for its "primary key" attr. This change reverts a dictionary mutation that discarded the value from `static_pk_value` and used `key_id` instead.

In simple terms, same effect as:

```python
a = {"my_key": "must_be_static"}
b = {
    **a,
    "my_key": "this is the final value"  # this shouldn't exist as it'll always win last insertion
}
``` 

### User experience

> Please share what the user experience looks like before and after this change

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] [Meet tenets criteria](https://awslabs.github.io/aws-lambda-powertools-python/#tenets)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [ ] Changes are documented
* [ ] PR title follows [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-python/blob/develop/.github/semantic.yml)

<details>
<summary>Is this a breaking change?</summary>

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
