### PR TITLE
feat(event_source): support custom json_deserializer; add json_body in SQSEvent

### DIFF
--- a/aws_lambda_powertools/utilities/data_classes/common.py
+++ b/aws_lambda_powertools/utilities/data_classes/common.py
@@ -1,7 +1,7 @@
 import base64
 import json
 from collections.abc import Mapping
-from typing import Any, Dict, Iterator, List, Optional
+from typing import Any, Callable, Dict, Iterator, List, Optional
 
 from aws_lambda_powertools.shared.headers_serializer import BaseHeadersSerializer
 
@@ -9,9 +9,10 @@ from aws_lambda_powertools.shared.headers_serializer import BaseHeadersSerialize
 class DictWrapper(Mapping):
     """Provides a single read only access to a wrapper dict"""
 
-    def __init__(self, data: Dict[str, Any]):
+    def __init__(self, data: Dict[str, Any], json_deserializer: Optional[Callable] = None):
         self._data = data
         self._json_data: Optional[Any] = None
+        self._json_deserializer = json_deserializer or json.loads
 
     def __getitem__(self, key: str) -> Any:
         return self._data[key]
@@ -122,7 +123,7 @@ class BaseProxyEvent(DictWrapper):
     def json_body(self) -> Any:
         """Parses the submitted body as json"""
         if self._json_data is None:
-            self._json_data = json.loads(self.decoded_body)
+            self._json_data = self._json_deserializer(self.decoded_body)
         return self._json_data
 
     @property

--- a/aws_lambda_powertools/utilities/data_classes/common.py
+++ b/aws_lambda_powertools/utilities/data_classes/common.py
@@ -10,6 +10,15 @@ class DictWrapper(Mapping):
     """Provides a single read only access to a wrapper dict"""
 
     def __init__(self, data: Dict[str, Any], json_deserializer: Optional[Callable] = None):
+        """
+        Parameters
+        ----------
+        data : Dict[str, Any]
+            Lambda Event Source Event payload
+        json_deserializer : Callable, optional
+            function to deserialize `str`, `bytes`, bytearray` containing a JSON document to a Python `obj`,
+            by default json.loads
+        """
         self._data = data
         self._json_data: Optional[Any] = None
         self._json_deserializer = json_deserializer or json.loads

--- a/aws_lambda_powertools/utilities/data_classes/kafka_event.py
+++ b/aws_lambda_powertools/utilities/data_classes/kafka_event.py
@@ -1,5 +1,4 @@
 import base64
-import json
 from typing import Any, Dict, Iterator, List, Optional
 
 from aws_lambda_powertools.utilities.data_classes.common import DictWrapper
@@ -55,7 +54,7 @@ class KafkaEventRecord(DictWrapper):
     def json_value(self) -> Any:
         """Decodes the text encoded data as JSON."""
         if self._json_data is None:
-            self._json_data = json.loads(self.decoded_value.decode("utf-8"))
+            self._json_data = self._json_deserializer(self.decoded_value.decode("utf-8"))
         return self._json_data
 
     @property
@@ -117,7 +116,7 @@ class KafkaEvent(DictWrapper):
         """The Kafka records."""
         for chunk in self["records"].values():
             for record in chunk:
-                yield KafkaEventRecord(record)
+                yield KafkaEventRecord(data=record, json_deserializer=self._json_deserializer)
 
     @property
     def record(self) -> KafkaEventRecord:

--- a/aws_lambda_powertools/utilities/data_classes/kinesis_firehose_event.py
+++ b/aws_lambda_powertools/utilities/data_classes/kinesis_firehose_event.py
@@ -1,5 +1,4 @@
 import base64
-import json
 from typing import Iterator, Optional
 
 from aws_lambda_powertools.utilities.data_classes.common import DictWrapper
@@ -75,7 +74,7 @@ class KinesisFirehoseRecord(DictWrapper):
     def data_as_json(self) -> dict:
         """Decoded base64-encoded data loaded to json"""
         if self._json_data is None:
-            self._json_data = json.loads(self.data_as_text)
+            self._json_data = self._json_deserializer(self.data_as_text)
         return self._json_data
 
 
@@ -110,4 +109,4 @@ class KinesisFirehoseEvent(DictWrapper):
     @property
     def records(self) -> Iterator[KinesisFirehoseRecord]:
         for record in self["records"]:
