### PR TITLE
fix(build): auto-generate setup.py for legacy build tools

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -176,6 +176,10 @@ markers = [
 requires = ["poetry-core>=1.3.2"]
 build-backend = "poetry.core.masonry.api"
 
+# poetry-core (PR #318) stopped generating setup.py by default, this enables it again.
+[tool.poetry.build]
+generate-setup-file = true
+
 # NOTE
 # As of now, Feb 2020, flake8 don't support pyproject
 # For latest: https://github.com/flying-sheep/awesome-python-packaging


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
#2012 

## Summary

### Changes

> Please provide a summary of what's being changed

pyproject.toml has a new section to re-enable the generation of setup.py

### User experience

> Please share what the user experience looks like before and after this change

As a result of a change in ([poetry-core](https://github.com/python-poetry/poetry-core/pull/318)), this project no longer generates a setup.py file when building, this could be required by other users of the package for things like third party vending of packages.

This PR restores the generation of setup.py

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [X] [Meet tenets criteria](https://awslabs.github.io/aws-lambda-powertools-python/#tenets)
* [X] I have performed a self-review of this change
* [X] Changes have been tested
* [X] Changes are documented
* [X] PR title follows [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-python/blob/develop/.github/semantic.yml)


## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
