### PR TITLE
fix(logger): add setLevel function to set level programmatically

### DIFF
--- a/aws_lambda_powertools/logging/logger.py
+++ b/aws_lambda_powertools/logging/logger.py
@@ -455,6 +455,7 @@ class Logger(logging.Logger):  # lgtm [py/missing-call-to-init]
             The level to set. Can be a string representing the level name: 'DEBUG', 'INFO', 'WARNING', 'ERROR', 'CRITICAL'
             or an integer representing the level value: 10 for 'DEBUG', 20 for 'INFO', 30 for 'WARNING', 40 for 'ERROR', 50 for 'CRITICAL'. # noqa: E501
         """
+        self.log_level = level
         self._logger.setLevel(level)
 
     def info(

--- a/aws_lambda_powertools/logging/logger.py
+++ b/aws_lambda_powertools/logging/logger.py
@@ -91,7 +91,9 @@ class Logger(logging.Logger):  # lgtm [py/missing-call-to-init]
     service : str, optional
         service name to be appended in logs, by default "service_undefined"
     level : str, int optional
-        logging.level, by default "INFO"
+        The level to set. Can be a string representing the level name: 'DEBUG', 'INFO', 'WARNING', 'ERROR', 'CRITICAL'
+        or an integer representing the level value: 10 for 'DEBUG', 20 for 'INFO', 30 for 'WARNING', 40 for 'ERROR', 50 for 'CRITICAL'. # noqa: E501
+        by default "INFO"
     child: bool, optional
         create a child Logger named <service>.<caller_file_name>, False by default
     sample_rate: float, optional
@@ -442,6 +444,18 @@ class Logger(logging.Logger):  # lgtm [py/missing-call-to-init]
             return lambda_handler(event, context, *args, **kwargs)
 
         return decorate
+
+    def setLevel(self, level: Union[str, int]):
+        """
+        Set the logging level for the logger.
+
+        Parameters:
+        -----------
+        level str | int
+            The level to set. Can be a string representing the level name: 'DEBUG', 'INFO', 'WARNING', 'ERROR', 'CRITICAL'
+            or an integer representing the level value: 10 for 'DEBUG', 20 for 'INFO', 30 for 'WARNING', 40 for 'ERROR', 50 for 'CRITICAL'. # noqa: E501
+        """
+        self._logger.setLevel(level)
 
     def info(
         self,

--- a/aws_lambda_powertools/logging/logger.py
+++ b/aws_lambda_powertools/logging/logger.py
@@ -329,7 +329,7 @@ class Logger(logging.Logger):  # lgtm [py/missing-call-to-init]
         try:
             if self.sampling_rate and random.random() <= float(self.sampling_rate):
                 logger.debug("Setting log level to Debug due to sampling rate")
-                self.log_level = logging.DEBUG
+                self.setLevel(logging.DEBUG)
         except ValueError:
             raise InvalidLoggerSamplingRateError(
                 f"Expected a float value ranging 0 to 1, but received {self.sampling_rate} instead."

--- a/tests/functional/test_logger.py
+++ b/tests/functional/test_logger.py
@@ -379,6 +379,23 @@ def test_logger_level_env_var_as_int(monkeypatch, service_name):
         Logger(service=service_name)
 
 
+def test_logger_switch_between_levels(stdout, service_name):
+    # GIVEN a Loggers is initialized with INFO level
+    logger = Logger(service=service_name, level="INFO", stream=stdout)
+    logger.info("message info")
+
+    # WHEN we switch to DEBUG level
+    logger.setLevel(level="DEBUG")
+    logger.debug("message debug")
+
+    # THEN we must have different levels and messages in stdout
+    log_output = capture_multiple_logging_statements_output(stdout)
+    assert log_output[0]["level"] == "INFO"
+    assert log_output[0]["message"] == "message info"
+    assert log_output[1]["level"] == "DEBUG"
+    assert log_output[1]["message"] == "message debug"
+
+
 def test_logger_record_caller_location(stdout, service_name):
     # GIVEN Logger is initialized
     logger = Logger(service=service_name, stream=stdout)


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
**Issue number:** #2303 

## Summary

### Changes

When changing the logging level of a Logger via code, the logging level must be changed. With the current implementation, this was not happening because it was modifying the superclass and not the Logger instance. This PR aims to fix that.

### User experience

> Please share what the user experience looks like before and after this change

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] [Meet tenets criteria](https://awslabs.github.io/aws-lambda-powertools-python/#tenets)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [ ] Changes are documented
* [x] PR title follows [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-python/blob/develop/.github/semantic.yml)

<details>
<summary>Is this a breaking change?</summary>

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
