### PR TITLE
docs(idempotency): new sequence diagrams, fix idempotency record vs DynamoDB TTL confusion

### DIFF
--- a/docs/utilities/idempotency.md
+++ b/docs/utilities/idempotency.md
@@ -248,7 +248,7 @@ When using `idempotent_function`, you must tell us which keyword parameter in yo
 You can can easily integrate with [Batch utility](batch.md) via context manager. This ensures that you process each record in an idempotent manner, and guard against a [Lambda timeout](#lambda-timeouts) idempotent situation.
 
 ???+ "Choosing an unique batch record attribute"
-    In this example, we choose `messageId` as our idempotency token since we know it'll be unique.
+    In this example, we choose `messageId` as our idempotency key since we know it'll be unique.
 
     Depending on your use case, it might be more accurate [to choose another field](#choosing-a-payload-subset-for-idempotency) your producer intentionally set to define uniqueness.
 

--- a/docs/utilities/idempotency.md
+++ b/docs/utilities/idempotency.md
@@ -70,7 +70,7 @@ Resources:
   HelloWorldFunction:
   Type: AWS::Serverless::Function
   Properties:
-	Runtime: python3.8
+	Runtime: python3.9
 	...
 	Policies:
 	  - DynamoDBCrudPolicy:

--- a/docs/utilities/idempotency.md
+++ b/docs/utilities/idempotency.md
@@ -92,6 +92,9 @@ Resources:
 
 You can quickly start by initializing the `DynamoDBPersistenceLayer` class and using it with the `idempotent` decorator on your lambda handler.
 
+???+ note
+    In this example, the entire Lambda handler is treated as a single idempotent operation. If your Lambda handler can cause multiple side effects, or you're only interested in making a specific logic idempotent, use [`idempotent_function`](#idempotent_function-decorator) instead.
+
 === "app.py"
 
     ```python hl_lines="1-3 5 7 14"
@@ -123,6 +126,8 @@ You can quickly start by initializing the `DynamoDBPersistenceLayer` class and u
       "product_id": "123456789"
     }
     ```
+
+After processing this request successfully, a second request containing the exact same payload above will now return the same response, ensuring our customer isn't charged twice.
 
 ### Idempotent_function decorator
 
@@ -401,13 +406,8 @@ sequenceDiagram
         Lambda-->>Client: Same response sent to client
     end
 ```
-<i>Idempotent sequence</i>
+<i>Idempotent successful request</i>
 </center>
-
-The client was successful in receiving the result after the retry. Since the Lambda handler was only executed once, our customer hasn't been charged twice.
-
-???+ note
-    Bear in mind that the entire Lambda handler is treated as a single idempotent operation. If your Lambda handler can cause multiple side effects, consider splitting it into separate functions.
 
 #### Lambda timeouts
 

--- a/docs/utilities/idempotency.md
+++ b/docs/utilities/idempotency.md
@@ -157,6 +157,8 @@ You can quickly start by initializing the `DynamoDBPersistenceLayer` class and u
 
 After processing this request successfully, a second request containing the exact same payload above will now return the same response, ensuring our customer isn't charged twice.
 
+!!! question "New to idempotency concept? Please review our [Terminology](#terminology) section if you haven't yet."
+
 ### Idempotent_function decorator
 
 Similar to [idempotent decorator](#idempotent-decorator), you can use `idempotent_function` decorator for any synchronous Python function.

--- a/docs/utilities/idempotency.md
+++ b/docs/utilities/idempotency.md
@@ -16,6 +16,32 @@ times with the same parameters**. This makes idempotent operations safe to retry
 
 **Idempotency key** is a hash representation of either the entire event or a specific configured subset of the event, and invocation results are **JSON serialized** and stored in your persistence storage layer.
 
+**Idempotency record** is the data representation of an idempotent request saved in your preferred  storage layer. We use it to coordinate whether a request is idempotent, whether it's still valid or expired based on timestamps, etc.
+
+<center>
+```mermaid
+classDiagram
+    direction LR
+    class IdempotencyRecord {
+        idempotency_key str
+        status Status
+        expiry_timestamp int
+        in_progress_expiry_timestamp int
+        response_data Json~str~
+        payload_hash str
+    }
+    class Status {
+        <<Enumeration>>
+        INPROGRESS
+        COMPLETE
+        EXPIRED internal_only
+    }
+    IdempotencyRecord -- Status
+```
+
+<i>Idempotency record representation</i>
+</center>
+
 ## Key features
 
 * Prevent Lambda handler from executing more than once on the same event payload during a time window

--- a/docs/utilities/idempotency.md
+++ b/docs/utilities/idempotency.md
@@ -121,6 +121,8 @@ You can quickly start by initializing the `DynamoDBPersistenceLayer` class and u
 ???+ note
     In this example, the entire Lambda handler is treated as a single idempotent operation. If your Lambda handler can cause multiple side effects, or you're only interested in making a specific logic idempotent, use [`idempotent_function`](#idempotent_function-decorator) instead.
 
+!!! tip "See [Choosing a payload subset for idempotency](#choosing-a-payload-subset-for-idempotency) for more elaborate use cases."
+
 === "app.py"
 
     ```python hl_lines="1-3 5 7 14"
@@ -161,7 +163,7 @@ Similar to [idempotent decorator](#idempotent-decorator), you can use `idempoten
 
 When using `idempotent_function`, you must tell us which keyword parameter in your function signature has the data we should use via **`data_keyword_argument`**.
 
-!!! info "We support JSON serializable data, [Python Dataclasses](https://docs.python.org/3.7/library/dataclasses.html){target="_blank"}, [Parser/Pydantic Models](parser.md){target="_blank"}, and our [Event Source Data Classes](./data_classes.md){target="_blank"}."
+!!! tip "We support JSON serializable data, [Python Dataclasses](https://docs.python.org/3.7/library/dataclasses.html){target="_blank"}, [Parser/Pydantic Models](parser.md){target="_blank"}, and our [Event Source Data Classes](./data_classes.md){target="_blank"}."
 
 ???+ warning "Limitation"
     Make sure to call your decorated function using keyword arguments.


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
**Issue number:** #2023

## Summary

Improves Idempotency documentation after discussion with @pmarko1711 on Idempotency Record expiration vs DynamoDB TTL expiration.

As I improved it, I've noticed we were light on sequence diagrams to explain common scenarios Idempotency handles it (we can add more later).

### Changes

> Please provide a summary of what's being changed

- [x] Created multiple sub-sections to ease referencing sequence diagrams throughout docs
- [x] Added new sequence diagram to demonstrate in-memory cache flow
- [x] Added new sequence diagram to demonstrate how we handle records that expired
- [x] Added new sequence diagram to demonstrate in-flight requests
- [x] revamped timeout sequence diagram
- [x] Added `idempotency record` terminology along with a diagram to explain what's in it (missed that when explaining to Peter how it looks like)
- [x] Added new banner to address idempotency record vs DynamoDB Time-to-live (TTL) confusion

Unrelated but sorely needed changes after

- [x] Within `Choosing a payload subset for idempotency`, improved payment scenario by using composite idempotency hash with JMESPath. It's way more realistic and less error-prone to HTTP header change for example.
- [x] Hint customers can choose a portion of the payload earlier in the docs

### User experience

> Please share what the user experience looks like before and after this change

**New and revamped sequence diagrams depicting Idempotency Record Status too**

<img width="1505" alt="image" src="https://user-images.githubusercontent.com/3340292/229134522-97f63e8b-1f7f-42e7-a18f-5b0cdf0a0785.png">

**New Idempotency Record terminology**

<img width="1466" alt="image" src="https://user-images.githubusercontent.com/3340292/229134897-7e7e4036-e00a-4e9e-93e4-ac2b1654ec21.png">

**Address confusion between Idempotency Record expiration vs DynamoDB time-to-live (TTL)**

<img width="1546" alt="image" src="https://user-images.githubusercontent.com/3340292/229135301-117a35bb-cfd4-4744-93f0-d0e40f06d0de.png">


Adding screenshots shortly

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] [Meet tenets criteria](https://awslabs.github.io/aws-lambda-powertools-python/#tenets)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented
* [x] PR title follows [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-python/blob/develop/.github/semantic.yml)

<details>
<summary>Is this a breaking change?</summary>

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
