### PR TITLE
feat(event_source): add support for dynamic partitions in the Api Gateway Authorizer event

### DIFF
--- a/aws_lambda_powertools/utilities/data_classes/api_gateway_authorizer_event.py
+++ b/aws_lambda_powertools/utilities/data_classes/api_gateway_authorizer_event.py
@@ -21,8 +21,9 @@ class APIGatewayRouteArn:
         stage: str,
         http_method: str,
         resource: str,
+        partition: str = "aws",
     ):
-        self.partition = "aws"
+        self.partition = partition
         self.region = region
         self.aws_account_id = aws_account_id
         self.api_id = api_id
@@ -55,6 +56,7 @@ def parse_api_gateway_arn(arn: str) -> APIGatewayRouteArn:
     arn_parts = arn.split(":")
     api_gateway_arn_parts = arn_parts[5].split("/")
     return APIGatewayRouteArn(
+        partition=arn_parts[1],
         region=arn_parts[3],
         aws_account_id=arn_parts[4],
         api_id=api_gateway_arn_parts[0],
@@ -369,6 +371,7 @@ class APIGatewayAuthorizerResponse:
         stage: str,
         context: Optional[Dict] = None,
         usage_identifier_key: Optional[str] = None,
+        partition: str = "aws"
     ):
         """
         Parameters
@@ -401,6 +404,9 @@ class APIGatewayAuthorizerResponse:
             If the API uses a usage plan (the apiKeySource is set to `AUTHORIZER`), the Lambda authorizer function
             must return one of the usage plan's API keys as the usageIdentifierKey property value.
             > **Note:** This only applies for REST APIs.
+        partition: str, optional
+            Default is aws,
+            But it is "aws-cn" in China.
         """
         self.principal_id = principal_id
         self.region = region
@@ -412,6 +418,7 @@ class APIGatewayAuthorizerResponse:
         self._allow_routes: List[Dict] = []
         self._deny_routes: List[Dict] = []
         self._resource_pattern = re.compile(self.path_regex)
+        self.partition = partition
 
     @staticmethod
     def from_route_arn(
@@ -443,7 +450,7 @@ class APIGatewayAuthorizerResponse:
             raise ValueError(f"Invalid resource path: {resource}. Path should match {self.path_regex}")
 
         resource_arn = APIGatewayRouteArn(
-            self.region, self.aws_account_id, self.api_id, self.stage, http_method, resource
+            self.region, self.aws_account_id, self.api_id, self.stage, http_method, resource, self.partition
         ).arn
 
         route = {"resourceArn": resource_arn, "conditions": conditions}

--- a/aws_lambda_powertools/utilities/data_classes/api_gateway_authorizer_event.py
+++ b/aws_lambda_powertools/utilities/data_classes/api_gateway_authorizer_event.py
@@ -371,7 +371,7 @@ class APIGatewayAuthorizerResponse:
         stage: str,
         context: Optional[Dict] = None,
         usage_identifier_key: Optional[str] = None,
-        partition: str = "aws"
+        partition: str = "aws",
     ):
         """
         Parameters
@@ -405,8 +405,8 @@ class APIGatewayAuthorizerResponse:
             must return one of the usage plan's API keys as the usageIdentifierKey property value.
             > **Note:** This only applies for REST APIs.
         partition: str, optional
-            Default is aws,
-            But it is "aws-cn" in China.
+            Optional, arn partition.
+            See https://docs.aws.amazon.com/IAM/latest/UserGuide/reference-arns.html
         """
         self.principal_id = principal_id
         self.region = region


### PR DESCRIPTION
CN partition adaption

<!-- markdownlint-disable MD041 MD043 -->
**Issue number:** #2177 

## Summary
CN partition adaption
### Changes
Change partition hard code 
> Please provide a summary of what's being changed

### User experience

> Please share what the user experience looks like before and after this change

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [ ] [Meet tenets criteria](https://awslabs.github.io/aws-lambda-powertools-python/#tenets)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented
* [ ] PR title follows [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-python/blob/develop/.github/semantic.yml)

<details>
<summary>Is this a breaking change?</summary>

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
