### PR TITLE
chore(batch): safeguard custom use of BatchProcessingError exception

### DIFF
--- a/aws_lambda_powertools/utilities/batch/exceptions.py
+++ b/aws_lambda_powertools/utilities/batch/exceptions.py
@@ -1,6 +1,8 @@
 """
 Batch processing exceptions
 """
+from __future__ import annotations
+
 import traceback
 from types import TracebackType
 from typing import List, Optional, Tuple, Type
@@ -9,10 +11,10 @@ ExceptionInfo = Tuple[Optional[Type[BaseException]], Optional[BaseException], Op
 
 
 class BaseBatchProcessingError(Exception):
-    def __init__(self, msg="", child_exceptions: Optional[List[ExceptionInfo]] = None):
+    def __init__(self, msg="", child_exceptions: List[ExceptionInfo] | None = None):
         super().__init__(msg)
         self.msg = msg
-        self.child_exceptions = child_exceptions
+        self.child_exceptions = child_exceptions or []
 
     def format_exceptions(self, parent_exception_str):
         exception_list = [f"{parent_exception_str}\n"]
@@ -27,7 +29,7 @@ class BaseBatchProcessingError(Exception):
 class BatchProcessingError(BaseBatchProcessingError):
     """When all batch records failed to be processed"""
 
-    def __init__(self, msg="", child_exceptions: Optional[List[ExceptionInfo]] = None):
+    def __init__(self, msg="", child_exceptions: List[ExceptionInfo] | None = None):
         super().__init__(msg, child_exceptions)
 
     def __str__(self):


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
**Issue number:** #1203

## Summary

### Changes

> Please provide a summary of what's being changed

Default list arg to empty list if `None`. This will safe guard for any undocumented use of `BatchProcessingError` within  Batch utility.

### User experience

> Please share what the user experience looks like before and after this change

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] [Meet tenets criteria](https://awslabs.github.io/aws-lambda-powertools-python/#tenets)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [ ] Changes are documented
* [x] PR title follows [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-python/blob/develop/.github/semantic.yml)

<details>
<summary>Is this a breaking change?</summary>

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