-            yield KinesisFirehoseRecord(record)
+            yield KinesisFirehoseRecord(data=record, json_deserializer=self._json_deserializer)

--- a/aws_lambda_powertools/utilities/data_classes/sqs_event.py
+++ b/aws_lambda_powertools/utilities/data_classes/sqs_event.py
@@ -104,6 +104,16 @@ class SQSRecord(DictWrapper):
         return self["body"]
 
     @property
+    def json_body(self) -> Dict:
+        """Parses the submitted body as json"""
+        try:
+            if self._json_data is None:
+                self._json_data = self._json_deserializer(self["body"])
+            return self._json_data
+        except Exception:
+            return self["body"]
+
+    @property
     def attributes(self) -> SQSRecordAttributes:
         """A map of the attributes requested in ReceiveMessage to their respective values."""
         return SQSRecordAttributes(self["attributes"])
@@ -157,4 +167,4 @@ class SQSEvent(DictWrapper):
     @property
     def records(self) -> Iterator[SQSRecord]:
         for record in self["Records"]:
-            yield SQSRecord(record)
+            yield SQSRecord(data=record, json_deserializer=self._json_deserializer)

--- a/aws_lambda_powertools/utilities/data_classes/sqs_event.py
+++ b/aws_lambda_powertools/utilities/data_classes/sqs_event.py
@@ -1,4 +1,4 @@
-from typing import Dict, Iterator, Optional
+from typing import Any, Dict, Iterator, Optional
 
 from aws_lambda_powertools.utilities.data_classes.common import DictWrapper
 
@@ -104,8 +104,30 @@ class SQSRecord(DictWrapper):
         return self["body"]
 
     @property
-    def json_body(self) -> Dict:
-        """Parses the submitted body as json"""
+    def json_body(self) -> Any:
+        """Deserializes JSON string available in 'body' property
+
+        Notes
+        -----
+
+        **Strict typing**
+
+        Caller controls the type as we can't use recursive generics here.
+
+        JSON Union types would force caller to have to cast a type. Instead,
+        we choose Any to ease ergonomics and other tools receiving this data.
+
+        Examples
+        --------
+
+        **Type deserialized data from JSON string**
+
+        ```python
+        data: dict = record.json_body  # {"telemetry": [], ...}
+        # or
+        data: list = record.json_body  # ["telemetry_values"]
+        ```
+        """
         if self._json_data is None:
             self._json_data = self._json_deserializer(self["body"])
         return self._json_data

--- a/aws_lambda_powertools/utilities/data_classes/sqs_event.py
+++ b/aws_lambda_powertools/utilities/data_classes/sqs_event.py
@@ -106,12 +106,9 @@ class SQSRecord(DictWrapper):
     @property
     def json_body(self) -> Dict:
         """Parses the submitted body as json"""
-        try:
-            if self._json_data is None:
-                self._json_data = self._json_deserializer(self["body"])
-            return self._json_data
-        except Exception:
-            return self["body"]
+        if self._json_data is None:
+            self._json_data = self._json_deserializer(self["body"])
+        return self._json_data
 
     @property
     def attributes(self) -> SQSRecordAttributes:

