### PR TITLE
fix(docs): use concrete secrets from settings

### DIFF
--- a/.github/workflows/on_push_docs.yml
+++ b/.github/workflows/on_push_docs.yml
@@ -24,4 +24,3 @@ jobs:
     with:
       version: develop
       alias: stage
-      environment: "Docs"

--- a/.github/workflows/on_push_docs.yml
+++ b/.github/workflows/on_push_docs.yml
@@ -19,10 +19,9 @@ jobs:
       contents: write
       pages: write
       id-token: write
+    secrets: inherit
     uses: ./.github/workflows/reusable_publish_docs.yml
     with:
       version: develop
       alias: stage
-    secrets:
-      AWS_DOCS_ROLE_ARN: ${{ secrets.AWS_DOCS_ROLE_ARN }}
-      AWS_DOCS_BUCKET: ${{ secrets.AWS_DOCS_BUCKET }}
+      environment: "Docs"

--- a/.github/workflows/on_push_docs.yml
+++ b/.github/workflows/on_push_docs.yml
@@ -23,3 +23,6 @@ jobs:
     with:
       version: develop
       alias: stage
+    secrets:
+      AWS_DOCS_ROLE_ARN: ${{ secrets.AWS_DOCS_ROLE_ARN }}
+      AWS_DOCS_BUCKET: ${{ secrets.AWS_DOCS_BUCKET }}

--- a/.github/workflows/publish_v2_layer.yml
+++ b/.github/workflows/publish_v2_layer.yml
@@ -224,11 +224,10 @@ jobs:
       pages: write
       pull-requests: none
       id-token: write
+    secrets: inherit
     uses: ./.github/workflows/reusable_publish_docs.yml
     with:
       version: ${{ inputs.latest_published_version }}
       alias: ${{ needs.prepare_docs_alias.outputs.DOCS_ALIAS }}
       git_ref: ${{ needs.update_v2_layer_arn_docs.outputs.temp_branch }}
-    secrets:
-      AWS_DOCS_ROLE_ARN: ${{ secrets.AWS_DOCS_ROLE_ARN }}
-      AWS_DOCS_BUCKET: ${{ secrets.AWS_DOCS_BUCKET }}
+      environment: "Docs"

--- a/.github/workflows/publish_v2_layer.yml
+++ b/.github/workflows/publish_v2_layer.yml
@@ -230,4 +230,3 @@ jobs:
       version: ${{ inputs.latest_published_version }}
       alias: ${{ needs.prepare_docs_alias.outputs.DOCS_ALIAS }}
       git_ref: ${{ needs.update_v2_layer_arn_docs.outputs.temp_branch }}
-      environment: "Docs"

--- a/.github/workflows/publish_v2_layer.yml
+++ b/.github/workflows/publish_v2_layer.yml
@@ -229,3 +229,6 @@ jobs:
       version: ${{ inputs.latest_published_version }}
       alias: ${{ needs.prepare_docs_alias.outputs.DOCS_ALIAS }}
       git_ref: ${{ needs.update_v2_layer_arn_docs.outputs.temp_branch }}
+    secrets:
+      AWS_DOCS_ROLE_ARN: ${{ secrets.AWS_DOCS_ROLE_ARN }}
+      AWS_DOCS_BUCKET: ${{ secrets.AWS_DOCS_BUCKET }}

--- a/.github/workflows/rebuild_latest_docs.yml
+++ b/.github/workflows/rebuild_latest_docs.yml
@@ -23,10 +23,9 @@ jobs:
       contents: write
       pages: write
       id-token: write
+    secrets: inherit
     uses: ./.github/workflows/reusable_publish_docs.yml
     with:
       version: ${{ inputs.latest_published_version }}
       alias: latest
-    secrets:
-      AWS_DOCS_ROLE_ARN: ${{ secrets.AWS_DOCS_ROLE_ARN }}
-      AWS_DOCS_BUCKET: ${{ secrets.AWS_DOCS_BUCKET }}
+      environment: "Docs"

--- a/.github/workflows/rebuild_latest_docs.yml
+++ b/.github/workflows/rebuild_latest_docs.yml
@@ -28,4 +28,3 @@ jobs:
     with:
       version: ${{ inputs.latest_published_version }}
       alias: latest
-      environment: "Docs"

--- a/.github/workflows/rebuild_latest_docs.yml
+++ b/.github/workflows/rebuild_latest_docs.yml
@@ -27,3 +27,6 @@ jobs:
     with:
       version: ${{ inputs.latest_published_version }}
       alias: latest
+    secrets:
+      AWS_DOCS_ROLE_ARN: ${{ secrets.AWS_DOCS_ROLE_ARN }}
+      AWS_DOCS_BUCKET: ${{ secrets.AWS_DOCS_BUCKET }}

--- a/.github/workflows/reusable_publish_docs.yml
+++ b/.github/workflows/reusable_publish_docs.yml
@@ -24,10 +24,6 @@ on:
         required: false
         type: string
         default: develop
-      environment:
-        description: "GitHub Environment to use for encrypted secrets"
-        required: true
-        type: string
 
 permissions:
   id-token: write

--- a/.github/workflows/reusable_publish_docs.yml
+++ b/.github/workflows/reusable_publish_docs.yml
@@ -5,13 +5,6 @@ env:
 
 on:
   workflow_call:
-    secrets:
-      AWS_DOCS_ROLE_ARN:
-        description: Docs IAM Role
-        required: false
-      AWS_DOCS_BUCKET:
-        description: Docs S3 Bucket
-        required: false
     inputs:
       version:
         description: "Version to build and publish docs (1.28.0, develop)"
@@ -31,6 +24,10 @@ on:
         required: false
         type: string
         default: develop
+      environment:
+        description: "GitHub Environment to use for encrypted secrets"
+        required: true
+        type: string
 
 permissions:
   id-token: write
@@ -44,7 +41,7 @@ jobs:
     concurrency:
       group: on-docs-rebuild
     runs-on: ubuntu-latest
-    environment: Docs
+    environment: ${{ inputs.environment }}
     steps:
       - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab  # v3.5.2
         with:

--- a/.github/workflows/reusable_publish_docs.yml
+++ b/.github/workflows/reusable_publish_docs.yml
@@ -37,7 +37,7 @@ jobs:
     concurrency:
       group: on-docs-rebuild
     runs-on: ubuntu-latest
-    environment: ${{ inputs.environment }}
+    environment: "Docs"
     steps:
       - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab  # v3.5.2
         with:

--- a/.github/workflows/reusable_publish_docs.yml
+++ b/.github/workflows/reusable_publish_docs.yml
@@ -5,6 +5,13 @@ env:
 
 on:
   workflow_call:
+    secrets:
+      AWS_DOCS_ROLE_ARN:
+        description: Docs IAM Role
+        required: false
+      AWS_DOCS_BUCKET:
+        description: Docs S3 Bucket
+        required: false
     inputs:
       version:
         description: "Version to build and publish docs (1.28.0, develop)"


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
**Issue number:** #2277

## Summary

### Changes

> Please provide a summary of what's being changed

Forces GHA to use the secrets stored in the repository.

### User experience

> Please share what the user experience looks like before and after this change

No change

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [X] [Meet tenets criteria](https://awslabs.github.io/aws-lambda-powertools-python/#tenets)
* [X] I have performed a self-review of this change
* [X] Changes have been tested
* [X] Changes are documented
* [X] PR title follows [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-python/blob/develop/.github/semantic.yml)

<details>
<summary>Is this a breaking change?</summary>

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
