### PR TITLE
feat(metrics): add flush_metrics() method to allow manual flushing of metrics

### DIFF
--- a/docs/core/metrics.md
+++ b/docs/core/metrics.md
@@ -251,10 +251,12 @@ By default it will skip all previously defined dimensions including default dime
 
 ### Flushing metrics manually
 
-If you prefer not to use `log_metrics` because you might want to encapsulate additional logic when doing so, you can manually flush and clear metrics as follows:
+If you are using the AWS Lambda Web Adapter project, or a middleware with custom metric logic, you can use `flush_metrics()`. This method will serialize, print metrics available to standard output, and clear in-memory metrics data.
 
 ???+ warning
-	Metrics, dimensions and namespace validation still applies
+    This does not capture Cold Start metrics, and metric data validation still applies.
+
+Contrary to the `log_metrics` decorator, you are now also responsible to flush metrics in the event of an exception.
 
 ```python hl_lines="18" title="Manually flushing and clearing metrics from memory"
 --8<-- "examples/metrics/src/flush_metrics.py"

--- a/docs/core/metrics.md
+++ b/docs/core/metrics.md
@@ -256,9 +256,17 @@ If you prefer not to use `log_metrics` because you might want to encapsulate add
 ???+ warning
 	Metrics, dimensions and namespace validation still applies
 
-```python hl_lines="11-14" title="Manually flushing and clearing metrics from memory"
---8<-- "examples/metrics/src/single_metric.py"
-```
+=== "Regular Metrics"
+
+    ```python hl_lines="10"
+    --8<-- "examples/metrics/src/flush_metrics.py"
+    ```
+
+=== "Single Metrics"
+
+    ```python hl_lines="11-14"
+    --8<-- "examples/metrics/src/single_metric.py"
+    ```
 
 ### Metrics isolation
 

--- a/docs/core/metrics.md
+++ b/docs/core/metrics.md
@@ -256,17 +256,9 @@ If you prefer not to use `log_metrics` because you might want to encapsulate add
 ???+ warning
 	Metrics, dimensions and namespace validation still applies
 
-=== "Regular Metrics"
-
-    ```python hl_lines="10"
-    --8<-- "examples/metrics/src/flush_metrics.py"
-    ```
-
-=== "Single Metrics"
-
-    ```python hl_lines="11-14"
-    --8<-- "examples/metrics/src/single_metric.py"
-    ```
+```python hl_lines="12" title="Manually flushing and clearing metrics from memory"
+--8<-- "examples/metrics/src/flush_metrics.py"
+```
 
 ### Metrics isolation
 

--- a/docs/core/metrics.md
+++ b/docs/core/metrics.md
@@ -256,7 +256,7 @@ If you prefer not to use `log_metrics` because you might want to encapsulate add
 ???+ warning
 	Metrics, dimensions and namespace validation still applies
 
-```python hl_lines="12" title="Manually flushing and clearing metrics from memory"
+```python hl_lines="18" title="Manually flushing and clearing metrics from memory"
 --8<-- "examples/metrics/src/flush_metrics.py"
 ```
 

--- a/examples/metrics/src/flush_metrics.py
+++ b/examples/metrics/src/flush_metrics.py
@@ -1,5 +1,3 @@
-import json
-
 from aws_lambda_powertools import Metrics
 from aws_lambda_powertools.metrics import MetricUnit
 from aws_lambda_powertools.utilities.typing import LambdaContext
@@ -9,6 +7,4 @@ metrics = Metrics()
 
 def lambda_handler(event: dict, context: LambdaContext):
     metrics.add_metric(name="SuccessfulBooking", unit=MetricUnit.Count, value=1)
-    your_metrics_object = metrics.serialize_metric_set()
-    metrics.clear_metrics()
-    print(json.dumps(your_metrics_object))
+    metrics.flush_metrics()

