### PR TITLE
fix(feature_flags): handle expected falsy values in conditions

### DIFF
--- a/aws_lambda_powertools/utilities/feature_flags/feature_flags.py
+++ b/aws_lambda_powertools/utilities/feature_flags/feature_flags.py
@@ -47,8 +47,6 @@ class FeatureFlags:
         self.logger = logger or logging.getLogger(__name__)
 
     def _match_by_action(self, action: str, condition_value: Any, context_value: Any) -> bool:
-        if not context_value:
-            return False
         mapping_by_action = {
             schema.RuleAction.EQUALS.value: lambda a, b: a == b,
             schema.RuleAction.NOT_EQUALS.value: lambda a, b: a != b,

--- a/aws_lambda_powertools/utilities/feature_flags/schema.py
+++ b/aws_lambda_powertools/utilities/feature_flags/schema.py
@@ -325,8 +325,8 @@ class ConditionsValidator(BaseValidator):
 
     @staticmethod
     def validate_condition_value(condition: Dict[str, Any], rule_name: str):
-        value = condition.get(CONDITION_VALUE, "")
-        if not value:
+        value = condition.get(CONDITION_VALUE)
+        if value is None:
             raise SchemaValidationError(f"'value' key must not be empty, rule={rule_name}")
         action = condition.get(CONDITION_ACTION, "")
 

--- a/aws_lambda_powertools/utilities/feature_flags/schema.py
+++ b/aws_lambda_powertools/utilities/feature_flags/schema.py
@@ -327,7 +327,7 @@ class ConditionsValidator(BaseValidator):
     def validate_condition_value(condition: Dict[str, Any], rule_name: str):
         value = condition.get(CONDITION_VALUE)
         if value is None:
-            raise SchemaValidationError(f"'value' key must not be none, rule={rule_name}")
+            raise SchemaValidationError(f"'value' key must not be null, rule={rule_name}")
         action = condition.get(CONDITION_ACTION, "")
 
         # time actions need to be parsed to make sure date and time format is valid and timezone is recognized

--- a/aws_lambda_powertools/utilities/feature_flags/schema.py
+++ b/aws_lambda_powertools/utilities/feature_flags/schema.py
@@ -327,7 +327,7 @@ class ConditionsValidator(BaseValidator):
     def validate_condition_value(condition: Dict[str, Any], rule_name: str):
         value = condition.get(CONDITION_VALUE)
         if value is None:
-            raise SchemaValidationError(f"'value' key must not be empty, rule={rule_name}")
+            raise SchemaValidationError(f"'value' key must not be none, rule={rule_name}")
         action = condition.get(CONDITION_ACTION, "")
 
         # time actions need to be parsed to make sure date and time format is valid and timezone is recognized

--- a/tests/functional/feature_flags/test_schema_validation.py
+++ b/tests/functional/feature_flags/test_schema_validation.py
@@ -314,7 +314,7 @@ def test_validate_condition_none_condition_value():
     }
 
     # WHEN calling validate_condition
-    with pytest.raises(SchemaValidationError, match="'value' key must not be none"):
+    with pytest.raises(SchemaValidationError, match="'value' key must not be null"):
         ConditionsValidator.validate_condition_value(condition=condition, rule_name="dummy")
 
 

--- a/tests/functional/feature_flags/test_schema_validation.py
+++ b/tests/functional/feature_flags/test_schema_validation.py
@@ -301,7 +301,7 @@ def test_validate_condition_missing_condition_value():
     }
 
     # WHEN calling validate_condition
-    with pytest.raises(SchemaValidationError, match="'value' key must not be empty"):
+    with pytest.raises(SchemaValidationError, match="'value' key must not be none"):
         ConditionsValidator.validate_condition_value(condition=condition, rule_name="dummy")
 
 
@@ -314,8 +314,20 @@ def test_validate_condition_none_condition_value():
     }
 
     # WHEN calling validate_condition
-    with pytest.raises(SchemaValidationError, match="'value' key must not be empty"):
+    with pytest.raises(SchemaValidationError, match="'value' key must not be none"):
         ConditionsValidator.validate_condition_value(condition=condition, rule_name="dummy")
+
+
+def test_validate_condition_empty_condition_value():
+    # GIVEN a configuration with a missing condition value
+    condition = {
+        "action": RuleAction.EQUALS.value,
+        "key": "tenant_id",
+        "value": "",
+    }
+
+    # WHEN calling validate_condition
+    ConditionsValidator.validate_condition_value(condition=condition, rule_name="dummy")
 
 
 def test_validate_condition_valid_falsy_condition_value():

--- a/tests/functional/feature_flags/test_schema_validation.py
+++ b/tests/functional/feature_flags/test_schema_validation.py
@@ -301,7 +301,7 @@ def test_validate_condition_missing_condition_value():
     }
 
     # WHEN calling validate_condition
-    with pytest.raises(SchemaValidationError, match="'value' key must not be none"):
+    with pytest.raises(SchemaValidationError, match="'value' key must not be null"):
         ConditionsValidator.validate_condition_value(condition=condition, rule_name="dummy")
 
 

--- a/tests/functional/feature_flags/test_schema_validation.py
+++ b/tests/functional/feature_flags/test_schema_validation.py
@@ -305,6 +305,31 @@ def test_validate_condition_missing_condition_value():
         ConditionsValidator.validate_condition_value(condition=condition, rule_name="dummy")
 
 
+def test_validate_condition_none_condition_value():
+    # GIVEN a configuration with a missing condition value
+    condition = {
+        "action": RuleAction.EQUALS.value,
+        "key": "tenant_id",
+        "value": None,
+    }
+
+    # WHEN calling validate_condition
+    with pytest.raises(SchemaValidationError, match="'value' key must not be empty"):
+        ConditionsValidator.validate_condition_value(condition=condition, rule_name="dummy")
+
+
+def test_validate_condition_valid_falsy_condition_value():
+    # GIVEN a configuration with a missing condition value
+    condition = {
+        "action": RuleAction.EQUALS.value,
+        "key": "tenant_id",
+        "value": 0,
+    }
+
+    # WHEN calling validate_condition
+    ConditionsValidator.validate_condition_value(condition=condition, rule_name="dummy")
+
+
 def test_validate_rule_invalid_rule_type():
     # GIVEN an invalid rule type of empty list
     # WHEN calling validate_rule


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
**Issue number:** #2051 

## Summary
Rule Conditions allow users to evaluate context attributes against values and actions defined in Rule Conditions.
The condition can easily be pivoted on a certain value in the context evaluating to falsy values
The values attribute should be able to accept any value except null
The condition should also honor any value for context key variable.

### Changes

- Added tests
- changed the validation from if true to if none
- changed error message to none instead of empty


## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] [Meet tenets criteria](https://awslabs.github.io/aws-lambda-powertools-python/#tenets)
* [ ] I have performed a self-review of this change
* [ ] Changes have been tested
* [ ] Changes are documented
* [x] PR title follows [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-python/blob/develop/.github/semantic.yml)

<details>
<summary>Is this a breaking change?</summary>

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
