### PR TITLE
feat(event_sources): Add __str__ to Data Classes base DictWrapper

### DIFF
--- a/aws_lambda_powertools/utilities/data_classes/code_pipeline_job_event.py
+++ b/aws_lambda_powertools/utilities/data_classes/code_pipeline_job_event.py
@@ -80,6 +80,8 @@ class CodePipelineArtifact(DictWrapper):
 
 
 class CodePipelineArtifactCredentials(DictWrapper):
+    _sensitive_properties = ["secret_access_key", "session_token"]
+
     @property
     def access_key_id(self) -> str:
         return self["accessKeyId"]

--- a/aws_lambda_powertools/utilities/data_classes/common.py
+++ b/aws_lambda_powertools/utilities/data_classes/common.py
@@ -55,14 +55,16 @@ class DictWrapper(Mapping):
                     property_value = getattr(self, property_key)
                     result[property_key] = property_value
 
+                    # Checks whether the class is a subclass of the parent class to perform a recursive operation.
                     if issubclass(property_value.__class__, DictWrapper):
                         result[property_key] = property_value._str_helper()
+                    # Checks if the key is a list and if it is a subclass of the parent class
                     elif isinstance(property_value, list):
                         for seq, item in enumerate(property_value):
                             if issubclass(item.__class__, DictWrapper):
                                 result[property_key][seq] = item._str_helper()
-                except Exception as e:
-                    result[property_key] = f"[EXCEPTION {type(e)}]"
+                except Exception:
+                    result[property_key] = "[Cannot be deserialized]"
 
         return result
 

--- a/aws_lambda_powertools/utilities/data_classes/common.py
+++ b/aws_lambda_powertools/utilities/data_classes/common.py
@@ -1,7 +1,7 @@
 import base64
 import json
 from collections.abc import Mapping
-from typing import Any, Dict, Iterator, Optional
+from typing import Any, Dict, Iterator, List, Optional
 
 from aws_lambda_powertools.shared.headers_serializer import BaseHeadersSerializer
 
@@ -27,6 +27,47 @@ class DictWrapper(Mapping):
 
     def __len__(self) -> int:
         return len(self._data)
+
+    def __str__(self) -> str:
+        return str(self._str_helper())
+
+    def _str_helper(self) -> Dict[str, Any]:
+        """
+        Recursively get a Dictionary of DictWrapper properties primarily
+        for use by __str__ for debugging purposes.
+
+        Will remove "raw_event" properties, and any defined by the Data Class
+        `_sensitive_properties` list field.
+        This should be used in case where secrets, such as access keys, are
+        stored in the Data Class but should not be logged out.
+        """
+        properties = self._properties()
+        sensitive_properties = ["raw_event"]
+        if hasattr(self, "_sensitive_properties"):
+            sensitive_properties.extend(self._sensitive_properties)  # pyright: ignore
+
+        result: Dict[str, Any] = {}
+        for property_key in properties:
+            if property_key in sensitive_properties:
+                result[property_key] = "[SENSITIVE]"
+            else:
+                try:
+                    property_value = getattr(self, property_key)
+                    result[property_key] = property_value
+
+                    if issubclass(property_value.__class__, DictWrapper):
+                        result[property_key] = property_value._str_helper()
+                    elif isinstance(property_value, list):
+                        for seq, item in enumerate(property_value):
+                            if issubclass(item.__class__, DictWrapper):
+                                result[property_key][seq] = item._str_helper()
+                except Exception as e:
+                    result[property_key] = f"[EXCEPTION {type(e)}]"
+
+        return result
+
+    def _properties(self) -> List[str]:
+        return [p for p in dir(self.__class__) if isinstance(getattr(self.__class__, p), property)]
 
     def get(self, key: str, default: Optional[Any] = None) -> Optional[Any]:
         return self._data.get(key, default)

