### PR TITLE
fix(batch): handle early validation errors for pydantic models (poison pill) #2091

### DIFF
--- a/aws_lambda_powertools/utilities/batch/base.py
+++ b/aws_lambda_powertools/utilities/batch/base.py
@@ -331,14 +331,20 @@ class BasePartialBatchProcessor(BasePartialProcessor):  # noqa
     def _collect_kinesis_failures(self):
         failures = []
         for msg in self.fail_messages:
-            msg_id = msg.kinesis.sequenceNumber if self.model else msg.kinesis.sequence_number
+            if self.model and getattr(msg, "parse_obj", None):
+                msg_id = msg.kinesis.sequenceNumber
+            else:
+                msg_id = msg.kinesis.sequence_number
             failures.append({"itemIdentifier": msg_id})
         return failures
 
     def _collect_dynamodb_failures(self):
         failures = []
         for msg in self.fail_messages:
-            msg_id = msg.dynamodb.SequenceNumber if self.model else msg.dynamodb.sequence_number
+            if self.model and getattr(msg, "parse_obj", None):
+                msg_id = msg.dynamodb.SequenceNumber
+            else:
+                msg_id = msg.dynamodb.sequence_number
             failures.append({"itemIdentifier": msg_id})
         return failures
 

--- a/aws_lambda_powertools/utilities/batch/base.py
+++ b/aws_lambda_powertools/utilities/batch/base.py
@@ -331,6 +331,7 @@ class BasePartialBatchProcessor(BasePartialProcessor):  # noqa
     def _collect_kinesis_failures(self):
         failures = []
         for msg in self.fail_messages:
+            # # see https://github.com/awslabs/aws-lambda-powertools-python/issues/2091
             if self.model and getattr(msg, "parse_obj", None):
                 msg_id = msg.kinesis.sequenceNumber
             else:
@@ -341,6 +342,7 @@ class BasePartialBatchProcessor(BasePartialProcessor):  # noqa
     def _collect_dynamodb_failures(self):
         failures = []
         for msg in self.fail_messages:
+            # see https://github.com/awslabs/aws-lambda-powertools-python/issues/2091
             if self.model and getattr(msg, "parse_obj", None):
                 msg_id = msg.dynamodb.SequenceNumber
             else:

--- a/aws_lambda_powertools/utilities/batch/base.py
+++ b/aws_lambda_powertools/utilities/batch/base.py
@@ -37,6 +37,7 @@ from aws_lambda_powertools.utilities.data_classes.kinesis_stream_event import (
     KinesisStreamRecord,
 )
 from aws_lambda_powertools.utilities.data_classes.sqs_event import SQSRecord
+from aws_lambda_powertools.utilities.parser import ValidationError
 from aws_lambda_powertools.utilities.typing import LambdaContext
 
 logger = logging.getLogger(__name__)
@@ -316,7 +317,14 @@ class BasePartialBatchProcessor(BasePartialProcessor):  # noqa
     def _collect_sqs_failures(self):
         failures = []
         for msg in self.fail_messages:
-            msg_id = msg.messageId if self.model else msg.message_id
+            # If a message failed due to model validation (e.g., poison pill)
+            # we convert to an event source data class...but self.model is still true
+            # therefore, we do an additional check on whether the failed message is still a model
+            # see https://github.com/awslabs/aws-lambda-powertools-python/issues/2091
+            if self.model and getattr(msg, "parse_obj", None):
+                msg_id = msg.messageId
+            else:
+                msg_id = msg.message_id
             failures.append({"itemIdentifier": msg_id})
         return failures
 
@@ -471,6 +479,7 @@ class BatchProcessor(BasePartialBatchProcessor):  # Keep old name for compatibil
         record: dict
             A batch record to be processed.
         """
+        data: Optional["BatchTypeModels"] = None
         try:
             data = self._to_batch_type(record=record, event_type=self.event_type, model=self.model)
             if self._handler_accepts_lambda_context:
@@ -479,6 +488,15 @@ class BatchProcessor(BasePartialBatchProcessor):  # Keep old name for compatibil
                 result = self.handler(record=data)
 
             return self.success_handler(record=record, result=result)
+        # Parser will fail validation if record is a poison pill (malformed input)
+        # this means we can't collect the message id if we try transforming again
+        # so we convert into to the equivalent batch type model (e.g., SQS, Kinesis, DynamoDB Stream)
+        # and downstream we can correctly collect the correct message id identifier and make the failed record available
+        # see https://github.com/awslabs/aws-lambda-powertools-python/issues/2091
+        except ValidationError:
+            logger.debug("Record cannot be converted to customer's model; converting without model")
+            failed_record: "EventSourceDataClassTypes" = self._to_batch_type(record=record, event_type=self.event_type)
+            return self.failure_handler(record=failed_record, exception=sys.exc_info())
         except Exception:
             return self.failure_handler(record=data, exception=sys.exc_info())
 

--- a/aws_lambda_powertools/utilities/batch/base.py
+++ b/aws_lambda_powertools/utilities/batch/base.py
@@ -471,8 +471,8 @@ class BatchProcessor(BasePartialBatchProcessor):  # Keep old name for compatibil
         record: dict
             A batch record to be processed.
         """
-        data = self._to_batch_type(record=record, event_type=self.event_type, model=self.model)
         try:
+            data = self._to_batch_type(record=record, event_type=self.event_type, model=self.model)
             if self._handler_accepts_lambda_context:
                 result = self.handler(record=data, lambda_context=self.lambda_context)
             else:
