### PR TITLE
docs(homepage): remove banner for end-of-support v1

### DIFF
--- a/docs/overrides/main.html
+++ b/docs/overrides/main.html
@@ -1,10 +1,5 @@
 {% extends "base.html" %}
 
-{% block announce %}
-👋 Powertools for Python v1 will no longer receive updates or releases after 31/03/2023!
-We encourage you to read our <a href="{{ base_url }}/upgrade/#end-of-support-v1">upgrade guide on how to migrate to v2</a>.
-{% endblock %}
-
 {% block outdated %}
   You're not viewing the latest version.
   <a href="{{ '../' ~ base_url }}">

--- a/docs/upgrade.md
+++ b/docs/upgrade.md
@@ -7,7 +7,7 @@ description: Guide to update between major Powertools versions
 
 ## End of support v1
 
-On March 31st, AWS Lambda Powertools for Python v1 will reach end of support. After that, Powertools v1 will no longer receive updates or releases. If you are still using v1, we encourage you to read our upgrade guide and update to the latest version.
+!!! warning "On March 31st, 2023, AWS Lambda Powertools for Python v1 reached end of support and will no longer receive updates or releases. If you are still using v1, we strongly recommend you to read our upgrade guide and update to the latest version."
 
 Given our commitment to all of our customers using AWS Lambda Powertools for Python, we will keep [Pypi](https://pypi.org/project/aws-lambda-powertools/) v1 releases and documentation 1.x versions to prevent any disruption.
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
**Issue number:** #2089 

## Summary

### Changes

Update documentation to stating that version 1.x reached end of support and will no longer receive updates or releases.

### User experience

BEFORE
![image](https://user-images.githubusercontent.com/4295173/230497943-91c84777-827a-4e98-a084-573da5f9ea98.png)
![image](https://user-images.githubusercontent.com/4295173/230497967-e8b0aa71-4ae1-47ee-acc7-d80e851481dd.png)

AFTER
![image](https://user-images.githubusercontent.com/4295173/230498088-129589d0-bd83-425a-9f79-2ad23d88a996.png)
![image](https://user-images.githubusercontent.com/4295173/230498123-f6243ddd-3c45-4dec-a6eb-5c227b68349b.png)


## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] [Meet tenets criteria](https://awslabs.github.io/aws-lambda-powertools-python/#tenets)
* [x] I have performed a self-review of this change
* [ ] Changes have been tested
* [x] Changes are documented
* [x] PR title follows [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-python/blob/develop/.github/semantic.yml)

<details>
<summary>Is this a breaking change?</summary>

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
