### PR TITLE
chore(ci): add support for x86-64 regions only

### DIFF
--- a/.github/workflows/reusable_deploy_v2_layer_stack.yml
+++ b/.github/workflows/reusable_deploy_v2_layer_stack.yml
@@ -34,31 +34,63 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        region:
-          [
-            "af-south-1",
-            "eu-central-1",
-            "us-east-1",
-            "us-east-2",
-            "us-west-1",
-            "us-west-2",
-            "ap-east-1",
-            "ap-south-1",
-            "ap-northeast-1",
-            "ap-northeast-2",
-            "ap-southeast-1",
-            "ap-southeast-2",
-            "ca-central-1",
-            "eu-west-1",
-            "eu-west-2",
-            "eu-west-3",
-            "eu-south-1",
-            "eu-north-1",
-            "sa-east-1",
-            "ap-southeast-3",
-            "ap-northeast-3",
-            "me-south-1",
-          ]
+        # To get a list of current regions, use:
+        # aws ec2 describe-regions --all-regions --query "Regions[].RegionName" --output text | tr "\t" "\n" | sort
+        include:
+          - region: "af-south-1"
+            has_arm64_support: "true"
+          - region: "ap-east-1"
+            has_arm64_support: "true"
+          - region: "ap-northeast-1"
+            has_arm64_support: "true"
+          - region: "ap-northeast-2"
+            has_arm64_support: "true"
+          - region: "ap-northeast-3"
+            has_arm64_support: "true"
+          - region: "ap-south-1"
+            has_arm64_support: "true"
+          - region: "ap-south-2"
+            has_arm64_support: "false"
+          - region: "ap-southeast-1"
+            has_arm64_support: "true"
+          - region: "ap-southeast-2"
+            has_arm64_support: "true"
+          - region: "ap-southeast-3"
+            has_arm64_support: "true"
+          - region: "ap-southeast-4"
+            has_arm64_support: "false"
+          - region: "ca-central-1"
+            has_arm64_support: "true"
+          - region: "eu-central-1"
+            has_arm64_support: "true"
+          - region: "eu-central-2"
+            has_arm64_support: "false"
+          - region: "eu-north-1"
+            has_arm64_support: "true"
+          - region: "eu-south-1"
+            has_arm64_support: "true"
+          - region: "eu-south-2"
+            has_arm64_support: "false"
+          - region: "eu-west-1"
+            has_arm64_support: "true"
+          - region: "eu-west-2"
+            has_arm64_support: "true"
+          - region: "eu-west-3"
+            has_arm64_support: "true"
+          - region: "me-central-1"
+            has_arm64_support: "false"
+          - region: "me-south-1"
+            has_arm64_support: "true"
+          - region: "sa-east-1"
+            has_arm64_support: "true"
+          - region: "us-east-1"
+            has_arm64_support: "true"
+          - region: "us-east-2"
+            has_arm64_support: "true"
+          - region: "us-west-1"
+            has_arm64_support: "true"
+          - region: "us-west-2"
+            has_arm64_support: "true"
     steps:
       - name: checkout
         uses: actions/checkout@v3
@@ -99,7 +131,7 @@ jobs:
       - name: unzip artefact
         run: unzip cdk.out.zip
       - name: CDK Deploy Layer
-        run: npx cdk deploy --app cdk.out --context region=${{ matrix.region }} 'LayerV2Stack' --require-approval never --verbose --outputs-file cdk-outputs.json
+        run: npx cdk deploy --app cdk.out --context region=${{ matrix.region }} --parameters HasARM64Support=${{ matrix.has_arm64_support }} 'LayerV2Stack' --require-approval never --verbose --outputs-file cdk-outputs.json
       - name: Store latest Layer ARN
         if: ${{ inputs.stage == 'PROD' }}
         run: |
@@ -116,7 +148,7 @@ jobs:
           if-no-files-found: error
           retention-days: 1
       - name: CDK Deploy Canary
-        run: npx cdk deploy --app cdk.out --context region=${{ matrix.region}} --parameters DeployStage="${{ inputs.stage }}" 'CanaryV2Stack' --require-approval never --verbose
+        run: npx cdk deploy --app cdk.out --context region=${{ matrix.region }} --parameters DeployStage="${{ inputs.stage }}" --parameters HasARM64Support=${{ matrix.has_arm64_support }} 'CanaryV2Stack' --require-approval never --verbose
 
   update_v2_layer_arn_docs:
     needs: deploy-cdk-stack

