### PR TITLE
chore(parser): add workaround to make API GW test button work

### DIFF
--- a/aws_lambda_powertools/utilities/parser/models/apigw.py
+++ b/aws_lambda_powertools/utilities/parser/models/apigw.py
@@ -31,7 +31,9 @@ class APIGatewayEventIdentity(BaseModel):
     cognitoIdentityId: Optional[str]
     cognitoIdentityPoolId: Optional[str]
     principalOrgId: Optional[str]
-    sourceIp: IPvAnyNetwork
+    # see #1562, temp workaround until API Gateway fixes it the Test button payload
+    # removing it will not be considered a regression in the future
+    sourceIp: Union[IPvAnyNetwork, Literal["test-invoke-source-ip"]]
     user: Optional[str]
     userAgent: Optional[str]
     userArn: Optional[str]


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
**Issue number:** #1562

## Summary

### Changes

> Please provide a summary of what's being changed

This PR allows parser validation to pass when customers use API Gateway Test button, since it doesn't use an actual IP address for the field `source`. Instead, it uses a hardcoded string value of `"test-invoke-source-ip"`

### User experience

> Please share what the user experience looks like before and after this change

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] [Meet tenets criteria](https://awslabs.github.io/aws-lambda-powertools-python/#tenets)
* [x] I have performed a self-review of this change
* [ ] Changes have been tested
* [ ] Changes are documented
* [x] PR title follows [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-python/blob/develop/.github/semantic.yml)

<details>
<summary>Is this a breaking change?</summary>

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
