### PR TITLE
docs(batch): fixed typo in DynamoDB Streams section

### DIFF
--- a/docs/utilities/batch.md
+++ b/docs/utilities/batch.md
@@ -508,7 +508,7 @@ Processing batches from Kinesis works in three stages:
 
 ### Processing messages from DynamoDB
 
-Processing batches from Kinesis works in three stages:
+Processing batches from DynamoDB Streams works in three stages:
 
 1. Instantiate **`BatchProcessor`** and choose **`EventType.DynamoDBStreams`** for the event type
 2. Define your function to handle each batch record, and use [`DynamoDBRecord`](data_classes.md#dynamodb-streams){target="_blank"} type annotation for autocompletion


### PR DESCRIPTION
The "Processing messages from DynamoDB" paragraph mentioned "Kinesis" instead of "DynamoDB Streams"

<!-- markdownlint-disable MD041 MD043 -->
**Issue number:** #2188 

## Summary

DynamoDB Streams paragraph contained reference to Kinesis.

### Changes

Replaced Kinesis reference with DynamoDB Streams

### User experience

> Please share what the user experience looks like before and after this change

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [ v] [Meet tenets criteria](https://awslabs.github.io/aws-lambda-powertools-python/#tenets)
* [v ] I have performed a self-review of this change
* [v ] Changes have been tested
* [ v] Changes are documented
* [v ] PR title follows [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-python/blob/develop/.github/semantic.yml)

<details>
<summary>Is this a breaking change?</summary>

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