--- a/docs/utilities/data_classes.md
+++ b/docs/utilities/data_classes.md
@@ -1127,12 +1127,12 @@ This example is based on the AWS Blog post [Introducing Amazon S3 Object Lambda 
 
 Alternatively, you can print out the fields to obtain more information. All classes come with a `__str__` method that generates a dictionary string which can be quite useful for debugging.
 
-However, certain events may contain sensitive fields such as `secret_access_key` and `session_token`, which are labeled as sensitive to prevent any accidental disclosure of confidential information.
+However, certain events may contain sensitive fields such as `secret_access_key` and `session_token`, which are labeled as `[SENSITIVE]` to prevent any accidental disclosure of confidential information.
 
-!!! warning "Some fields, like JSON dictionaries, can't be processed and will display as "[Cannot be deserialized]""
+!!! warning "Some fields contain user-supplied data, which can be plain text or JSON. If deserialization of this field fails, it will appear as [Cannot be deserialized]"
 
 === "debugging.py"
-    ```python hl_lines="5"
+    ```python hl_lines="9"
     --8<-- "examples/event_sources/src/debugging.py"
     ```
 

--- a/docs/utilities/data_classes.md
+++ b/docs/utilities/data_classes.md
@@ -12,6 +12,7 @@ Event Source Data Classes utility provides classes self-describing Lambda event 
 * Type hinting and code completion for common event types
 * Helper functions for decoding/deserializing nested fields
 * Docstrings for fields contained in event schemas
+* Implement str() to recursively inspect contents
 
 **Background**
 
@@ -52,6 +53,22 @@ Same example as above, but using the `event_source` decorator
         if 'helloworld' in event.path and event.http_method == 'GET':
             do_something_with(event.body, user)
     ```
+
+Log Data Event for Troubleshooting
+
+=== "app.py"
+
+    ```python hl_lines="4 8"
+    from aws_lambda_powertools.utilities.data_classes import event_source, APIGatewayProxyEvent
+    from aws_lambda_powertools.logging.logger import Logger
+
+    logger = Logger(service="hello_logs", level="DEBUG")
+
+    @event_source(data_class=APIGatewayProxyEvent)
+    def lambda_handler(event: APIGatewayProxyEvent, context):
+        logger.debug(event)
+    ```
+
 **Autocomplete with self-documented properties and methods**
 
 ![Utilities Data Classes](../media/utilities_data_classes.png)

--- a/docs/utilities/data_classes.md
+++ b/docs/utilities/data_classes.md
@@ -1129,7 +1129,7 @@ Alternatively, you can print out the fields to obtain more information. All clas
 
 However, certain events may contain sensitive fields such as `secret_access_key` and `session_token`, which are labeled as `[SENSITIVE]` to prevent any accidental disclosure of confidential information.
 
-!!! warning "Some fields contain user-supplied data, which can be plain text or JSON. If deserialization of this field fails, it will appear as [Cannot be deserialized]"
+!!! warning "If we fail to deserialize a field value (e.g., JSON), they will appear as `[Cannot be deserialized]`"
 
 === "debugging.py"
     ```python hl_lines="9"

--- a/docs/utilities/data_classes.md
+++ b/docs/utilities/data_classes.md
@@ -12,7 +12,6 @@ Event Source Data Classes utility provides classes self-describing Lambda event 
 * Type hinting and code completion for common event types
 * Helper functions for decoding/deserializing nested fields
 * Docstrings for fields contained in event schemas
-* Implement str() to recursively inspect contents
 
 **Background**
 
@@ -1120,4 +1119,29 @@ This example is based on the AWS Blog post [Introducing Amazon S3 Object Lambda 
         # Multiple records can be delivered in a single event
         for record in event.records:
             do_something_with(record.body)
+    ```
+
+## Advanced
+
+### Debugging
+
+Alternatively, you can print out the fields to obtain more information. All classes come with a `__str__` method that generates a dictionary string which can be quite useful for debugging.
+
+However, certain events may contain sensitive fields such as `secret_access_key` and `session_token`, which are labeled as sensitive to prevent any accidental disclosure of confidential information.
+
+!!! warning "Some fields, like JSON dictionaries, can't be processed and will display as "[Cannot be deserialized]""
+
+=== "debugging.py"
+    ```python hl_lines="5"
+    --8<-- "examples/event_sources/src/debugging.py"
+    ```
+
+=== "debugging_event.json"
+    ```json hl_lines="28 29"
+    --8<-- "examples/event_sources/src/debugging_event.json"
+    ```
+=== "debugging_output.json"
+    ```json hl_lines="16 17 18"
+    --8<-- "examples/event_sources/src/debugging_output.json"
+    ```
     ```

--- a/examples/event_sources/src/debugging.py
+++ b/examples/event_sources/src/debugging.py
@@ -1,0 +1,9 @@
+from aws_lambda_powertools.utilities.data_classes import (
+    CodePipelineJobEvent,
+    event_source,
+)
+
+
+@event_source(data_class=CodePipelineJobEvent)
+def lambda_handler(event, context):
+    print(event)

--- a/examples/event_sources/src/debugging_event.json
+++ b/examples/event_sources/src/debugging_event.json
@@ -1,0 +1,34 @@
+{
+    "CodePipeline.job": {
+        "id": "11111111-abcd-1111-abcd-111111abcdef",
+        "accountId": "111111111111",
+        "data": {
+            "actionConfiguration": {
+                "configuration": {
+                    "FunctionName": "MyLambdaFunctionForAWSCodePipeline",
+                    "UserParameters": "some-input-such-as-a-URL"
+                }
+            },
+            "inputArtifacts": [
+                {
+                    "name": "ArtifactName",
+                    "revision": null,
+                    "location": {
+                        "type": "S3",
+                        "s3Location": {
+                            "bucketName": "the name of the bucket configured as the pipeline artifact store in Amazon S3, for example codepipeline-us-east-2-1234567890",
+                            "objectKey": "the name of the application, for example CodePipelineDemoApplication.zip"
+                        }
+                    }
+                }
+            ],
+            "outputArtifacts": [],
+            "artifactCredentials": {
+                "accessKeyId": "AKIAIOSFODNN7EXAMPLE",
+                "secretAccessKey": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+                "sessionToken": "MIICiTCCAfICCQD6m7oRw0uXOjANBgkqhkiG9w0BAQUFADCBiDELMAkGA1UEBhMCVVMxCzAJBgNVBAgTAldBMRAwDgYDVQQHEwdTZWF0dGxlMQ8wDQYDVQQKEwZBbWF6b24xFDASBgNVBAsTC0lBTSBDb25zb2xlMRIwEAYDVQQDEwlUZXN0Q2lsYWMxHzAdBgkqhkiG9w0BCQEWEG5vb25lQGFtYXpvbi5jb20wHhcNMTEwNDI1MjA0NTIxWhcNMTIwNDI0MjA0NTIxWjCBiDELMAkGA1UEBhMCVVMxCzAJBgNVBAgTAldBMRAwDgYDVQQHEwdTZWF0dGxlMQ8wDQYDVQQKEwZBbWF6b24xFDASBgNVBAsTC0lBTSBDb25zb2xlMRIwEAYDVQQDEwlUZXN0Q2lsYWMxHzAdBgkqhkiG9w0BCQEWEG5vb25lQGFtYXpvbi5jb20wgZ8wDQYJKoZIhvcNAQEBBQADgY0AMIGJAoGBAMaK0dn+a4GmWIWJ21uUSfwfEvySWtC2XADZ4nB+BLYgVIk60CpiwsZ3G93vUEIO3IyNoH/f0wYK8m9TrDHudUZg3qX4waLG5M43q7Wgc/MbQITxOUSQv7c7ugFFDzQGBzZswY6786m86gpEIbb3OhjZnzcvQAaRHhdlQWIMm2nrAgMBAAEwDQYJKoZIhvcNAQEFBQADgYEAtCu4nUhVVxYUntneD9+h8Mg9q6q+auNKyExzyLwaxlAoo7TJHidbtS4J5iNmZgXL0FkbFFBjvSfpJIlJ00zbhNYS5f6GuoEDmFJl0ZxBHjJnyp378OD8uTs7fLvjx79LjSTbNYiytVbZPQUQ5Yaxu2jXnimvw3rrszlaEXAMPLE="
+            },
+            "continuationToken": "A continuation token if continuing job"
+        }
+    }
+  }

--- a/examples/event_sources/src/debugging_output.json
+++ b/examples/event_sources/src/debugging_output.json
@@ -1,0 +1,50 @@
+{
+    "account_id":"111111111111",
+    "data":{
+       "action_configuration":{
+          "configuration":{
+             "decoded_user_parameters":"[Cannot be deserialized]",
+             "function_name":"MyLambdaFunctionForAWSCodePipeline",
+             "raw_event":"[SENSITIVE]",
+             "user_parameters":"some-input-such-as-a-URL"
+          },
+          "raw_event":"[SENSITIVE]"
+       },
+       "artifact_credentials":{
+          "access_key_id":"AKIAIOSFODNN7EXAMPLE",
+          "expiration_time":"None",
+          "raw_event":"[SENSITIVE]",
+          "secret_access_key":"[SENSITIVE]",
+          "session_token":"[SENSITIVE]"
+       },
+       "continuation_token":"A continuation token if continuing job",
+       "encryption_key":"None",
+       "input_artifacts":[
+          {
+             "location":{
+                "get_type":"S3",
+                "raw_event":"[SENSITIVE]",
+                "s3_location":{
+                   "bucket_name":"the name of the bucket configured as the pipeline artifact store in Amazon S3, for example codepipeline-us-east-2-1234567890",
+                   "key":"the name of the application, for example CodePipelineDemoApplication.zip",
+                   "object_key":"the name of the application, for example CodePipelineDemoApplication.zip",
+                   "raw_event":"[SENSITIVE]"
+                }
+             },
+             "name":"ArtifactName",
+             "raw_event":"[SENSITIVE]",
+             "revision":"None"
+          }
+       ],
+       "output_artifacts":[
+
+       ],
+       "raw_event":"[SENSITIVE]"
+    },
+    "decoded_user_parameters":"[Cannot be deserialized]",
+    "get_id":"11111111-abcd-1111-abcd-111111abcdef",
+    "input_bucket_name":"the name of the bucket configured as the pipeline artifact store in Amazon S3, for example codepipeline-us-east-2-1234567890",
+    "input_object_key":"the name of the application, for example CodePipelineDemoApplication.zip",
+    "raw_event":"[SENSITIVE]",
+    "user_parameters":"some-input-such-as-a-URL"
+ }


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
**Issue number:** #2128 

## Summary

Allow Data Classes to be printed with `str()`

### Changes

> Add in a `__str__` method to the base class used by all Data Classes.
> This provides a dictionary string primarily for debugging purposes.
>
> Include example usage for CodePipeline Data Classes

### User experience

> Prior to change:
```
>>> event = CodePipelineJobEvent(load_event("codePipelineEventData.json"))
>>> str(event)
'<aws_lambda_powertools.utilities.data_classes.code_pipeline_job_event.CodePipelineJobEvent object at 0x7f9a248342e0>'
```

> Post change
```
>>> event = CodePipelineJobEvent(load_event("codePipelineEventData.json"))
>>> str(event)
'{\'account_id\': \'123456789012\', \'data\': {\'action_configuration\': {\'configuration\': {\'decoded_user_parameters\': "{\'KEY\': \'VALUE\'}", \'function_name\': \'my-function\', \'raw_event\': \'[SENSITIVE]\', \'user_parameters\': \'{"KEY": "VALUE"}\'}, \'raw_event\': \'[SENSITIVE]\'}, \'artifact_credentials\': {\'access_key_id\': \'AKIAIOSFODNN7EXAMPLE\', \'expiration_time\': \'1575493418000\', \'raw_event\': \'[SENSITIVE]\', \'secret_access_key\': \'[SENSITIVE]\', \'session_token\': \'[SENSITIVE]\'}, \'continuation_token\': \'None\', \'encryption_key\': \'None\', \'input_artifacts\': [{\'location\': {\'get_type\': \'S3\', \'raw_event\': \'[SENSITIVE]\', \'s3_location\': {\'bucket_name\': \'us-west-2-123456789012-my-pipeline\', \'key\': \'my-pipeline/test-api-2/TdOSFRV\', \'object_key\': \'my-pipeline/test-api-2/TdOSFRV\', \'raw_event\': \'[SENSITIVE]\'}}, \'name\': \'my-pipeline-SourceArtifact\', \'raw_event\': \'[SENSITIVE]\', \'revision\': \'e0c7xmpl2308ca3071aa7bab414de234ab52eea\'}], \'output_artifacts\': [{\'location\': {\'get_type\': \'S3\', \'raw_event\': \'[SENSITIVE]\', \'s3_location\': {\'bucket_name\': \'us-west-2-123456789012-my-pipeline\', \'key\': \'my-pipeline/invokeOutp/D0YHsJn\', \'object_key\': \'my-pipeline/invokeOutp/D0YHsJn\', \'raw_event\': \'[SENSITIVE]\'}}, \'name\': \'invokeOutput\', \'raw_event\': \'[SENSITIVE]\', \'revision\': \'None\'}], \'raw_event\': \'[SENSITIVE]\'}, \'decoded_user_parameters\': "{\'KEY\': \'VALUE\'}", \'get_id\': \'c0d76431-b0e7-xmpl-97e3-e8ee786eb6f6\', \'input_bucket_name\': \'us-west-2-123456789012-my-pipeline\', \'input_object_key\': \'my-pipeline/test-api-2/TdOSFRV\', \'raw_event\': \'[SENSITIVE]\', \'user_parameters\': \'{"KEY": "VALUE"}\'}'
```

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] [Meet tenets criteria](https://awslabs.github.io/aws-lambda-powertools-python/#tenets)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented
* [x] PR title follows [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-python/blob/develop/.github/semantic.yml)

<details>
<summary>Is this a breaking change?</summary>

`__str__` isn't implemented elsewhere for Data Classes in the library, so shouldn't impact the library.
I _assume_ most people wouldn't deliberately print the class name, and memory location for debugging/troubleshooting, so shouldn't impact them.

One area where I need assistance is noting what properties throughout the Data Classes should be blacklisted.

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
