### PR TITLE
feat(idempotency): allow custom sdk clients in DynamoDBPersistenceLayer

### DIFF
--- a/aws_lambda_powertools/utilities/idempotency/persistence/base.py
+++ b/aws_lambda_powertools/utilities/idempotency/persistence/base.py
@@ -41,8 +41,8 @@ class DataRecord:
         status: str = "",
         expiry_timestamp: Optional[int] = None,
         in_progress_expiry_timestamp: Optional[int] = None,
-        response_data: Optional[str] = "",
-        payload_hash: Optional[str] = None,
+        response_data: str = "",
+        payload_hash: str = "",
     ) -> None:
         """
 

--- a/aws_lambda_powertools/utilities/idempotency/persistence/base.py
+++ b/aws_lambda_powertools/utilities/idempotency/persistence/base.py
@@ -117,7 +117,7 @@ class BasePersistenceLayer(ABC):
         """Initialize the defaults"""
         self.function_name = ""
         self.configured = False
-        self.event_key_jmespath: Optional[str] = None
+        self.event_key_jmespath: str = ""
         self.event_key_compiled_jmespath = None
         self.jmespath_options: Optional[dict] = None
         self.payload_validation_enabled = False
@@ -125,7 +125,7 @@ class BasePersistenceLayer(ABC):
         self.raise_on_no_idempotency_key = False
         self.expires_after_seconds: int = 60 * 60  # 1 hour default
         self.use_local_cache = False
-        self.hash_function = None
+        self.hash_function = hashlib.md5
 
     def configure(self, config: IdempotencyConfig, function_name: Optional[str] = None) -> None:
         """

--- a/aws_lambda_powertools/utilities/idempotency/persistence/dynamodb.py
+++ b/aws_lambda_powertools/utilities/idempotency/persistence/dynamodb.py
@@ -89,7 +89,7 @@ class DynamoDBPersistenceLayer(BasePersistenceLayer):
         if boto3_client is None:
             self._boto_config = boto_config or Config()
             self._boto3_session: boto3.Session = boto3_session or boto3.session.Session()
-            self.client = self._boto3_session.client("dynamodb", config=self._boto_config)
+            self.client: "DynamoDBClient" = self._boto3_session.client("dynamodb", config=self._boto_config)
         else:
             self.client = boto3_client
 

