### PR TITLE
feat(event_sources): support for custom properties in ActiveMQEvent

### DIFF
--- a/aws_lambda_powertools/utilities/data_classes/active_mq_event.py
+++ b/aws_lambda_powertools/utilities/data_classes/active_mq_event.py
@@ -56,6 +56,11 @@ class ActiveMQMessage(DictWrapper):
         return self["brokerOutTime"]
 
     @property
+    def properties(self) -> dict:
+        """Custom properties"""
+        return self["properties"]
+
+    @property
     def destination_physicalname(self) -> str:
         return self["destination"]["physicalname"]
 

--- a/tests/events/activeMQEvent.json
+++ b/tests/events/activeMQEvent.json
@@ -13,7 +13,10 @@
       },
       "timestamp": 1598827811958,
       "brokerInTime": 1598827811958,
-      "brokerOutTime": 1598827811959
+      "brokerOutTime": 1598827811959,
+      "properties": {
+        "testKey": "testValue"
+      }
     },
     {
       "messageID": "ID:b-9bcfa592-423a-4942-879d-eb284b418fc8-1.mq.us-west-2.amazonaws.com-37557-1234520418293-4:1:1:1:1",

--- a/tests/events/activeMQEvent.json
+++ b/tests/events/activeMQEvent.json
@@ -26,7 +26,11 @@
       },
       "timestamp": 1598827811958,
       "brokerInTime": 1598827811958,
-      "brokerOutTime": 1598827811959
+      "brokerOutTime": 1598827811959,
+      "properties": {
+        "testKey": "testValue"
+      }
+
     },
     {
       "messageID": "ID:b-9bcfa592-423a-4942-879d-eb284b418fc8-1.mq.us-west-2.amazonaws.com-37557-1234520418293-4:1:1:1:1",
@@ -39,7 +43,10 @@
       },
       "timestamp": 1598827811958,
       "brokerInTime": 1598827811958,
-      "brokerOutTime": 1598827811959
+      "brokerOutTime": 1598827811959,
+      "properties": {
+        "testKey": "testValue"
+      }
     }
   ]
 }

--- a/tests/functional/data_classes/test_amazon_mq.py
+++ b/tests/functional/data_classes/test_amazon_mq.py
@@ -30,6 +30,7 @@ def test_active_mq_event():
     assert message.timestamp is not None
     assert message.broker_in_time is not None
     assert message.broker_out_time is not None
+    assert message.properties["testKey"] == "testValue"
     assert message.destination_physicalname is not None
     assert message.delivery_mode is None
     assert message.correlation_id is None


### PR DESCRIPTION
## Summary

### Changes

Adds custom properties to ActiveMQ event after Lambda Event Source Mappings added the support

### User experience

Users will now be able to interpret custom properties at runtime for their ActiveMQ messages delivered via Lambda Event Source Mappings.

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [X] [Meet tenets criteria](https://awslabs.github.io/aws-lambda-powertools-python/#tenets)
* [X] I have performed a self-review of this change
* [X] Changes have been tested
* [X] Changes are documented
* [X] PR title follows [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-python/blob/develop/.github/semantic.yml)

<details>
<summary>Is this a breaking change?</summary>

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