--- a/layer/app.py
+++ b/layer/app.py
@@ -21,7 +21,7 @@ LayerStack(
     app,
     "LayerV2Stack",
     powertools_version=POWERTOOLS_VERSION,
-    ssm_paramter_layer_arn=SSM_PARAM_LAYER_ARN,
+    ssm_parameter_layer_arn=SSM_PARAM_LAYER_ARN,
     ssm_parameter_layer_arm64_arn=SSM_PARAM_LAYER_ARM64_ARN,
 )
 

--- a/layer/layer/layer_stack.py
+++ b/layer/layer/layer_stack.py
@@ -39,7 +39,7 @@ class Layer(Construct):
         powertools_version: str,
         architecture: Optional[Architecture] = None,
         **kwargs
-    ):
+    ) -> None:
         super().__init__(scope, construct_id, **kwargs)
 
         layer = LambdaPowertoolsLayer(

--- a/layer/layer/layer_stack.py
+++ b/layer/layer/layer_stack.py
@@ -1,39 +1,58 @@
-from aws_cdk import CfnOutput, RemovalPolicy, Stack
+from typing import Optional
+
+import jsii
+from aws_cdk import (
+    Aspects,
+    CfnCondition,
+    CfnOutput,
+    CfnParameter,
+    CfnResource,
+    Fn,
+    IAspect,
+    RemovalPolicy,
+    Stack,
+)
 from aws_cdk.aws_lambda import Architecture, CfnLayerVersionPermission
 from aws_cdk.aws_ssm import StringParameter
 from cdk_aws_lambda_powertools_layer import LambdaPowertoolsLayer
 from constructs import Construct
 
 
-class LayerStack(Stack):
+@jsii.implements(IAspect)
+class ApplyCondition:
+    def __init__(self, condition: CfnCondition):
+        self.condition = condition
+
+    def visit(self, node):
+        if isinstance(node, CfnResource):
+            node.cfn_options.condition = self.condition
+        if isinstance(node, CfnOutput):
+            node.condition = self.condition
+
+
+class Layer(Construct):
     def __init__(
         self,
         scope: Construct,
         construct_id: str,
+        layer_version_name: str,
         powertools_version: str,
-        ssm_paramter_layer_arn: str,
-        ssm_parameter_layer_arm64_arn: str,
+        architecture: Optional[Architecture] = None,
         **kwargs
-    ) -> None:
+    ):
         super().__init__(scope, construct_id, **kwargs)
 
         layer = LambdaPowertoolsLayer(
             self,
             "Layer",
-            layer_version_name="AWSLambdaPowertoolsPythonV2",
+            layer_version_name=layer_version_name,
             version=powertools_version,
             include_extras=True,
-            compatible_architectures=[Architecture.X86_64],
+            compatible_architectures=[architecture] if architecture else [],
         )
+        layer.apply_removal_policy(RemovalPolicy.RETAIN)
 
-        layer_arm64 = LambdaPowertoolsLayer(
-            self,
-            "Layer-ARM64",
-            layer_version_name="AWSLambdaPowertoolsPythonV2-Arm64",
-            version=powertools_version,
-            include_extras=True,
-            compatible_architectures=[Architecture.ARM_64],
-        )
+        self.layer_version_arn = layer.layer_version_arn
 
         layer_permission = CfnLayerVersionPermission(
             self,
@@ -42,33 +61,115 @@ class LayerStack(Stack):
             layer_version_arn=layer.layer_version_arn,
             principal="*",
         )
-
-        layer_permission_arm64 = CfnLayerVersionPermission(
-            self,
-            "PublicLayerAccessArm64",
-            action="lambda:GetLayerVersion",
-            layer_version_arn=layer_arm64.layer_version_arn,
-            principal="*",
-        )
-
         layer_permission.apply_removal_policy(RemovalPolicy.RETAIN)
-        layer_permission_arm64.apply_removal_policy(RemovalPolicy.RETAIN)
 
-        layer.apply_removal_policy(RemovalPolicy.RETAIN)
-        layer_arm64.apply_removal_policy(RemovalPolicy.RETAIN)
 
