### PR TITLE
chore(ci): schedule changelog to rebuild daily at 8am, and on release only

### DIFF
--- a/.github/workflows/build_changelog.yml
+++ b/.github/workflows/build_changelog.yml
@@ -3,6 +3,17 @@ name: Build changelog
 
 on:
   workflow_dispatch:
+  schedule:
+           # ┌───────────── minute (0 - 59)
+           # │ ┌───────────── hour (0 - 23)
+           # │ │ ┌───────────── day of the month (1 - 31)
+           # │ │ │ ┌───────────── month (1 - 12 or JAN-DEC)
+           # │ │ │ │ ┌───────────── day of the week (0 - 6 or SUN-SAT)
+           # │ │ │ │ │
+           # │ │ │ │ │
+           # │ │ │ │ │
+           # * * * * *
+    - cron: '0 8 * * *'
 
 jobs:
   changelog:

--- a/.github/workflows/on_push_docs.yml
+++ b/.github/workflows/on_push_docs.yml
@@ -8,15 +8,10 @@ on:
       - "docs/**"
       - "mkdocs.yml"
       - "examples/**"
+      - "CHANGELOG.md"
 
 jobs:
-  changelog:
-    permissions:
-      contents: write
-    uses: ./.github/workflows/reusable_publish_changelog.yml
-
   release-docs:
-    needs: changelog
     permissions:
       contents: write
       pages: write
@@ -24,12 +19,3 @@ jobs:
     with:
       version: develop
       alias: stage
-# Maintenance: Only necessary in repo migration
-# - name: Create redirect from old docs
-#   run: |
-#     git checkout gh-pages
-#     test -f 404.html && echo "Redirect already set" && exit 0
-#     git checkout develop -- 404.html
-#     git add 404.html
-#     git commit -m "chore: set docs redirect" --no-verify
-#     git push origin gh-pages -f

--- a/.github/workflows/rebuild_latest_docs.yml
+++ b/.github/workflows/rebuild_latest_docs.yml
@@ -15,13 +15,7 @@ on:
         required: true
 
 jobs:
-  changelog:
-    permissions:
-      contents: write
-    uses: ./.github/workflows/reusable_publish_changelog.yml
-
   release-docs:
-    needs: changelog
     permissions:
       contents: write
       pages: write


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
**Issue number:** closes #2208 #2209 

## Summary

### Changes

> Please provide a summary of what's being changed

* Update changelog workflow to rebuild daily at 8am
* Remove changelog rebuild from other workflows but release

### User experience

> Please share what the user experience looks like before and after this change

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] [Meet tenets criteria](https://awslabs.github.io/aws-lambda-powertools-python/#tenets)
* [x] I have performed a self-review of this change
* [ ] Changes have been tested
* [x] Changes are documented
* [x] PR title follows [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-python/blob/develop/.github/semantic.yml)

<details>
<summary>Is this a breaking change?</summary>

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
