### PR TITLE
fix(feature_flags): make test conditions deterministic

### DIFF
--- a/docs/utilities/feature_flags.md
+++ b/docs/utilities/feature_flags.md
@@ -827,10 +827,10 @@ def test_flags_condition_match(mocker):
 	expected_value = True
 	mocked_app_config_schema = {
 		"my_feature": {
-			"default": expected_value,
+			"default": False,
 			"rules": {
 				"tenant id equals 12345": {
-					"when_match": True,
+					"when_match": expected_value,
 					"conditions": [
 						{
 							"action": RuleAction.EQUALS.value,

--- a/tests/functional/feature_flags/test_feature_flags.py
+++ b/tests/functional/feature_flags/test_feature_flags.py
@@ -808,10 +808,10 @@ def test_flags_not_equal_match(mocker, config):
     expected_value = True
     mocked_app_config_schema = {
         "my_feature": {
-            "default": expected_value,
+            "default": False,
             "rules": {
                 "tenant id not equals 345345435": {
-                    "when_match": True,
+                    "when_match": expected_value,
                     "conditions": [
                         {
                             "action": RuleAction.NOT_EQUALS.value,
@@ -889,10 +889,10 @@ def test_flags_less_than_match(mocker, config):
     expected_value = True
     mocked_app_config_schema = {
         "my_feature": {
-            "default": expected_value,
+            "default": False,
             "rules": {
                 "Date less than 2021.10.31": {
-                    "when_match": True,
+                    "when_match": expected_value,
                     "conditions": [
                         {
                             "action": RuleAction.KEY_LESS_THAN_VALUE.value,
@@ -946,10 +946,10 @@ def test_flags_less_than_or_equal_match_1(mocker, config):
     expected_value = True
     mocked_app_config_schema = {
         "my_feature": {
-            "default": expected_value,
+            "default": False,
             "rules": {
                 "Date less than or equal 2021.10.31": {
-                    "when_match": True,
+                    "when_match": expected_value,
                     "conditions": [
                         {
                             "action": RuleAction.KEY_LESS_THAN_OR_EQUAL_VALUE.value,
@@ -974,10 +974,10 @@ def test_flags_less_than_or_equal_match_2(mocker, config):
     expected_value = True
     mocked_app_config_schema = {
         "my_feature": {
-            "default": expected_value,
+            "default": False,
             "rules": {
                 "Date less than or equal 2021.10.31": {
-                    "when_match": True,
+                    "when_match": expected_value,
                     "conditions": [
                         {
                             "action": RuleAction.KEY_LESS_THAN_OR_EQUAL_VALUE.value,
@@ -1059,10 +1059,10 @@ def test_flags_greater_than_match(mocker, config):
     expected_value = True
     mocked_app_config_schema = {
         "my_feature": {
-            "default": expected_value,
+            "default": False,
             "rules": {
                 "Date greater than 2021.10.31": {
-                    "when_match": True,
+                    "when_match": expected_value,
                     "conditions": [
                         {
                             "action": RuleAction.KEY_GREATER_THAN_VALUE.value,
@@ -1116,10 +1116,10 @@ def test_flags_greater_than_or_equal_match_1(mocker, config):
     expected_value = True
     mocked_app_config_schema = {
         "my_feature": {
-            "default": expected_value,
+            "default": False,
             "rules": {
                 "Date greater than or equal 2021.10.31": {
-                    "when_match": True,
+                    "when_match": expected_value,
                     "conditions": [
                         {
                             "action": RuleAction.KEY_GREATER_THAN_OR_EQUAL_VALUE.value,
@@ -1144,10 +1144,10 @@ def test_flags_greater_than_or_equal_match_2(mocker, config):
     expected_value = True
     mocked_app_config_schema = {
         "my_feature": {
-            "default": expected_value,
+            "default": False,
             "rules": {
                 "Date greater than or equal 2021.10.31": {
-                    "when_match": True,
+                    "when_match": expected_value,
                     "conditions": [
                         {
                             "action": RuleAction.KEY_GREATER_THAN_OR_EQUAL_VALUE.value,


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
**Issue number:** #2058 

## Summary

Feature Flags `match` type test cases must have the non-expected value as default and the condition `when_match` must be equal to `expected_value`

For the list of test cases below, the `expected_value` is assigned as the `default` value which is returned when the condition does **not** match. The test only passes because both the expected and non-expected values are the same - `True` meaning that the test cannot fail ever.

- test_flags_not_equal_match
- test_flags_less_than_match
- test_flags_less_than_or_equal_match_1
- test_flags_less_than_or_equal_match_2
- test_flags_greater_than_match
- test_flags_greater_than_or_equal_match_1
- test_flags_greater_than_or_equal_match_2


### Changes

> Please provide a summary of what's being changed

For `match` cases - expected_value, is assigned to the `when_match` of condition rather than `default` and `default` must return `False`

Changed a similar flaw in the test case mentioned in documentation

### User experience

> Please share what the user experience looks like before and after this change

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] [Meet tenets criteria](https://awslabs.github.io/aws-lambda-powertools-python/#tenets)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented
* [x] PR title follows [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-python/blob/develop/.github/semantic.yml)

<details>
<summary>Is this a breaking change?</summary>

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
