### PR TITLE
chore(governance): Fix python version in issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -58,10 +58,10 @@ body:
     attributes:
       label: AWS Lambda function runtime
       options:
-        - 3.7
-        - 3.8
-        - 3.9
-        - 3.10
+        - "3.7"
+        - "3.8"
+        - "3.9"
+        - "3.10"
     validations:
       required: true
   - type: dropdown

--- a/.github/ISSUE_TEMPLATE/static_typing.yml
+++ b/.github/ISSUE_TEMPLATE/static_typing.yml
@@ -25,10 +25,10 @@ body:
     attributes:
       label: AWS Lambda function runtime
       options:
-        - 3.7
-        - 3.8
-        - 3.9
-        - 3.10
+        - "3.7"
+        - "3.8"
+        - "3.9"
+        - "3.10"
     validations:
       required: true
   - type: input


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
**Issue number:** #2274 

## Summary

### Changes

After adding support for Python 3.10, our issue templates are showing it as Python 3.1. We need to fix this.

### User experience

> Please share what the user experience looks like before and after this change

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] [Meet tenets criteria](https://awslabs.github.io/aws-lambda-powertools-python/#tenets)
* [x] I have performed a self-review of this change
* [ ] Changes have been tested
* [ ] Changes are documented
* [x] PR title follows [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-python/blob/develop/.github/semantic.yml)

<details>
<summary>Is this a breaking change?</summary>

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