--- a/tests/events/sqsEvent.json
+++ b/tests/events/sqsEvent.json
@@ -25,7 +25,7 @@
     {
       "messageId": "2e1424d4-f796-459a-8184-9c92662be6da",
       "receiptHandle": "AQEBzWwaftRI0KuVm4tP+/7q1rGgNqicHq...",
-      "body": "Test message2.",
+      "body": "{\"message\": \"foo1\"}",
       "attributes": {
         "ApproximateReceiveCount": "1",
         "SentTimestamp": "1545082650636",

--- a/tests/functional/test_data_classes.py
+++ b/tests/functional/test_data_classes.py
@@ -113,6 +113,46 @@ def test_dict_wrapper_equals():
     assert DataClassSample(data1).raw_event is data1
 
 
+def test_dict_wrapper_with_default_custom_json_deserializer():
+    class DataClassSample(DictWrapper):
+        @property
+        def json_body(self) -> dict:
+            return self._json_deserializer(self["body"])
+
+    data = {"body": '{"message": "foo1"}'}
+    event = DataClassSample(data=data)
+    assert (event.json_body) == {"message": "foo1"}
+
+
+def test_dict_wrapper_with_valid_custom_json_deserializer():
+    class DataClassSample(DictWrapper):
+        @property
+        def json_body(self) -> dict:
+            return self._json_deserializer(self["body"])
+
+    def fake_json_deserializer(record: dict):
+        return json.loads(record)
+
+    data = {"body": '{"message": "foo1"}'}
+    event = DataClassSample(data=data, json_deserializer=fake_json_deserializer)
+    assert (event.json_body) == {"message": "foo1"}
+
+
+def test_dict_wrapper_with_wrong_custom_json_deserializer():
+    class DataClassSample(DictWrapper):
+        @property
+        def json_body(self) -> dict:
+            return self._json_deserializer(self["body"])
+
+    def fake_json_deserializer() -> None:
+        pass
+
+    data = {"body": {"message": "foo1"}}
+    with pytest.raises(TypeError):
+        event = DataClassSample(data=data, json_deserializer=fake_json_deserializer)
+        assert (event.json_body) == {"message": "foo1"}
+
+
 def test_dict_wrapper_implements_mapping():
     class DataClassSample(DictWrapper):
         pass

--- a/tests/functional/test_data_classes.py
+++ b/tests/functional/test_data_classes.py
@@ -121,7 +121,7 @@ def test_dict_wrapper_with_default_custom_json_deserializer():
 
     data = {"body": '{"message": "foo1"}'}
     event = DataClassSample(data=data)
-    assert (event.json_body) == {"message": "foo1"}
+    assert event.json_body == json.loads(data["body"])
 
 
 def test_dict_wrapper_with_valid_custom_json_deserializer():
@@ -135,22 +135,23 @@ def test_dict_wrapper_with_valid_custom_json_deserializer():
 
     data = {"body": '{"message": "foo1"}'}
     event = DataClassSample(data=data, json_deserializer=fake_json_deserializer)
-    assert (event.json_body) == {"message": "foo1"}
+    assert event.json_body == json.loads(data["body"])
 
 
-def test_dict_wrapper_with_wrong_custom_json_deserializer():
+def test_dict_wrapper_with_invalid_custom_json_deserializer():
     class DataClassSample(DictWrapper):
         @property
         def json_body(self) -> dict:
             return self._json_deserializer(self["body"])
 
     def fake_json_deserializer() -> None:
+        # invalid fn signature should raise TypeError
         pass
 
     data = {"body": {"message": "foo1"}}
     with pytest.raises(TypeError):
         event = DataClassSample(data=data, json_deserializer=fake_json_deserializer)
-        assert (event.json_body) == {"message": "foo1"}
+        assert event.json_body == {"message": "foo1"}
 
 
 def test_dict_wrapper_implements_mapping():

--- a/tests/functional/test_data_classes.py
+++ b/tests/functional/test_data_classes.py
@@ -966,6 +966,9 @@ def test_seq_trigger_event():
     assert record.queue_url == "https://sqs.us-east-2.amazonaws.com/123456789012/my-queue"
     assert record.aws_region == "us-east-2"
 
+    record_2 = records[1]
+    assert record_2.json_body == {"message": "foo1"}
+
 
 def test_default_api_gateway_proxy_event():
     event = APIGatewayProxyEvent(load_event("apiGatewayProxyEvent_noVersionAuth.json"))


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
**Issue number:** #2199 

## Summary

### Changes

This PR aims to add support for a custom `json` deserialization method in the event source classes.

### User experience

**BEFORE**

```python
from aws_lambda_powertools.utilities.data_classes import event_source, SQSEvent
import json 

def lambda_handler(event: SQSEvent, context):
    parsed = SQSEvent(data=event)
    # Multiple records can be delivered in a single event
    for record in parsed.records:
        print(json.loads(record.body))
```


**AFTER**

```python
from aws_lambda_powertools.utilities.data_classes import event_source, SQSEvent
import ujson

def lambda_handler(event: SQSEvent, context):
    
    parsed = SQSEvent(data = event, json_deserializer=ujson.loads)
    # Multiple records can be delivered in a single event
    for record in parsed.records:
        print(record.json_body)
```


## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] [Meet tenets criteria](https://awslabs.github.io/aws-lambda-powertools-python/#tenets)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [ ] Changes are documented
* [ ] PR title follows [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-python/blob/develop/.github/semantic.yml)

<details>
<summary>Is this a breaking change?</summary>

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
