### PR TITLE
docs(logger): warn append_keys on not being thread-safe

### DIFF
--- a/docs/core/logger.md
+++ b/docs/core/logger.md
@@ -162,8 +162,8 @@ You can append additional keys using either mechanism:
 
 #### append_keys method
 
-???+ note
-	`append_keys` replaces `structure_logs(append=True, **kwargs)` method. structure_logs will be removed in v2.
+???+ warning
+	`append_keys` is not thread-safe, please see [RFC](https://github.com/awslabs/aws-lambda-powertools-python/issues/991){target="_blank"}.
 
 You can append your own keys to your existing Logger via `append_keys(**additional_key_values)` method.
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
**Issue number:** #2040

## Summary

### Changes

> Please provide a summary of what's being changed

Add a warning to signal `logger.append_keys` isn't thread-safe at the moment.

### User experience

> Please share what the user experience looks like before and after this change

<img width="1443" alt="image" src="https://user-images.githubusercontent.com/3340292/227441404-dbd441eb-240d-43a6-bef6-4dc0c9735d2a.png">


## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] [Meet tenets criteria](https://awslabs.github.io/aws-lambda-powertools-python/#tenets)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented
* [x] PR title follows [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-python/blob/develop/.github/semantic.yml)

<details>
<summary>Is this a breaking change?</summary>

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