--- a/examples/metrics/src/flush_metrics.py
+++ b/examples/metrics/src/flush_metrics.py
@@ -5,6 +5,12 @@ from aws_lambda_powertools.utilities.typing import LambdaContext
 metrics = Metrics()
 
 
+def book_flight(flight_id: str, **kwargs): 
+    # logic to book flight
+    ...
+    metrics.add_metric(name="SuccessfulBooking", unit=MetricUnit.Count, value=1)
+
+
 def lambda_handler(event: dict, context: LambdaContext):
     try:
         metrics.add_metric(name="SuccessfulBooking", unit=MetricUnit.Count, value=1)

--- a/examples/metrics/src/flush_metrics.py
+++ b/examples/metrics/src/flush_metrics.py
@@ -13,6 +13,6 @@ def book_flight(flight_id: str, **kwargs):
 
 def lambda_handler(event: dict, context: LambdaContext):
     try:
-        metrics.add_metric(name="SuccessfulBooking", unit=MetricUnit.Count, value=1)
+        book_flight(flight_id=event.get("flight_id", ""))
     finally:
         metrics.flush_metrics()

--- a/examples/metrics/src/flush_metrics.py
+++ b/examples/metrics/src/flush_metrics.py
@@ -6,5 +6,7 @@ metrics = Metrics()
 
 
 def lambda_handler(event: dict, context: LambdaContext):
-    metrics.add_metric(name="SuccessfulBooking", unit=MetricUnit.Count, value=1)
-    metrics.flush_metrics()
+    try:
+        metrics.add_metric(name="SuccessfulBooking", unit=MetricUnit.Count, value=1)
+    finally:
+        metrics.flush_metrics()

--- a/tests/functional/test_metrics.py
+++ b/tests/functional/test_metrics.py
@@ -249,6 +249,26 @@ def test_log_metrics(capsys, metrics, dimensions, namespace):
     assert expected == output
 
 
+def test_log_metrics_manual_flush(capsys, metrics, dimensions, namespace):
+    # GIVEN Metrics is initialized
+    my_metrics = Metrics(namespace=namespace)
+    for metric in metrics:
+        my_metrics.add_metric(**metric)
+    for dimension in dimensions:
+        my_metrics.add_dimension(**dimension)
+
+    # WHEN we manually the metrics
+    my_metrics.flush_metrics()
+
+    output = capture_metrics_output(capsys)
+    expected = serialize_metrics(metrics=metrics, dimensions=dimensions, namespace=namespace)
+
+    # THEN we should have no exceptions
+    # and a valid EMF object should be flushed correctly
+    remove_timestamp(metrics=[output, expected])
+    assert expected == output
+
+
 def test_namespace_env_var(monkeypatch, capsys, metric, dimension, namespace):
     # GIVEN POWERTOOLS_METRICS_NAMESPACE is set
     monkeypatch.setenv("POWERTOOLS_METRICS_NAMESPACE", namespace)


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->

**Issue number:** #2109

## Summary

### Changes

> Please provide a summary of what's being changed

This PR adds a new `flush_metrics` to the metrics utility to manually flush the metrics.

![carbon (1)](https://user-images.githubusercontent.com/10713/234875874-2ca606b1-c078-4ced-ae13-3485bc7ce1d2.png)

### User experience

> Please share what the user experience looks like before and after this change

Before this PR it was hard for users of the metrics utility to flush the metrics when not running on the Lambda runtime. This simple refactor enables the users
quick access to manually flushing the metrics.

![image](https://user-images.githubusercontent.com/10713/234876136-a75582a0-3c3b-4309-95b1-44a0fa451209.png)

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

- [x] [Meet tenets criteria](https://awslabs.github.io/aws-lambda-powertools-python/#tenets)
- [x] I have performed a self-review of this change
- [x] Changes have been tested
- [x] Changes are documented
- [ ] PR title follows [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-python/blob/develop/.github/semantic.yml)

<details>
<summary>Is this a breaking change?</summary>

**RFC issue number**:

Checklist:

- [ ] Migration process documented
- [ ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
