### PR TITLE
fix(typing): swap NoReturn with None for methods with no return value

### DIFF
--- a/aws_lambda_powertools/tracing/base.py
+++ b/aws_lambda_powertools/tracing/base.py
@@ -2,7 +2,7 @@ import abc
 import numbers
 import traceback
 from contextlib import contextmanager
-from typing import Any, Generator, List, NoReturn, Optional, Sequence, Union
+from typing import Any, Generator, List, Optional, Sequence, Union
 
 
 class BaseSegment(abc.ABC):
@@ -28,7 +28,7 @@ class BaseSegment(abc.ABC):
         """Remove input subsegment from child subsegments."""
 
     @abc.abstractmethod
-    def put_annotation(self, key: str, value: Union[str, numbers.Number, bool]) -> NoReturn:
+    def put_annotation(self, key: str, value: Union[str, numbers.Number, bool]) -> None:
         """Annotate segment or subsegment with a key-value pair.
 
         Note: Annotations will be indexed for later search query.
@@ -42,7 +42,7 @@ class BaseSegment(abc.ABC):
         """
 
     @abc.abstractmethod
-    def put_metadata(self, key: str, value: Any, namespace: str = "default") -> NoReturn:
+    def put_metadata(self, key: str, value: Any, namespace: str = "default") -> None:
         """Add metadata to segment or subsegment. Metadata is not indexed
         but can be later retrieved by BatchGetTraces API.
 
@@ -101,7 +101,7 @@ class BaseProvider(abc.ABC):
         """
 
     @abc.abstractmethod
-    def put_annotation(self, key: str, value: Union[str, numbers.Number, bool]) -> NoReturn:
+    def put_annotation(self, key: str, value: Union[str, numbers.Number, bool]) -> None:
         """Annotate current active trace entity with a key-value pair.
 
         Note: Annotations will be indexed for later search query.
@@ -115,7 +115,7 @@ class BaseProvider(abc.ABC):
         """
 
     @abc.abstractmethod
-    def put_metadata(self, key: str, value: Any, namespace: str = "default") -> NoReturn:
+    def put_metadata(self, key: str, value: Any, namespace: str = "default") -> None:
         """Add metadata to the current active trace entity.
 
         Note: Metadata is not indexed but can be later retrieved by BatchGetTraces API.
@@ -131,7 +131,7 @@ class BaseProvider(abc.ABC):
         """
 
     @abc.abstractmethod
-    def patch(self, modules: Sequence[str]) -> NoReturn:
+    def patch(self, modules: Sequence[str]) -> None:
         """Instrument a set of supported libraries
 
         Parameters
@@ -141,5 +141,5 @@ class BaseProvider(abc.ABC):
         """
 
     @abc.abstractmethod
-    def patch_all(self) -> NoReturn:
+    def patch_all(self) -> None:
         """Instrument all supported libraries"""


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
**Issue number:** #2002

## Summary

NoReturn are for methods that never return (e.g. always raise exceptions). Using NoReturn causes e.g. mypy to think all code following the call to the NoReturn method to be unreachable.


### Changes

The

- `put_annotation`
- `put_metadata`
- `patch`
- `patch_all`

methods of `BaseSegment` now have the correct return type for methods that return not (but do in fact return).

### User experience

Before this change using any of the above methods would lead to type errors/unreachable code errors when used with e.g. mypy.

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] [Meet tenets criteria](https://awslabs.github.io/aws-lambda-powertools-python/#tenets)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented
* [x] PR title follows [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-python/blob/develop/.github/semantic.yml)

<details>
<summary>Is this a breaking change?</summary>

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