--- a/tests/functional/idempotency/test_idempotency.py
+++ b/tests/functional/idempotency/test_idempotency.py
@@ -76,7 +76,7 @@ def test_idempotent_lambda_already_completed(
     Test idempotent decorator where event with matching event key has already been successfully processed
     """
 
-    stubber = stub.Stubber(persistence_store._client)
+    stubber = stub.Stubber(persistence_store.client)
     ddb_response = {
         "Item": {
             "id": {"S": hashed_idempotency_key},
@@ -120,7 +120,7 @@ def test_idempotent_lambda_in_progress(
     Test idempotent decorator where lambda_handler is already processing an event with matching event key
     """
 
-    stubber = stub.Stubber(persistence_store._client)
+    stubber = stub.Stubber(persistence_store.client)
 
     expected_params = {
         "TableName": TABLE_NAME,
@@ -172,7 +172,7 @@ def test_idempotent_lambda_in_progress_with_cache(
     """
     save_to_cache_spy = mocker.spy(persistence_store, "_save_to_cache")
     retrieve_from_cache_spy = mocker.spy(persistence_store, "_retrieve_from_cache")
-    stubber = stub.Stubber(persistence_store._client)
+    stubber = stub.Stubber(persistence_store.client)
 
     expected_params = {
         "TableName": TABLE_NAME,
@@ -234,7 +234,7 @@ def test_idempotent_lambda_first_execution(
     Test idempotent decorator when lambda is executed with an event with a previously unknown event key
     """
 
-    stubber = stub.Stubber(persistence_store._client)
+    stubber = stub.Stubber(persistence_store.client)
     ddb_response = {}
 
     stubber.add_response("put_item", ddb_response, expected_params_put_item)
@@ -269,7 +269,7 @@ def test_idempotent_lambda_first_execution_cached(
     """
     save_to_cache_spy = mocker.spy(persistence_store, "_save_to_cache")
     retrieve_from_cache_spy = mocker.spy(persistence_store, "_retrieve_from_cache")
-    stubber = stub.Stubber(persistence_store._client)
+    stubber = stub.Stubber(persistence_store.client)
     ddb_response = {}
 
     stubber.add_response("put_item", ddb_response, expected_params_put_item)
@@ -310,7 +310,7 @@ def test_idempotent_lambda_first_execution_event_mutation(
     Ensures we're passing data by value, not reference.
     """
     event = copy.deepcopy(lambda_apigw_event)
-    stubber = stub.Stubber(persistence_store._client)
+    stubber = stub.Stubber(persistence_store.client)
     ddb_response = {}
     stubber.add_response(
         "put_item",
@@ -350,7 +350,7 @@ def test_idempotent_lambda_expired(
     expiry window
     """
 
-    stubber = stub.Stubber(persistence_store._client)
+    stubber = stub.Stubber(persistence_store.client)
 
     ddb_response = {}
 
@@ -385,7 +385,7 @@ def test_idempotent_lambda_exception(
     # Create a new provider
 
     # Stub the boto3 client
-    stubber = stub.Stubber(persistence_store._client)
+    stubber = stub.Stubber(persistence_store.client)
 
     ddb_response = {}
     expected_params_delete_item = {"TableName": TABLE_NAME, "Key": {"id": {"S": hashed_idempotency_key}}}
@@ -427,7 +427,7 @@ def test_idempotent_lambda_already_completed_with_validation_bad_payload(
     Test idempotent decorator where event with matching event key has already been successfully processed
     """
 
-    stubber = stub.Stubber(persistence_store._client)
+    stubber = stub.Stubber(persistence_store.client)
     ddb_response = {
         "Item": {
             "id": {"S": hashed_idempotency_key},
@@ -471,7 +471,7 @@ def test_idempotent_lambda_expired_during_request(
     returns inconsistent/rapidly changing result between put_item and get_item calls.
     """
 
-    stubber = stub.Stubber(persistence_store._client)
+    stubber = stub.Stubber(persistence_store.client)
 
     ddb_response_get_item = {
         "Item": {
@@ -524,7 +524,7 @@ def test_idempotent_persistence_exception_deleting(
     Test idempotent decorator when lambda is executed with an event with a previously unknown event key, but
     lambda_handler raises an exception which is retryable.
     """
-    stubber = stub.Stubber(persistence_store._client)
+    stubber = stub.Stubber(persistence_store.client)
 
     ddb_response = {}
 
@@ -556,7 +556,7 @@ def test_idempotent_persistence_exception_updating(
     Test idempotent decorator when lambda is executed with an event with a previously unknown event key, but
     lambda_handler raises an exception which is retryable.
     """
-    stubber = stub.Stubber(persistence_store._client)
+    stubber = stub.Stubber(persistence_store.client)
 
     ddb_response = {}
 
@@ -587,7 +587,7 @@ def test_idempotent_persistence_exception_getting(
     Test idempotent decorator when lambda is executed with an event with a previously unknown event key, but
     lambda_handler raises an exception which is retryable.
     """
-    stubber = stub.Stubber(persistence_store._client)
+    stubber = stub.Stubber(persistence_store.client)
 
     stubber.add_client_error("put_item", "ConditionalCheckFailedException")
     stubber.add_client_error("get_item", "UnexpectedException")
@@ -625,7 +625,7 @@ def test_idempotent_lambda_first_execution_with_validation(
     """
     Test idempotent decorator when lambda is executed with an event with a previously unknown event key
     """
-    stubber = stub.Stubber(persistence_store._client)
+    stubber = stub.Stubber(persistence_store.client)
     ddb_response = {}
 
     stubber.add_response("put_item", ddb_response, expected_params_put_item_with_validation)
@@ -661,7 +661,7 @@ def test_idempotent_lambda_with_validator_util(
     validator utility to unwrap the event
     """
 
-    stubber = stub.Stubber(persistence_store._client)
+    stubber = stub.Stubber(persistence_store.client)
     ddb_response = {
         "Item": {
             "id": {"S": hashed_idempotency_key_with_envelope},
@@ -704,7 +704,7 @@ def test_idempotent_lambda_expires_in_progress_before_expire(
     hashed_idempotency_key,
     lambda_context,
 ):
-    stubber = stub.Stubber(persistence_store._client)
+    stubber = stub.Stubber(persistence_store.client)
 
     stubber.add_client_error("put_item", "ConditionalCheckFailedException")
 
@@ -751,7 +751,7 @@ def test_idempotent_lambda_expires_in_progress_after_expire(
     hashed_idempotency_key,
     lambda_context,
 ):
-    stubber = stub.Stubber(persistence_store._client)
+    stubber = stub.Stubber(persistence_store.client)
 
     for _ in range(MAX_RETRIES + 1):
         stubber.add_client_error("put_item", "ConditionalCheckFailedException")
@@ -1070,7 +1070,7 @@ def test_custom_jmespath_function_overrides_builtin_functions(
 def test_idempotent_lambda_save_inprogress_error(persistence_store: DynamoDBPersistenceLayer, lambda_context):
     # GIVEN a miss configured persistence layer
     # like no table was created for the idempotency persistence layer
-    stubber = stub.Stubber(persistence_store._client)
+    stubber = stub.Stubber(persistence_store.client)
     service_error_code = "ResourceNotFoundException"
     service_message = "Custom message"
 
@@ -1327,7 +1327,7 @@ def test_idempotency_disabled_envvar(monkeypatch, lambda_context, persistence_st
     # Scenario to validate no requests sent to dynamodb table when 'POWERTOOLS_IDEMPOTENCY_DISABLED' is set
     mock_event = {"data": "value"}
 
-    persistence_store._client = MagicMock()
+    persistence_store.client = MagicMock()
 
     monkeypatch.setenv("POWERTOOLS_IDEMPOTENCY_DISABLED", "1")
 
@@ -1342,7 +1342,7 @@ def test_idempotency_disabled_envvar(monkeypatch, lambda_context, persistence_st
     dummy(data=mock_event)
     dummy_handler(mock_event, lambda_context)
 
-    assert len(persistence_store._client.method_calls) == 0
+    assert len(persistence_store.client.method_calls) == 0
 
 
 @pytest.mark.parametrize("idempotency_config", [{"use_local_cache": True}], indirect=True)
@@ -1351,7 +1351,7 @@ def test_idempotent_function_duplicates(
 ):
     # Scenario to validate the both methods are called
     mock_event = {"data": "value"}
-    persistence_store._client = MagicMock()
+    persistence_store.client = MagicMock()
 
     @idempotent_function(data_keyword_argument="data", persistence_store=persistence_store, config=idempotency_config)
     def one(data):
@@ -1363,7 +1363,7 @@ def test_idempotent_function_duplicates(
 
     assert one(data=mock_event) == "one"
     assert two(data=mock_event) == "two"
-    assert len(persistence_store._client.method_calls) == 4
+    assert len(persistence_store.client.method_calls) == 4
 
 
 def test_invalid_dynamodb_persistence_layer():
@@ -1475,7 +1475,7 @@ def test_idempotent_lambda_compound_already_completed(
     Test idempotent decorator having a DynamoDBPersistenceLayer with a compound key
     """
 
-    stubber = stub.Stubber(persistence_store_compound._client)
+    stubber = stub.Stubber(persistence_store_compound.client)
     stubber.add_client_error("put_item", "ConditionalCheckFailedException")
     ddb_response = {
         "Item": {
@@ -1520,7 +1520,7 @@ def test_idempotent_lambda_compound_static_pk_value_has_correct_pk(
     Test idempotent decorator having a DynamoDBPersistenceLayer with a compound key and a static PK value
     """
 
-    stubber = stub.Stubber(persistence_store_compound_static_pk_value._client)
+    stubber = stub.Stubber(persistence_store_compound_static_pk_value.client)
     ddb_response = {}
 
     stubber.add_response("put_item", ddb_response, expected_params_put_item_compound_key_static_pk_value)

--- a/tests/unit/idempotency/test_dynamodb_persistence.py
+++ b/tests/unit/idempotency/test_dynamodb_persistence.py
@@ -1,0 +1,21 @@
+from dataclasses import dataclass
+
+from aws_lambda_powertools.utilities.idempotency import DynamoDBPersistenceLayer
+from tests.e2e.utils.data_builder.common import build_random_value
+
+
+def test_custom_sdk_client_injection():
+    # GIVEN
+    @dataclass
+    class DummyClient:
+        table_name: str
+
+    table_name = build_random_value()
+    fake_client = DummyClient(table_name)
+
+    # WHEN
+    persistence_layer = DynamoDBPersistenceLayer(table_name, boto3_client=fake_client)
+
+    # THEN
+    assert persistence_layer.table_name == table_name
+    assert persistence_layer.client == fake_client


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
**Issue number:** #2073

## Summary

### Changes

> Please provide a summary of what's being changed

This PR adds a [new constructor parameter `boto3_client` in `DynamoDBPersistenceLayer`](https://github.com/awslabs/aws-lambda-powertools-python/pull/2087/files#diff-c2c13a8644a6c9f191dc3de231dc33ccb38f6666ab011b68fc4e5005567b848dR17). This unblocks customers wanting to use DynamoDB Local, LocalStack, or AWS SDK Stubbers more cleanly (no private attribute access).

It also unblocks the documentation PR where we're trying to provide an example of how to use DynamoDB Local for testing.

### User experience

> Please share what the user experience looks like before and after this change

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] [Meet tenets criteria](https://awslabs.github.io/aws-lambda-powertools-python/#tenets)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented
* [x] PR title follows [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-python/blob/develop/.github/semantic.yml)

<details>
<summary>Is this a breaking change?</summary>

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