-        StringParameter(
+class LayerStack(Stack):
+    def __init__(
+        self,
+        scope: Construct,
+        construct_id: str,
+        powertools_version: str,
+        ssm_parameter_layer_arn: str,
+        ssm_parameter_layer_arm64_arn: str,
+        **kwargs
+    ) -> None:
+        super().__init__(scope, construct_id, **kwargs)
+
+        has_arm64_support = CfnParameter(
             self,
-            "VersionArn",
-            parameter_name=ssm_paramter_layer_arn,
-            string_value=layer.layer_version_arn,
+            "HasARM64Suppor",
+            description="Has ARM64 Support Condition",
+            type="String",
+            allowed_values=["true", "false"],
         )
+
+        has_arm64_condition = CfnCondition(
+            self,
+            "HasARM64SupportCondition",
+            expression=Fn.condition_equals(has_arm64_support, "true"),
+        )
+        has_no_arm64_condition = CfnCondition(
+            self,
+            "HasNOArm64SupportCondition",
+            expression=Fn.condition_equals(has_arm64_support, "false"),
+        )
+
+        # The following code is used when the region does not support ARM64 Lambdas. We make sure to only create the
+        # X86_64 Layer without specifying any compatible architecture, which would result in a CloudFormation error.
+
+        layer_single = Layer(
+            self,
+            "LayerSingle",
+            layer_version_name="AWSLambdaPowertoolsPythonV2",
+            powertools_version=powertools_version,
+        )
+        Aspects.of(layer_single).add(ApplyCondition(has_no_arm64_condition))
+
+        Aspects.of(
+            StringParameter(
+                self,
+                "SingleVersionArn",
+                parameter_name=ssm_parameter_layer_arn,
+                string_value=layer_single.layer_version_arn,
+            )
+        ).add(ApplyCondition(has_no_arm64_condition))
+
+        # The following code is used when the region has support for ARM64 Lambdas. In this case, we explicitly
+        # create a Layer for both X86_64 and ARM64, specifying the compatible architectures.
+
+        # X86_64 layer
+
+        layer = Layer(
+            self,
+            "Layer",
+            layer_version_name="AWSLambdaPowertoolsPythonV2",
+            powertools_version=powertools_version,
+            architecture=Architecture.X86_64,
+        )
+        Aspects.of(layer).add(ApplyCondition(has_arm64_condition))
+
+        Aspects.of(
+            StringParameter(
+                self,
+                "VersionArn",
+                parameter_name=ssm_parameter_layer_arn,
+                string_value=layer.layer_version_arn,
+            )
+        ).add(ApplyCondition(has_arm64_condition))
+
+        CfnOutput(
+            self,
+            "LatestLayerArn",
+            value=Fn.condition_if(
+                has_arm64_condition.logical_id,
+                layer.layer_version_arn,
+                layer_single.layer_version_arn,
+            ).to_string(),
+        )
+
+        # ARM64 layer
+
+        layer_arm64 = Layer(
+            self,
+            "Layer-ARM64",
+            layer_version_name="AWSLambdaPowertoolsPythonV2-Arm64",
+            powertools_version=powertools_version,
+            architecture=Architecture.ARM_64,
+        )
+        Aspects.of(layer_arm64).add(ApplyCondition(has_arm64_condition))
+
         StringParameter(
             self,
             "Arm64VersionArn",
             parameter_name=ssm_parameter_layer_arm64_arn,
-            string_value=layer_arm64.layer_version_arn,
+            string_value=Fn.condition_if(
+                has_arm64_condition.logical_id,
+                layer_arm64.layer_version_arn,
+                "none",
+            ).to_string(),
         )
 
-        CfnOutput(self, "LatestLayerArn", value=layer.layer_version_arn)
-        CfnOutput(self, "LatestLayerArm64Arn", value=layer_arm64.layer_version_arn)
+        Aspects.of(
+            CfnOutput(self, "LatestLayerArm64Arn", value=layer_arm64.layer_version_arn)
+        ).add(ApplyCondition(has_arm64_condition))

--- a/layer/poetry.lock
+++ b/layer/poetry.lock
@@ -2,32 +2,33 @@
 
 [[package]]
 name = "attrs"
-version = "22.1.0"
+version = "22.2.0"
 description = "Classes Without Boilerplate"
 category = "main"
 optional = false
-python-versions = ">=3.5"
+python-versions = ">=3.6"
 files = [
-    {file = "attrs-22.1.0-py2.py3-none-any.whl", hash = "sha256:86efa402f67bf2df34f51a335487cf46b1ec130d02b8d39fd248abfd30da551c"},
-    {file = "attrs-22.1.0.tar.gz", hash = "sha256:29adc2665447e5191d0e7c568fde78b21f9672d344281d0c6e1ab085429b22b6"},
+    {file = "attrs-22.2.0-py3-none-any.whl", hash = "sha256:29e95c7f6778868dbd49170f98f8818f78f3dc5e0e37c0b1f474e3561b240836"},
+    {file = "attrs-22.2.0.tar.gz", hash = "sha256:c9227bfc2f01993c03f68db37d1d15c9690188323c067c641f1a35ca58185f99"},
 ]
 
 [package.extras]
-dev = ["cloudpickle", "coverage[toml] (>=5.0.2)", "furo", "hypothesis", "mypy (>=0.900,!=0.940)", "pre-commit", "pympler", "pytest (>=4.3.0)", "pytest-mypy-plugins", "sphinx", "sphinx-notfound-page", "zope.interface"]
-docs = ["furo", "sphinx", "sphinx-notfound-page", "zope.interface"]
-tests = ["cloudpickle", "coverage[toml] (>=5.0.2)", "hypothesis", "mypy (>=0.900,!=0.940)", "pympler", "pytest (>=4.3.0)", "pytest-mypy-plugins", "zope.interface"]
-tests-no-zope = ["cloudpickle", "coverage[toml] (>=5.0.2)", "hypothesis", "mypy (>=0.900,!=0.940)", "pympler", "pytest (>=4.3.0)", "pytest-mypy-plugins"]
+cov = ["attrs[tests]", "coverage-enable-subprocess", "coverage[toml] (>=5.3)"]
+dev = ["attrs[docs,tests]"]
+docs = ["furo", "myst-parser", "sphinx", "sphinx-notfound-page", "sphinxcontrib-towncrier", "towncrier", "zope.interface"]
+tests = ["attrs[tests-no-zope]", "zope.interface"]
+tests-no-zope = ["cloudpickle", "cloudpickle", "hypothesis", "hypothesis", "mypy (>=0.971,<0.990)", "mypy (>=0.971,<0.990)", "pympler", "pympler", "pytest (>=4.3.0)", "pytest (>=4.3.0)", "pytest-mypy-plugins", "pytest-mypy-plugins", "pytest-xdist[psutil]", "pytest-xdist[psutil]"]
 
 [[package]]
 name = "aws-cdk-asset-awscli-v1"
-version = "2.2.137"
+version = "2.2.138"
 description = "A library that contains the AWS CLI for use in Lambda Layers"
 category = "main"
 optional = false
 python-versions = "~=3.7"
 files = [
-    {file = "aws-cdk.asset-awscli-v1-2.2.137.tar.gz", hash = "sha256:699e17416635f82d3a92ff5edc99725b4d473b1be2b22b38e060d4aa2153683e"},
-    {file = "aws_cdk.asset_awscli_v1-2.2.137-py3-none-any.whl", hash = "sha256:cbd931a07c817c0cced3431a6d19f8169a7d95ec0dbb15d7b28ad8e11f3cdf1a"},
+    {file = "aws-cdk.asset-awscli-v1-2.2.138.tar.gz", hash = "sha256:0a6880aa02399f74102e120aee96db75ec122a199b0735494c3dbcd09bd89c9c"},
+    {file = "aws_cdk.asset_awscli_v1-2.2.138-py3-none-any.whl", hash = "sha256:d1f4e1b6a4bf5e9f1a7380a6141a3bf55d6fb6f1abfb0e1450bb258de3702f01"},
 ]
 
 [package.dependencies]
@@ -54,14 +55,14 @@ typeguard = ">=2.13.3,<2.14.0"
 
 [[package]]
 name = "aws-cdk-asset-node-proxy-agent-v5"
-version = "2.0.113"
+version = "2.0.114"
 description = "@aws-cdk/asset-node-proxy-agent-v5"
 category = "main"
 optional = false
 python-versions = "~=3.7"
 files = [
-    {file = "aws-cdk.asset-node-proxy-agent-v5-2.0.113.tar.gz", hash = "sha256:bdd26ce3689940373af73739f01b8e4a12fb701a64976c30e2532d481e0e7b35"},
-    {file = "aws_cdk.asset_node_proxy_agent_v5-2.0.113-py3-none-any.whl", hash = "sha256:179264ce2ad15fb4252995b2320f75ae1b3472881f1d5371137d4f6549137db8"},
+    {file = "aws-cdk.asset-node-proxy-agent-v5-2.0.114.tar.gz", hash = "sha256:5f8a0ecb4128617ef8321dd1b3501b52e4a071e7481a7d1498775897299f7349"},
+    {file = "aws_cdk.asset_node_proxy_agent_v5-2.0.114-py3-none-any.whl", hash = "sha256:3b034917bd15f84c710b031dbd29d7fbbb665ce16a609eaabd890fa47949df40"},
 ]
 
 [package.dependencies]
@@ -92,18 +93,18 @@ typeguard = ">=2.13.3,<2.14.0"
 
 [[package]]
 name = "boto3"
-version = "1.24.89"
+version = "1.26.112"
 description = "The AWS SDK for Python"
 category = "dev"
 optional = false
 python-versions = ">= 3.7"
 files = [
-    {file = "boto3-1.24.89-py3-none-any.whl", hash = "sha256:346f8f0d101a4261dac146a959df18d024feda6431e1d9d84f94efd24d086cae"},
-    {file = "boto3-1.24.89.tar.gz", hash = "sha256:d0d8ffcdc10821c4562bc7f935cdd840033bbc342ac0e14b6bdd348b3adf4c04"},
+    {file = "boto3-1.26.112-py3-none-any.whl", hash = "sha256:03c2e1ddd29d993a6ab9b8a8fe184027957fc32bd405c496ad0c30311445925f"},
+    {file = "boto3-1.26.112.tar.gz", hash = "sha256:4ea3319bba2e8ff7cd9560259ae64f073c7fb6312158aa375777687231cabe69"},
 ]
 
 [package.dependencies]
-botocore = ">=1.27.89,<1.28.0"
+botocore = ">=1.29.112,<1.30.0"
 jmespath = ">=0.7.1,<2.0.0"
 s3transfer = ">=0.6.0,<0.7.0"
 
@@ -112,14 +113,14 @@ crt = ["botocore[crt] (>=1.21.0,<2.0a0)"]
 
 [[package]]
 name = "botocore"
-version = "1.27.89"
+version = "1.29.112"
 description = "Low-level, data-driven core of boto 3."
 category = "dev"
 optional = false
 python-versions = ">= 3.7"
 files = [
-    {file = "botocore-1.27.89-py3-none-any.whl", hash = "sha256:238f1dfdb8d8d017c2aea082609a3764f3161d32745900f41bcdcf290d95a048"},
-    {file = "botocore-1.27.89.tar.gz", hash = "sha256:621f5413be8f97712b7e36c1b075a8791d1d1b9971a7ee060cdcdf5e2debf6c1"},
+    {file = "botocore-1.29.112-py3-none-any.whl", hash = "sha256:2cbaddb09b46dcb0a05490724d51acb224d3a8df433c347f995b4d78bfb02c8a"},
+    {file = "botocore-1.29.112.tar.gz", hash = "sha256:1f52d9371d7b5ee30a53dcef7954c3cf22e04b131cfab5268035f3299ccde9e1"},
 ]
 
 [package.dependencies]
@@ -128,34 +129,34 @@ python-dateutil = ">=2.1,<3.0.0"
 urllib3 = ">=1.25.4,<1.27"
 
 [package.extras]
-crt = ["awscrt (==0.14.0)"]
+crt = ["awscrt (==0.16.9)"]
 
 [[package]]
 name = "cattrs"
-version = "22.1.0"
+version = "22.2.0"
 description = "Composable complex class support for attrs and dataclasses."
 category = "main"
 optional = false
-python-versions = ">=3.7,<4.0"
+python-versions = ">=3.7"
 files = [
-    {file = "cattrs-22.1.0-py3-none-any.whl", hash = "sha256:d55c477b4672f93606e992049f15d526dc7867e6c756cd6256d4af92e2b1e364"},
-    {file = "cattrs-22.1.0.tar.gz", hash = "sha256:94b67b64cf92c994f8784c40c082177dc916e0489a73a9a36b24eb18a9db40c6"},
+    {file = "cattrs-22.2.0-py3-none-any.whl", hash = "sha256:bc12b1f0d000b9f9bee83335887d532a1d3e99a833d1bf0882151c97d3e68c21"},
+    {file = "cattrs-22.2.0.tar.gz", hash = "sha256:f0eed5642399423cf656e7b66ce92cdc5b963ecafd041d1b24d136fdde7acf6d"},
 ]
 
 [package.dependencies]
 attrs = ">=20"
-exceptiongroup = {version = "*", markers = "python_version <= \"3.10\""}
+exceptiongroup = {version = "*", markers = "python_version < \"3.11\""}
 
 [[package]]
 name = "cdk-aws-lambda-powertools-layer"
-version = "3.3.1"
+version = "3.4.0"
 description = "A lambda layer for AWS Powertools for python and typescript"
 category = "main"
 optional = false
 python-versions = "~=3.7"
 files = [
-    {file = "cdk-aws-lambda-powertools-layer-3.3.1.tar.gz", hash = "sha256:6cc48ec407a351bed40af64fc810eb51c6b619baa66fe1d6457c1d5ba195a632"},
-    {file = "cdk_aws_lambda_powertools_layer-3.3.1-py3-none-any.whl", hash = "sha256:9c050a8edf787538cd802cf67bfb5a6843c4b00e11584cfa5f9d359c8a46c946"},
+    {file = "cdk-aws-lambda-powertools-layer-3.4.0.tar.gz", hash = "sha256:3d3e89cb3b0f201f6f96473208e66b18279688049317d9c9849584a03c5d54a0"},
+    {file = "cdk_aws_lambda_powertools_layer-3.4.0-py3-none-any.whl", hash = "sha256:bb3c157de17d3fbdcbdc33e5ee967cc80606bbb7a14f46e4f1f6cc8c28db5c86"},
 ]
 
 [package.dependencies]
@@ -167,43 +168,43 @@ typeguard = ">=2.13.3,<2.14.0"
 
 [[package]]
 name = "colorama"
-version = "0.4.5"
+version = "0.4.6"
 description = "Cross-platform colored terminal text."
 category = "dev"
 optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,!=3.6.*,>=2.7"
 files = [
-    {file = "colorama-0.4.5-py2.py3-none-any.whl", hash = "sha256:854bf444933e37f5824ae7bfc1e98d5bce2ebe4160d46b5edf346a89358e99da"},
-    {file = "colorama-0.4.5.tar.gz", hash = "sha256:e6c6b4334fc50988a639d9b98aa429a0b57da6e17b9a44f0451f930b6967b7a4"},
+    {file = "colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6"},
+    {file = "colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44"},
 ]
 
 [[package]]
 name = "constructs"
-version = "10.1.128"
+version = "10.1.309"
 description = "A programming model for software-defined state"
 category = "main"
 optional = false
 python-versions = "~=3.7"
 files = [
-    {file = "constructs-10.1.128-py3-none-any.whl", hash = "sha256:d6fbc88de4c2517b59e28a9d0bc3663e75decbe3464030b5bc53809868b52c9e"},
-    {file = "constructs-10.1.128.tar.gz", hash = "sha256:6789412823ae27b39f659537337f688a9d555cad5845d4b821c7be02a061be1e"},
+    {file = "constructs-10.1.309-py3-none-any.whl", hash = "sha256:3127067e99151d1094b05443452bc9f84c685a719c00031c7b5e55e294e0deb7"},
+    {file = "constructs-10.1.309.tar.gz", hash = "sha256:cbc36a68187d4c9dd33b46b87aac2dda469bfda95c37d4c198bd98911064dce8"},
 ]
 
 [package.dependencies]
-jsii = ">=1.69.0,<2.0.0"
+jsii = ">=1.80.0,<2.0.0"
 publication = ">=0.0.3"
 typeguard = ">=2.13.3,<2.14.0"
 
 [[package]]
 name = "exceptiongroup"
-version = "1.0.0rc9"
+version = "1.1.1"
 description = "Backport of PEP 654 (exception groups)"
 category = "main"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "exceptiongroup-1.0.0rc9-py3-none-any.whl", hash = "sha256:2e3c3fc1538a094aab74fad52d6c33fc94de3dfee3ee01f187c0e0c72aec5337"},
