### PR TITLE
fix(batch): resolve use of ValidationError in batch

### DIFF
--- a/aws_lambda_powertools/utilities/batch/base.py
+++ b/aws_lambda_powertools/utilities/batch/base.py
@@ -26,7 +26,6 @@ from aws_lambda_powertools.utilities.data_classes.kinesis_stream_event import (
     KinesisStreamRecord,
 )
 from aws_lambda_powertools.utilities.data_classes.sqs_event import SQSRecord
-from aws_lambda_powertools.utilities.parser import ValidationError
 from aws_lambda_powertools.utilities.typing import LambdaContext
 
 logger = logging.getLogger(__name__)
@@ -496,9 +495,10 @@ class BatchProcessor(BasePartialBatchProcessor):  # Keep old name for compatibil
                 result = self.handler(record=data)
 
             return self.success_handler(record=record, result=result)
-        except ValidationError:
-            return self._register_model_validation_error_record(record)
-        except Exception:
+        except Exception as exc:
+            if exc.__class__.__name__ == "ValidationError":
+                return self._register_model_validation_error_record(record)
+
             return self.failure_handler(record=data, exception=sys.exc_info())
 
 
@@ -634,7 +634,8 @@ class AsyncBatchProcessor(BasePartialBatchProcessor):
                 result = await self.handler(record=data)
 
             return self.success_handler(record=record, result=result)
-        except ValidationError:
-            return self._register_model_validation_error_record(record)
-        except Exception:
+        except Exception as exc:
+            if exc.__class__.__name__ == "ValidationError":
+                return self._register_model_validation_error_record(record)
+
             return self.failure_handler(record=data, exception=sys.exc_info())

--- a/aws_lambda_powertools/utilities/batch/base.py
+++ b/aws_lambda_powertools/utilities/batch/base.py
@@ -640,7 +640,12 @@ class AsyncBatchProcessor(BasePartialBatchProcessor):
 
             return self.success_handler(record=record, result=result)
         except Exception as exc:
-            if exc.__class__.__name__ == "ValidationError":
+            # NOTE: Pydantic is an optional dependency, but when used and a poison pill scenario happens
+            # we need to handle that exception differently.
+            # We check for a public attr in validation errors coming from Pydantic exceptions (subclass or not)
+            # and we compare if it's coming from the same model that trigger the exception in the first place
+            model = getattr(exc, "model", None)
+            if model == self.model:
                 return self._register_model_validation_error_record(record)
 
             return self.failure_handler(record=data, exception=sys.exc_info())


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
**Issue number:** #2156 

## Summary
Remove ValidationError import to remove implicit pydantic dependency

### Changes

Removed use of "ValidationError" class in batch.py.  Replaced instead with slightly nastier string class name comparison to detect the ValidationError.  Intention of code remain in tact in that the ValidationError will be correctly handled when pydantic model validation fails.


### User experience

Before:
[ERROR] Runtime.ImportModuleError: Unable to import module 'app': No module named 'pydantic'

After:


## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] [Meet tenets criteria](https://awslabs.github.io/aws-lambda-powertools-python/#tenets)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented
* [x] PR title follows [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-python/blob/develop/.github/semantic.yml)

<details>
<summary>Is this a breaking change?</summary>
No not a breaking change - reversibng a breaking change

**RFC issue number**: Nil

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
