### PR TITLE
chore: add Python 3.10 PyPi language classifier

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -43,14 +43,14 @@ tests-no-zope = ["cloudpickle", "cloudpickle", "hypothesis", "hypothesis", "mypy
 
 [[package]]
 name = "aws-cdk-asset-awscli-v1"
-version = "2.2.144"
+version = "2.2.145"
 description = "A library that contains the AWS CLI for use in Lambda Layers"
 category = "dev"
 optional = false
 python-versions = "~=3.7"
 files = [
-    {file = "aws-cdk.asset-awscli-v1-2.2.144.tar.gz", hash = "sha256:2953dbaa0dae2a1893318452a6d681a975cb73f160d61eb197a6b47b293c6371"},
-    {file = "aws_cdk.asset_awscli_v1-2.2.144-py3-none-any.whl", hash = "sha256:cf9fd74fc56b4333ffb3631ce38ca585ec722fd59bd06f5f9b61c7f838ba1dd4"},
+    {file = "aws-cdk.asset-awscli-v1-2.2.145.tar.gz", hash = "sha256:74098ca36a0e3d0655c98638174c77f1c6599f1b16fb4e4387721a955b431aac"},
+    {file = "aws_cdk.asset_awscli_v1-2.2.145-py3-none-any.whl", hash = "sha256:bf736e03cff78b6bad51777cfa204985368975d5b0139434ef6d7e069b757bb7"},
 ]
 
 [package.dependencies]
@@ -77,14 +77,14 @@ typeguard = ">=2.13.3,<2.14.0"
 
 [[package]]
 name = "aws-cdk-asset-node-proxy-agent-v5"
-version = "2.0.119"
+version = "2.0.120"
 description = "@aws-cdk/asset-node-proxy-agent-v5"
 category = "dev"
 optional = false
 python-versions = "~=3.7"
 files = [
-    {file = "aws-cdk.asset-node-proxy-agent-v5-2.0.119.tar.gz", hash = "sha256:2a93b5a0870c0914771a0591a82aa44134f25e0236f94d05d4a558465caff385"},
-    {file = "aws_cdk.asset_node_proxy_agent_v5-2.0.119-py3-none-any.whl", hash = "sha256:ea59cc9f924fc9c566819b7106b330e7632e4b5f9c1d3bee3d3d494615bc680d"},
+    {file = "aws-cdk.asset-node-proxy-agent-v5-2.0.120.tar.gz", hash = "sha256:5c885003685fe86aafe1611a4f1310f1cda62b27036e3528e1fe4e16ba3a3ac4"},
+    {file = "aws_cdk.asset_node_proxy_agent_v5-2.0.120-py3-none-any.whl", hash = "sha256:6264375b03fa62a3a2e67e360517276874ec814dc4367d7c9eff55a4e8dff155"},
 ]
 
 [package.dependencies]
@@ -94,18 +94,18 @@ typeguard = ">=2.13.3,<2.14.0"
 
 [[package]]
 name = "aws-cdk-aws-apigatewayv2-alpha"
-version = "2.75.0a0"
+version = "2.75.1a0"
 description = "The CDK Construct Library for AWS::APIGatewayv2"
 category = "dev"
 optional = false
 python-versions = "~=3.7"
 files = [
-    {file = "aws-cdk.aws-apigatewayv2-alpha-2.75.0a0.tar.gz", hash = "sha256:1348c29ab83cccfe82ba0e34b97153a81f09391cdfab22b83d7d6390444bc551"},
-    {file = "aws_cdk.aws_apigatewayv2_alpha-2.75.0a0-py3-none-any.whl", hash = "sha256:42e2ecb3b1ec6da1bed0ee3be8dab29b10e92e17fcebfa8cf8a44bb487102332"},
+    {file = "aws-cdk.aws-apigatewayv2-alpha-2.75.1a0.tar.gz", hash = "sha256:ddfa9b4ad8c9a4968fd637081ed732b0e099ccedb4d7ccd7c1526bff7f036b93"},
+    {file = "aws_cdk.aws_apigatewayv2_alpha-2.75.1a0-py3-none-any.whl", hash = "sha256:cf1920e37a60265286c0ab50ea78e1e065278f3758c0dde9e79d0811bd7c90d9"},
 ]
 
 [package.dependencies]
-aws-cdk-lib = "2.75.0"
+aws-cdk-lib = "2.75.1"
 constructs = ">=10.0.0,<11.0.0"
 jsii = ">=1.78.1,<2.0.0"
 publication = ">=0.0.3"
@@ -113,19 +113,19 @@ typeguard = ">=2.13.3,<2.14.0"
 
 [[package]]
 name = "aws-cdk-aws-apigatewayv2-authorizers-alpha"
-version = "2.75.0a0"
+version = "2.75.1a0"
 description = "Authorizers for AWS APIGateway V2"
 category = "dev"
 optional = false
 python-versions = "~=3.7"
 files = [
-    {file = "aws-cdk.aws-apigatewayv2-authorizers-alpha-2.75.0a0.tar.gz", hash = "sha256:0b9407cef4d46b41e44433952ed4ca00cae651437f3f532bf942f1d719abe43e"},
-    {file = "aws_cdk.aws_apigatewayv2_authorizers_alpha-2.75.0a0-py3-none-any.whl", hash = "sha256:306e1ff0c919fc528ff1b69a6210870958f6e028266f5aba842ffcf74c3728ac"},
+    {file = "aws-cdk.aws-apigatewayv2-authorizers-alpha-2.75.1a0.tar.gz", hash = "sha256:524918a1aebf29c72f345162079bbb34cca87213480dc106931444a37496c8fe"},
+    {file = "aws_cdk.aws_apigatewayv2_authorizers_alpha-2.75.1a0-py3-none-any.whl", hash = "sha256:493ea5f7e981c08dd772e50c95158aa7223b395a0668b5bba05b8c0ccb694f5a"},
 ]
 
 [package.dependencies]
-"aws-cdk.aws-apigatewayv2-alpha" = "2.75.0.a0"
-aws-cdk-lib = "2.75.0"
+"aws-cdk.aws-apigatewayv2-alpha" = "2.75.1.a0"
+aws-cdk-lib = "2.75.1"
 constructs = ">=10.0.0,<11.0.0"
 jsii = ">=1.78.1,<2.0.0"
 publication = ">=0.0.3"
@@ -133,19 +133,19 @@ typeguard = ">=2.13.3,<2.14.0"
 
 [[package]]
 name = "aws-cdk-aws-apigatewayv2-integrations-alpha"
-version = "2.75.0a0"
+version = "2.75.1a0"
 description = "Integrations for AWS APIGateway V2"
 category = "dev"
 optional = false
 python-versions = "~=3.7"
 files = [
-    {file = "aws-cdk.aws-apigatewayv2-integrations-alpha-2.75.0a0.tar.gz", hash = "sha256:355e8980d886f50c37395b022647d31c0d071943f181de1d1f0c162055a3af39"},
-    {file = "aws_cdk.aws_apigatewayv2_integrations_alpha-2.75.0a0-py3-none-any.whl", hash = "sha256:75c442ee356e782d81613266efcd2520cee2abed482928ada2d16f457f829692"},
+    {file = "aws-cdk.aws-apigatewayv2-integrations-alpha-2.75.1a0.tar.gz", hash = "sha256:bfc11f80ad38b092c2ce861579b1bfa3b841773c85fb79c3ed548170f80cc115"},
+    {file = "aws_cdk.aws_apigatewayv2_integrations_alpha-2.75.1a0-py3-none-any.whl", hash = "sha256:f536d663a1fffb55e0785151d2def5a94f1b914a59463824e69ca185b6018f4c"},
 ]
 
 [package.dependencies]
-"aws-cdk.aws-apigatewayv2-alpha" = "2.75.0.a0"
-aws-cdk-lib = "2.75.0"
+"aws-cdk.aws-apigatewayv2-alpha" = "2.75.1.a0"
+aws-cdk-lib = "2.75.1"
 constructs = ">=10.0.0,<11.0.0"
 jsii = ">=1.78.1,<2.0.0"
 publication = ">=0.0.3"
@@ -153,14 +153,14 @@ typeguard = ">=2.13.3,<2.14.0"
 
 [[package]]
 name = "aws-cdk-lib"
-version = "2.75.0"
+version = "2.75.1"
 description = "Version 2 of the AWS Cloud Development Kit library"
 category = "dev"
 optional = false
 python-versions = "~=3.7"
 files = [
-    {file = "aws-cdk-lib-2.75.0.tar.gz", hash = "sha256:e81e328906577a79d8bb2980403e37a83645f8a883ba5c1309b399b5e0d1baae"},
-    {file = "aws_cdk_lib-2.75.0-py3-none-any.whl", hash = "sha256:eb11341f2dc7134a354087396b2efcd952f54f3cff18c5c55a281cd6c45fc821"},
+    {file = "aws-cdk-lib-2.75.1.tar.gz", hash = "sha256:7b9c285ea9681e59c215e2ad3917b046ef47c48d83bc9c555b425a37df30d34d"},
+    {file = "aws_cdk_lib-2.75.1-py3-none-any.whl", hash = "sha256:1a4a61ce69280f522b7cee7b910284ab01ef091af220e7e0fad8433fd58e4325"},
 ]
 
 [package.dependencies]
@@ -519,14 +519,14 @@ files = [
 
 [[package]]
 name = "constructs"
-version = "10.1.314"
+version = "10.2.1"
 description = "A programming model for software-defined state"
 category = "dev"
 optional = false
 python-versions = "~=3.7"
 files = [
-    {file = "constructs-10.1.314-py3-none-any.whl", hash = "sha256:852faf1acbb74355f172f4f4ead8029d085c0ad46e4a131203d216917a588daa"},
-    {file = "constructs-10.1.314.tar.gz", hash = "sha256:389c336c0f91471232dee07e3dbd7a218d85f99b07423c3f93e326d68fb2d857"},
+    {file = "constructs-10.2.1-py3-none-any.whl", hash = "sha256:398d32c65d2945949195dcc642bc7bd7b7552758d274fa0e1616ca0069d01a25"},
+    {file = "constructs-10.2.1.tar.gz", hash = "sha256:36e86d1092edd1f2ee8895d21c49bdabf81e62deb5f18329b275ee8ec1f67aa3"},
 ]
 
 [package.dependencies]
@@ -672,19 +672,19 @@ devel = ["colorama", "json-spec", "jsonschema", "pylint", "pytest", "pytest-benc
 
 [[package]]
 name = "filelock"
-version = "3.11.0"
+version = "3.12.0"
 description = "A platform independent file lock."
 category = "dev"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "filelock-3.11.0-py3-none-any.whl", hash = "sha256:f08a52314748335c6460fc8fe40cd5638b85001225db78c2aa01c8c0db83b318"},
-    {file = "filelock-3.11.0.tar.gz", hash = "sha256:3618c0da67adcc0506b015fd11ef7faf1b493f0b40d87728e19986b536890c37"},
+    {file = "filelock-3.12.0-py3-none-any.whl", hash = "sha256:ad98852315c2ab702aeb628412cbf7e95b7ce8c3bf9565670b4eaecf1db370a9"},
+    {file = "filelock-3.12.0.tar.gz", hash = "sha256:fc03ae43288c013d2ea83c8597001b1129db351aad9c57fe2409327916b8e718"},
 ]
 
 [package.extras]
-docs = ["furo (>=2023.3.27)", "sphinx (>=6.1.3)", "sphinx-autodoc-typehints (>=1.22,!=1.23.4)"]
-testing = ["covdefaults (>=2.3)", "coverage (>=7.2.2)", "diff-cover (>=7.5)", "pytest (>=7.2.2)", "pytest-cov (>=4)", "pytest-mock (>=3.10)", "pytest-timeout (>=2.1)"]
+docs = ["furo (>=2023.3.27)", "sphinx (>=6.1.3)", "sphinx-autodoc-typehints (>=1.23,!=1.23.4)"]
+testing = ["covdefaults (>=2.3)", "coverage (>=7.2.3)", "diff-cover (>=7.5)", "pytest (>=7.3.1)", "pytest-cov (>=4)", "pytest-mock (>=3.10)", "pytest-timeout (>=2.1)"]
 
 [[package]]
 name = "flake8"
@@ -1091,14 +1091,14 @@ files = [
 
 [[package]]
 name = "importlib-metadata"
-version = "6.4.1"
+version = "6.5.0"
 description = "Read metadata from Python packages"
 category = "dev"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "importlib_metadata-6.4.1-py3-none-any.whl", hash = "sha256:63ace321e24167d12fbb176b6015f4dbe06868c54a2af4f15849586afb9027fd"},
-    {file = "importlib_metadata-6.4.1.tar.gz", hash = "sha256:eb1a7933041f0f85c94cd130258df3fb0dec060ad8c1c9318892ef4192c47ce1"},
+    {file = "importlib_metadata-6.5.0-py3-none-any.whl", hash = "sha256:03ba783c3a2c69d751b109fc0c94a62c51f581b3d6acf8ed1331b6d5729321ff"},
+    {file = "importlib_metadata-6.5.0.tar.gz", hash = "sha256:7a8bdf1bc3a726297f5cfbc999e6e7ff6b4fa41b26bba4afc580448624460045"},
 ]
 
 [package.dependencies]
