### PR TITLE
docs(parser): fix highlighted line

### DIFF
--- a/docs/utilities/parser.md
+++ b/docs/utilities/parser.md
@@ -63,7 +63,7 @@ Use the decorator for fail fast scenarios where you want your Lambda function to
 ???+ note
     **This decorator will replace the `event` object with the parsed model if successful**. This means you might be careful when nesting other decorators that expect `event` to be a `dict`.
 
-```python hl_lines="18" title="Parsing and validating upon invocation with event_parser decorator"
+```python hl_lines="19" title="Parsing and validating upon invocation with event_parser decorator"
 from aws_lambda_powertools.utilities.parser import event_parser, BaseModel
 from aws_lambda_powertools.utilities.typing import LambdaContext
 from typing import List, Optional

--- a/docs/utilities/parser.md
+++ b/docs/utilities/parser.md
@@ -111,7 +111,7 @@ handler(event=json.dumps(payload), context=LambdaContext()) # also works if even
 
 Use this standalone function when you want more control over the data validation process, for example returning a 400 error for malformed payloads.
 
-```python hl_lines="21 30" title="Using standalone parse function for more flexibility"
+```python hl_lines="21 31" title="Using standalone parse function for more flexibility"
 from aws_lambda_powertools.utilities.parser import parse, BaseModel, ValidationError
 from typing import List, Optional
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
**Issue number:** #2079

## Summary

### Changes

> Please provide a summary of what's being changed

Highlight line with `event_parser` decorator instead of empty line.

https://awslabs.github.io/aws-lambda-powertools-python/2.11.0/utilities/parser/#parsing-events

### User experience

> Please share what the user experience looks like before and after this change

Before:

![image](https://user-images.githubusercontent.com/152008/228601550-61026edf-3f8f-433d-b64c-e84396a40afe.png)

After:

![image](https://user-images.githubusercontent.com/152008/228603774-52ab98a6-662e-4d47-a142-f28e2d9bf737.png)


## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [ ] [Meet tenets criteria](https://awslabs.github.io/aws-lambda-powertools-python/#tenets)
* [x] I have performed a self-review of this change
* [ ] Changes have been tested
* [ ] Changes are documented
* [x] PR title follows [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-python/blob/develop/.github/semantic.yml)

<details>
<summary>Is this a breaking change?</summary>

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