@@ -651,8 +651,8 @@ class AsyncBatchProcessor(BasePartialBatchProcessor):
         record: dict
             A batch record to be processed.
         """
-        data = self._to_batch_type(record=record, event_type=self.event_type, model=self.model)
         try:
+            data = self._to_batch_type(record=record, event_type=self.event_type, model=self.model)
             if self._handler_accepts_lambda_context:
                 result = await self.handler(record=data, lambda_context=self.lambda_context)
             else:

--- a/aws_lambda_powertools/utilities/parser/models/dynamodb.py
+++ b/aws_lambda_powertools/utilities/parser/models/dynamodb.py
@@ -9,8 +9,8 @@ from aws_lambda_powertools.utilities.parser.types import Literal
 class DynamoDBStreamChangedRecordModel(BaseModel):
     ApproximateCreationDateTime: Optional[date]
     Keys: Dict[str, Dict[str, Any]]
-    NewImage: Optional[Union[Dict[str, Any], Type[BaseModel]]]
-    OldImage: Optional[Union[Dict[str, Any], Type[BaseModel]]]
+    NewImage: Optional[Union[Dict[str, Any], Type[BaseModel], BaseModel]]
+    OldImage: Optional[Union[Dict[str, Any], Type[BaseModel], BaseModel]]
     SequenceNumber: str
     SizeBytes: int
     StreamViewType: Literal["NEW_AND_OLD_IMAGES", "KEYS_ONLY", "NEW_IMAGE", "OLD_IMAGE"]

--- a/aws_lambda_powertools/utilities/parser/models/kinesis.py
+++ b/aws_lambda_powertools/utilities/parser/models/kinesis.py
@@ -15,7 +15,7 @@ class KinesisDataStreamRecordPayload(BaseModel):
     kinesisSchemaVersion: str
     partitionKey: str
     sequenceNumber: str
-    data: Union[bytes, Type[BaseModel]]  # base64 encoded str is parsed into bytes
+    data: Union[bytes, Type[BaseModel], BaseModel]  # base64 encoded str is parsed into bytes
     approximateArrivalTimestamp: float
 
     @validator("data", pre=True, allow_reuse=True)

--- a/aws_lambda_powertools/utilities/parser/models/sqs.py
+++ b/aws_lambda_powertools/utilities/parser/models/sqs.py
@@ -52,7 +52,7 @@ class SqsMsgAttributeModel(BaseModel):
 class SqsRecordModel(BaseModel):
     messageId: str
     receiptHandle: str
-    body: Union[str, Type[BaseModel]]
+    body: Union[str, Type[BaseModel], BaseModel]
     attributes: SqsAttributesModel
     messageAttributes: Dict[str, SqsMsgAttributeModel]
     md5OfBody: str

--- a/aws_lambda_powertools/utilities/parser/types.py
+++ b/aws_lambda_powertools/utilities/parser/types.py
@@ -3,16 +3,18 @@
 import sys
 from typing import Any, Dict, Type, TypeVar, Union
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Json
 
 # We only need typing_extensions for python versions <3.8
 if sys.version_info >= (3, 8):
-    from typing import Literal  # noqa: F401
+    from typing import Literal
 else:
-    from typing_extensions import Literal  # noqa: F401
+    from typing_extensions import Literal
 
 Model = TypeVar("Model", bound=BaseModel)
 EnvelopeModel = TypeVar("EnvelopeModel")
 EventParserReturnType = TypeVar("EventParserReturnType")
 AnyInheritedModel = Union[Type[BaseModel], BaseModel]
 RawDictOrModel = Union[Dict[str, Any], AnyInheritedModel]
+
+__all__ = ["Json", "Literal"]

--- a/tests/functional/batch/sample_models.py
+++ b/tests/functional/batch/sample_models.py
@@ -1,0 +1,47 @@
+import json
+from typing import Dict, Optional
+
+from aws_lambda_powertools.utilities.parser import BaseModel, validator
+from aws_lambda_powertools.utilities.parser.models import (
+    DynamoDBStreamChangedRecordModel,
+    DynamoDBStreamRecordModel,
+    KinesisDataStreamRecord,
+    KinesisDataStreamRecordPayload,
+    SqsRecordModel,
+)
+from aws_lambda_powertools.utilities.parser.types import Json, Literal
+
+
+class Order(BaseModel):
+    item: dict
+
+
+class OrderSqs(SqsRecordModel):
+    body: Json[Order]
+
+
+class OrderKinesisPayloadRecord(KinesisDataStreamRecordPayload):
+    data: Json[Order]
+
+
+class OrderKinesisRecord(KinesisDataStreamRecord):
+    kinesis: OrderKinesisPayloadRecord
+
+
+class OrderDynamoDB(BaseModel):
+    Message: Order
+
+    # auto transform json string
+    # so Pydantic can auto-initialize nested Order model
+    @validator("Message", pre=True)
+    def transform_message_to_dict(cls, value: Dict[Literal["S"], str]):
+        return json.loads(value["S"])
+
+
+class OrderDynamoDBChangeRecord(DynamoDBStreamChangedRecordModel):
+    NewImage: Optional[OrderDynamoDB]
+    OldImage: Optional[OrderDynamoDB]
+
+
+class OrderDynamoDBRecord(DynamoDBStreamRecordModel):
+    dynamodb: OrderDynamoDBChangeRecord


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
**Issue number:** #2091 

## Summary

Lambda shouldn't failure if there is at least one successful record and return {batchItemFailures: [...] } when we use pydantic model check. For resolution, checking model function has been moved under try section in batch processing for BatchProcessor and AsyncBatchProcessor classes

### Changes

Move pydantic model check line under try section in batch processing.

### User experience

Now only records which aren't pass pydantic modeling check will mark as failed records

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] [Meet tenets criteria](https://awslabs.github.io/aws-lambda-powertools-python/#tenets)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [ ] Changes are documented
* [x] PR title follows [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-python/blob/develop/.github/semantic.yml)

<details>
<summary>Is this a breaking change?</summary>

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