@@ -2110,14 +2110,14 @@ files = [
 
 [[package]]
 name = "pygments"
-version = "2.15.0"
+version = "2.15.1"
 description = "Pygments is a syntax highlighting package written in Python."
 category = "dev"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "Pygments-2.15.0-py3-none-any.whl", hash = "sha256:77a3299119af881904cd5ecd1ac6a66214b6e9bed1f2db16993b54adede64094"},
-    {file = "Pygments-2.15.0.tar.gz", hash = "sha256:f7e36cffc4c517fbc252861b9a6e4644ca0e5abadf9a113c72d1358ad09b9500"},
+    {file = "Pygments-2.15.1-py3-none-any.whl", hash = "sha256:db2db3deb4b4179f399a09054b023b6a586b76499d36965813c71aa8ed7b5fd1"},
+    {file = "Pygments-2.15.1.tar.gz", hash = "sha256:8ace4d3c1dd481894b2005f560ead0f9f19ee64fe983366be1a21e171d12775c"},
 ]
 
 [package.extras]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ classifiers=[
     "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
 ]
 repository = "https://github.com/awslabs/aws-lambda-powertools-python"
 documentation = "https://awslabs.github.io/aws-lambda-powertools-python/"


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
**Issue number:** #2143

## Summary

### Changes

> Please provide a summary of what's being changed

Adds Python 3.10 to the `pyproject` classifiers.

### User experience

> Please share what the user experience looks like before and after this change

This will update the trove classifier when the next package is published on pypi.

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] [Meet tenets criteria](https://awslabs.github.io/aws-lambda-powertools-python/#tenets)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [ ] Changes are documented
* [ ] PR title follows [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-python/blob/develop/.github/semantic.yml)

<details>
<summary>Is this a breaking change?</summary>

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