-    {file = "exceptiongroup-1.0.0rc9.tar.gz", hash = "sha256:9086a4a21ef9b31c72181c77c040a074ba0889ee56a7b289ff0afb0d97655f96"},
+    {file = "exceptiongroup-1.1.1-py3-none-any.whl", hash = "sha256:232c37c63e4f682982c8b6459f33a8981039e5fb8756b2074364e5055c498c9e"},
+    {file = "exceptiongroup-1.1.1.tar.gz", hash = "sha256:d484c3090ba2889ae2928419117447a14daf3c1231d5e30d0aae34f354f01785"},
 ]
 
 [package.extras]
@@ -230,14 +231,14 @@ testing = ["flake8 (<5)", "pytest (>=6)", "pytest-black (>=0.3.7)", "pytest-chec
 
 [[package]]
 name = "iniconfig"
-version = "1.1.1"
-description = "iniconfig: brain-dead simple config-ini parsing"
+version = "2.0.0"
+description = "brain-dead simple config-ini parsing"
 category = "dev"
 optional = false
-python-versions = "*"
+python-versions = ">=3.7"
 files = [
-    {file = "iniconfig-1.1.1-py2.py3-none-any.whl", hash = "sha256:011e24c64b7f47f6ebd835bb12a743f2fbe9a26d4cecaa7f53bc4f35ee9da8b3"},
-    {file = "iniconfig-1.1.1.tar.gz", hash = "sha256:bc3af051d7d14b2ee5ef9969666def0cd1a000e121eaea580d4a313df4b37f32"},
+    {file = "iniconfig-2.0.0-py3-none-any.whl", hash = "sha256:b6a85871a79d2e3b22d2d1b94ac2824226a63c6b741c88f7ae975f18b6778374"},
+    {file = "iniconfig-2.0.0.tar.gz", hash = "sha256:2d91e135bf72d31a410b17c16da610a82cb55f6b0477d1a902134b24a455b8b3"},
 ]
 
 [[package]]
@@ -275,18 +276,15 @@ typing-extensions = ">=3.7,<5.0"
 
 [[package]]
 name = "packaging"
-version = "21.3"
+version = "23.1"
 description = "Core utilities for Python packages"
 category = "dev"
 optional = false
-python-versions = ">=3.6"
+python-versions = ">=3.7"
 files = [
-    {file = "packaging-21.3-py3-none-any.whl", hash = "sha256:ef103e05f519cdc783ae24ea4e2e0f508a9c99b2d4969652eed6a2e1ea5bd522"},
-    {file = "packaging-21.3.tar.gz", hash = "sha256:dd47c42927d89ab911e606518907cc2d3a1f38bbd026385970643f9c5b8ecfeb"},
+    {file = "packaging-23.1-py3-none-any.whl", hash = "sha256:994793af429502c4ea2ebf6bf664629d07c1a9fe974af92966e4b8d2df7edc61"},
+    {file = "packaging-23.1.tar.gz", hash = "sha256:a392980d2b6cffa644431898be54b0045151319d1e7ec34f0cfed48767dd334f"},
 ]
-
-[package.dependencies]
-pyparsing = ">=2.0.2,<3.0.5 || >3.0.5"
 
 [[package]]
 name = "pluggy"
@@ -317,55 +315,27 @@ files = [
 ]
 
 [[package]]
-name = "py"
-version = "1.11.0"
-description = "library with cross-python path, ini-parsing, io, code, log facilities"
-category = "dev"
-optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
-files = [
-    {file = "py-1.11.0-py2.py3-none-any.whl", hash = "sha256:607c53218732647dff4acdfcd50cb62615cedf612e72d1724fb1a0cc6405b378"},
-    {file = "py-1.11.0.tar.gz", hash = "sha256:51c75c4126074b472f746a24399ad32f6053d1b34b68d2fa41e558e6f4a98719"},
-]
-
-[[package]]
-name = "pyparsing"
-version = "3.0.9"
-description = "pyparsing module - Classes and methods to define and execute parsing grammars"
-category = "dev"
-optional = false
-python-versions = ">=3.6.8"
-files = [
-    {file = "pyparsing-3.0.9-py3-none-any.whl", hash = "sha256:5026bae9a10eeaefb61dab2f09052b9f4307d44aee4eda64b309723d8d206bbc"},
-    {file = "pyparsing-3.0.9.tar.gz", hash = "sha256:2b020ecf7d21b687f219b71ecad3631f644a47f01403fa1d1036b0c6416d70fb"},
-]
-
-[package.extras]
-diagrams = ["jinja2", "railroad-diagrams"]
-
-[[package]]
 name = "pytest"
-version = "7.1.3"
+version = "7.3.0"
 description = "pytest: simple powerful testing with Python"
 category = "dev"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "pytest-7.1.3-py3-none-any.whl", hash = "sha256:1377bda3466d70b55e3f5cecfa55bb7cfcf219c7964629b967c37cf0bda818b7"},
