### PR TITLE
fix(e2e): fix test brittleness

### DIFF
--- a/tests/e2e/idempotency/test_idempotency_dynamodb.py
+++ b/tests/e2e/idempotency/test_idempotency_dynamodb.py
@@ -130,4 +130,5 @@ def test_idempotent_function_thread_safety(function_thread_safety_handler_fn_arn
         assert function_thread["exception"] is None
         assert function_thread["output"] is not None
 
-    assert first_execution_response == second_execution_response
+    # we use set() here because we want to compare the elements regardless of their order in the array
+    assert set(first_execution_response) == set(second_execution_response)

--- a/tests/e2e/streaming/handlers/s3_object_handler.py
+++ b/tests/e2e/streaming/handlers/s3_object_handler.py
@@ -66,13 +66,15 @@ def lambda_handler(event, context):
 
         if transform_zip or transform_zip_lzma:
             response["manifest"] = obj.namelist()
-            response["body"] = obj.read(obj.namelist()[1]).rstrip()  # extracts the second file on the zip
+            response["body"] = (
+                obj.read(obj.namelist()[1]).rstrip().decode("utf-8")
+            )  # extracts the second file on the zip
         elif transform_csv or csv:
             response["body"] = obj.__next__()
         elif transform_gzip or gunzip:
-            response["body"] = obj.readline().rstrip()
+            response["body"] = obj.readline().rstrip().decode("utf-8")
         else:
-            response["body"] = obj.readline().rstrip()
+            response["body"] = obj.readline().rstrip().decode("utf-8")
     except botocore.exceptions.ClientError as e:
         if e.response["Error"]["Code"] == "404":
             response["error"] = "Not found"


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
**Issue number:** #2151

## Summary

### Changes

> Please provide a summary of what's being changed

This PR makes two changes that fixes E2E tests brittleness and fixes E2E tests running under Python 3.7.

### User experience

> Please share what the user experience looks like before and after this change

After this change, E2E tests should pass consistently.

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] [Meet tenets criteria](https://awslabs.github.io/aws-lambda-powertools-python/#tenets)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [ ] Changes are documented
* [ ] PR title follows [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-python/blob/develop/.github/semantic.yml)

<details>
<summary>Is this a breaking change?</summary>

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
