### PR TITLE
fix(event_handler):  Updating body to empty-json instead of empty-string

### DIFF
--- a/aws_lambda_powertools/event_handler/api_gateway.py
+++ b/aws_lambda_powertools/event_handler/api_gateway.py
@@ -649,7 +649,7 @@ class ApiGatewayResolver(BaseRouter):
             if method == "OPTIONS":
                 logger.debug("Pre-flight request detected. Returning CORS with null response")
                 headers["Access-Control-Allow-Methods"] = ",".join(sorted(self._cors_methods))
-                return ResponseBuilder(Response(status_code=204, content_type=None, headers=headers, body=""))
+                return ResponseBuilder(Response(status_code=204, content_type=None, headers=headers, body="{}"))
 
         handler = self._lookup_exception_handler(NotFoundError)
         if handler:


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
**Issue number:** #2254 

## Summary

### Changes

> Updated response of body in case when the powertool router does not find any API's mapped to the request. The body is updated from empty-string "" to empty-json {}

### User experience

> Earlier, the API Gateway responded with 500 internal server error for a pre-flight CORS request. After the change, the API is succesfully called.

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] [Meet tenets criteria](https://awslabs.github.io/aws-lambda-powertools-python/#tenets)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented
* [x] PR title follows [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-python/blob/develop/.github/semantic.yml)

<details>
<summary>Is this a breaking change?</summary>

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