-    {file = "pytest-7.1.3.tar.gz", hash = "sha256:4f365fec2dff9c1162f834d9f18af1ba13062db0c708bf7b946f8a5c76180c39"},
+    {file = "pytest-7.3.0-py3-none-any.whl", hash = "sha256:933051fa1bfbd38a21e73c3960cebdad4cf59483ddba7696c48509727e17f201"},
+    {file = "pytest-7.3.0.tar.gz", hash = "sha256:58ecc27ebf0ea643ebfdf7fb1249335da761a00c9f955bcd922349bcb68ee57d"},
 ]
 
 [package.dependencies]
-attrs = ">=19.2.0"
 colorama = {version = "*", markers = "sys_platform == \"win32\""}
+exceptiongroup = {version = ">=1.0.0rc8", markers = "python_version < \"3.11\""}
 iniconfig = "*"
 packaging = "*"
 pluggy = ">=0.12,<2.0"
-py = ">=1.8.2"
-tomli = ">=1.0.0"
+tomli = {version = ">=1.0.0", markers = "python_version < \"3.11\""}
 
 [package.extras]
-testing = ["argcomplete", "hypothesis (>=3.56)", "mock", "nose", "pygments (>=2.7.2)", "requests", "xmlschema"]
+testing = ["argcomplete", "attrs (>=19.2.0)", "hypothesis (>=3.56)", "mock", "nose", "pygments (>=2.7.2)", "requests", "xmlschema"]
 
 [[package]]
 name = "python-dateutil"
