### PR TITLE
feat(event_sources): add queue_url field in SQS EventSource DataClass

### DIFF
--- a/aws_lambda_powertools/utilities/data_classes/sqs_event.py
+++ b/aws_lambda_powertools/utilities/data_classes/sqs_event.py
@@ -133,6 +133,18 @@ class SQSRecord(DictWrapper):
         """aws region eg: us-east-1"""
         return self["awsRegion"]
 
+    @property
+    def queue_url(self) -> str:
+        """The URL of the queue."""
+        arn_parts = self["eventSourceARN"].split(":")
+        region = arn_parts[3]
+        account_id = arn_parts[4]
+        queue_name = arn_parts[5]
+
+        queue_url = f"https://sqs.{region}.amazonaws.com/{account_id}/{queue_name}"
+
+        return queue_url
+
 
 class SQSEvent(DictWrapper):
     """SQS Event

--- a/tests/functional/test_data_classes.py
+++ b/tests/functional/test_data_classes.py
@@ -779,6 +779,7 @@ def test_seq_trigger_event():
     assert record.md5_of_body == "e4e68fb7bd0e697a0ae8f1bb342846b3"
     assert record.event_source == "aws:sqs"
     assert record.event_source_arn == "arn:aws:sqs:us-east-2:123456789012:my-queue"
+    assert record.queue_url == "https://sqs.us-east-2.amazonaws.com/123456789012/my-queue"
     assert record.aws_region == "us-east-2"
 
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
**Issue number:** #2145 

## Summary

### Changes

Make SQS EventSource more efficient with `queue_url` field addition

### User experience

Before the customer had to get the `eventSourceARN` and do a parser to format the queue's URL, with the introduction of the field `queue_url` it is easier to access this property.

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] [Meet tenets criteria](https://awslabs.github.io/aws-lambda-powertools-python/#tenets)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [ ] Changes are documented
* [x] PR title follows [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-python/blob/develop/.github/semantic.yml)

<details>
<summary>Is this a breaking change?</summary>

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
