### PR TITLE
docs(batch): use newly supported Json model

### DIFF
--- a/docs/utilities/batch.md
+++ b/docs/utilities/batch.md
@@ -693,27 +693,22 @@ Inheritance is importance because we need to access message IDs and sequence num
 
 === "SQS"
 
-    ```python hl_lines="5 13 22 28"
+    ```python hl_lines="5 14 23 29"
     import json
 
     from aws_lambda_powertools import Logger, Tracer
     from aws_lambda_powertools.utilities.batch import BatchProcessor, EventType, process_partial_response
     from aws_lambda_powertools.utilities.parser.models import SqsRecordModel
     from aws_lambda_powertools.utilities.typing import LambdaContext
-    from aws_lambda_powertools.utilities.parser import validator, BaseModel
+    from aws_lambda_powertools.utilities.parser import BaseModel
+    from aws_lambda_powertools.utilities.parser.types import Json
 
 
     class Order(BaseModel):
         item: dict
 
     class OrderSqsRecord(SqsRecordModel):
-        body: Order
-
-        # auto transform json string
-        # so Pydantic can auto-initialize nested Order model
-        @validator("body", pre=True)
-        def transform_body_to_dict(cls, value: str):
-            return json.loads(value)
+        body: Json[Order]  # deserialize order data from JSON string
 
     processor = BatchProcessor(event_type=EventType.SQS, model=OrderSqsRecord)
     tracer = Tracer()
@@ -732,13 +727,14 @@ Inheritance is importance because we need to access message IDs and sequence num
 
 === "Kinesis Data Streams"
 
-    ```python hl_lines="5 14 25 29 35"
+    ```python hl_lines="5 15 19 23 29 36"
     import json
 
     from aws_lambda_powertools import Logger, Tracer
     from aws_lambda_powertools.utilities.batch import BatchProcessor, EventType, process_partial_response
     from aws_lambda_powertools.utilities.parser.models import KinesisDataStreamRecordPayload, KinesisDataStreamRecord
     from aws_lambda_powertools.utilities.parser import BaseModel, validator
+    from aws_lambda_powertools.utilities.parser.types import Json
     from aws_lambda_powertools.utilities.typing import LambdaContext
 
 
@@ -747,14 +743,7 @@ Inheritance is importance because we need to access message IDs and sequence num
 
 
     class OrderKinesisPayloadRecord(KinesisDataStreamRecordPayload):
-        data: Order
-
-        # auto transform json string
-        # so Pydantic can auto-initialize nested Order model
-        @validator("data", pre=True)
-        def transform_message_to_dict(cls, value: str):
-            # Powertools KinesisDataStreamRecord already decodes b64 to str here
-            return json.loads(value)
+        data: Json[Order]
 
 
     class OrderKinesisRecord(KinesisDataStreamRecord):


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
**Issue number:** #2090

## Summary

Docs leftover from previous PR before release.

### Changes

> Please provide a summary of what's being changed

Recommends a less verbose option to auto-deserialize Batch records ingested as JSON String for SQS and Kinesis.

### User experience

> Please share what the user experience looks like before and after this change

**BEFORE**

```python
import json

from aws_lambda_powertools import Logger, Tracer
from aws_lambda_powertools.utilities.batch import BatchProcessor, EventType, process_partial_response
from aws_lambda_powertools.utilities.parser.models import SqsRecordModel
from aws_lambda_powertools.utilities.typing import LambdaContext
from aws_lambda_powertools.utilities.parser import validator, BaseModel


class Order(BaseModel):
    item: dict

class OrderSqsRecord(SqsRecordModel):
    body: Order

    # auto transform json string
    # so Pydantic can auto-initialize nested Order model
    @validator("body", pre=True)
    def transform_body_to_dict(cls, value: str):
        return json.loads(value)

processor = BatchProcessor(event_type=EventType.SQS, model=OrderSqsRecord)
tracer = Tracer()
logger = Logger()


@tracer.capture_method
def record_handler(record: OrderSqsRecord):
    return record.body.item

@logger.inject_lambda_context
@tracer.capture_lambda_handler
def lambda_handler(event, context: LambdaContext):
    return process_partial_response(event=event, record_handler=record_handler, processor=processor, context=context)

```

**AFTER**

```python
import json

from aws_lambda_powertools import Logger, Tracer
from aws_lambda_powertools.utilities.batch import BatchProcessor, EventType, process_partial_response
from aws_lambda_powertools.utilities.parser.models import SqsRecordModel
from aws_lambda_powertools.utilities.typing import LambdaContext
from aws_lambda_powertools.utilities.parser import BaseModel
from aws_lambda_powertools.utilities.parser.types import Json


class Order(BaseModel):
    item: dict

class OrderSqsRecord(SqsRecordModel):
    body: Json[Order]  # deserialize order data from JSON string

processor = BatchProcessor(event_type=EventType.SQS, model=OrderSqsRecord)
tracer = Tracer()
logger = Logger()


@tracer.capture_method
def record_handler(record: OrderSqsRecord):
    return record.body.item

@logger.inject_lambda_context
@tracer.capture_lambda_handler
def lambda_handler(event, context: LambdaContext):
    return process_partial_response(event=event, record_handler=record_handler, processor=processor, context=context)

```

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] [Meet tenets criteria](https://awslabs.github.io/aws-lambda-powertools-python/#tenets)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented
* [x] PR title follows [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-python/blob/develop/.github/semantic.yml)

<details>
<summary>Is this a breaking change?</summary>

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