@@ -442,26 +412,26 @@ test = ["mypy", "pytest", "typing-extensions"]
 
 [[package]]
 name = "typing-extensions"
-version = "4.4.0"
+version = "4.5.0"
 description = "Backported and Experimental Type Hints for Python 3.7+"
 category = "main"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "typing_extensions-4.4.0-py3-none-any.whl", hash = "sha256:16fa4864408f655d35ec496218b85f79b3437c829e93320c7c9215ccfd92489e"},
-    {file = "typing_extensions-4.4.0.tar.gz", hash = "sha256:1511434bb92bf8dd198c12b1cc812e800d4181cfcb867674e0f8279cc93087aa"},
+    {file = "typing_extensions-4.5.0-py3-none-any.whl", hash = "sha256:fb33085c39dd998ac16d1431ebc293a8b3eedd00fd4a32de0ff79002c19511b4"},
+    {file = "typing_extensions-4.5.0.tar.gz", hash = "sha256:5cb5f4a79139d699607b3ef622a1dedafa84e115ab0024e0d9c044a9479ca7cb"},
 ]
 
 [[package]]
 name = "urllib3"
-version = "1.26.12"
+version = "1.26.15"
 description = "HTTP library with thread-safe connection pooling, file post, and more."
 category = "dev"
 optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*, <4"
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*"
 files = [
-    {file = "urllib3-1.26.12-py2.py3-none-any.whl", hash = "sha256:b930dd878d5a8afb066a637fbb35144fe7901e3b209d1cd4f524bd0e9deee997"},
-    {file = "urllib3-1.26.12.tar.gz", hash = "sha256:3fa96cf423e6987997fc326ae8df396db2a8b7c667747d47ddd8ecba91f4a74e"},
+    {file = "urllib3-1.26.15-py2.py3-none-any.whl", hash = "sha256:aa751d169e23c7479ce47a0cb0da579e3ede798f994f5816a74e4f4500dcea42"},
+    {file = "urllib3-1.26.15.tar.gz", hash = "sha256:8a388717b9476f934a21484e8c8e61875ab60644d29b9b39e11e4b9dc1c6b305"},
 ]
 
 [package.extras]
