### PR TITLE
feat(docs): Move docs to S3

### DIFF
--- a/.github/workflows/on_push_docs.yml
+++ b/.github/workflows/on_push_docs.yml
@@ -10,11 +10,15 @@ on:
       - "examples/**"
       - "CHANGELOG.md"
 
+permissions:
+  id-token: write
+
 jobs:
   release-docs:
     permissions:
       contents: write
       pages: write
+      id-token: write
     uses: ./.github/workflows/reusable_publish_docs.yml
     with:
       version: develop

--- a/.github/workflows/publish_v2_layer.yml
+++ b/.github/workflows/publish_v2_layer.yml
@@ -28,7 +28,7 @@ jobs:
     permissions:
       # lower privilege propagated from parent workflow (release.yml)
       contents: read
-      id-token: none
+      id-token: write
       pages: none
       pull-requests: none
     runs-on: aws-lambda-powertools_ubuntu-latest_8-core
@@ -223,7 +223,7 @@ jobs:
       contents: write
       pages: write
       pull-requests: none
-      id-token: none
+      id-token: write
     uses: ./.github/workflows/reusable_publish_docs.yml
     with:
       version: ${{ inputs.latest_published_version }}

--- a/.github/workflows/rebuild_latest_docs.yml
+++ b/.github/workflows/rebuild_latest_docs.yml
@@ -14,11 +14,15 @@ on:
         default: "2.0.0"
         required: true
 
+permissions:
+  id-token: write
+
 jobs:
   release-docs:
     permissions:
       contents: write
       pages: write
+      id-token: write
     uses: ./.github/workflows/reusable_publish_docs.yml
     with:
       version: ${{ inputs.latest_published_version }}

--- a/.github/workflows/reusable_publish_docs.yml
+++ b/.github/workflows/reusable_publish_docs.yml
@@ -105,7 +105,7 @@ jobs:
         run: |
           aws s3 sync \
             site/ \
-            s3://${{ secrets.AWS_DOCS_BUCKET }}/lambda-test/${{ env.VERSION }}/
+            s3://${{ secrets.AWS_DOCS_BUCKET }}/lambda-python/${{ env.VERSION }}/
       - name: Deploy Docs (Alias)
         env:
           VERSION: ${{ inputs.version }}
@@ -113,4 +113,4 @@ jobs:
         run: |
           aws s3 sync \
             site/ \
-            s3://${{ secrets.AWS_DOCS_BUCKET }}/lambda-test/${{ env.ALIAS }}/
+            s3://${{ secrets.AWS_DOCS_BUCKET }}/lambda-python/${{ env.ALIAS }}/

--- a/.github/workflows/reusable_publish_docs.yml
+++ b/.github/workflows/reusable_publish_docs.yml
@@ -26,6 +26,7 @@ on:
         default: develop
 
 permissions:
+  id-token: write
   contents: write
   pages: write
 
@@ -36,6 +37,7 @@ jobs:
     concurrency:
       group: on-docs-rebuild
     runs-on: ubuntu-latest
+    environment: Docs
     steps:
       - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab  # v3.5.2
         with:
@@ -88,3 +90,27 @@ jobs:
           publish_dir: ./api
           keep_files: true
           destination_dir: latest/api
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@e1e17a757e536f70e52b5a12b2e8d1d1c60e04ef
+        with:
+          aws-region: us-east-1
+          role-to-assume: ${{ secrets.AWS_DOCS_ROLE_ARN }}
+      - name: Copy API Docs
+        run: |
+          cp -r api site/
+      - name: Deploy Docs (Version)
+        env:
+          VERSION: ${{ inputs.version }}
+          ALIAS: ${{ inputs.alias }}
+        run: |
+          aws s3 sync \
+            site/ \
+            s3://${{ secrets.AWS_DOCS_BUCKET }}/lambda-test/${{ env.VERSION }}/
+      - name: Deploy Docs (Alias)
+        env:
+          VERSION: ${{ inputs.version }}
+          ALIAS: ${{ inputs.alias }}
+        run: |
+          aws s3 sync \
+            site/ \
+            s3://${{ secrets.AWS_DOCS_BUCKET }}/lambda-test/${{ env.ALIAS }}/


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
**Issue number:**

## Summary
As the project changes, we want to host our documentation on our own domain, this frees us of GitHub Pages and related outages. After this change our docs will be hosted in two locations GH Pages and on docs.powertools.aws.dev, this is a middle step for further changes later.

### Changes

> Please provide a summary of what's being changed

This pull request adds some extra steps to the release docs process, it copies the generated docs to an S3 bucket.

### User experience

> Please share what the user experience looks like before and after this change

Docs will be available in S3 and GH Pages

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [ ] [Meet tenets criteria](https://awslabs.github.io/aws-lambda-powertools-python/#tenets)
* [ ] I have performed a self-review of this change
* [ ] Changes have been tested
* [ ] Changes are documented
* [ ] PR title follows [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-python/blob/develop/.github/semantic.yml)

<details>
<summary>Is this a breaking change?</summary>

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