@@ -488,4 +458,4 @@ testing = ["big-O", "flake8 (<5)", "jaraco.functools", "jaraco.itertools", "more
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9"
-content-hash = "8e77638e46b8fc0affe4fc283c80bf17846ccdfd357832343bb9fc07f47a8f77"
+content-hash = "ade085b1989174ee03e7f27a781b580e2f7199441da6d8f60b3bf7891f6ca66e"

--- a/layer/pyproject.toml
+++ b/layer/pyproject.toml
@@ -7,7 +7,7 @@ license = "MIT"
 
 [tool.poetry.dependencies]
 python = "^3.9"
-cdk-aws-lambda-powertools-layer = "^3.3.1"
+cdk-aws-lambda-powertools-layer = "^3.4.0"
 
 [tool.poetry.dev-dependencies]
 pytest = "^7.1.2"


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
**Issue number:** #1950

## Summary

### Changes

> Please provide a summary of what's being changed

This PR changes our Layer and Canary stack to support regions that only support x86_64 Lambdas. We couldn't find an easy and reliable way to
detect dinamically if a given region supports ARM64 Lambdas, so instead we maintain the map manually and indicate which regions don't support it.

This makes heavy use of CDK/CloudFormation Parameters and Conditions, so the same CloudFormation template can be used across all regions.

### User experience

> Please share what the user experience looks like before and after this change

After this change, we will generate Lambda Layers for regions that only support x86_64 Lambdas. We will need to update the documentation when the 
first Layer version is generated, and validate that the script to update the layer version in the docs works with the single-architecture regions.

### Regions that will be added by this PR

- ap-south-2
- ap-southeast-4
- eu-central-2
- eu-south-2
- me-central-1

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] [Meet tenets criteria](https://awslabs.github.io/aws-lambda-powertools-python/#tenets)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented
* [ ] PR title follows [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-python/blob/develop/.github/semantic.yml)

<details>
<summary>Is this a breaking change?</summary>

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
