### PR TITLE
fix(event_source): change the import location of boto3 in CodePipelineJobEvent data class

### DIFF
--- a/aws_lambda_powertools/utilities/data_classes/code_pipeline_job_event.py
+++ b/aws_lambda_powertools/utilities/data_classes/code_pipeline_job_event.py
@@ -4,8 +4,6 @@ import zipfile
 from typing import Any, Dict, List, Optional
 from urllib.parse import unquote_plus
 
-import boto3
-
 from aws_lambda_powertools.utilities.data_classes.common import DictWrapper
 
 
@@ -203,6 +201,10 @@ class CodePipelineJobEvent(DictWrapper):
         BaseClient
             An S3 client with the appropriate credentials
         """
+        # IMPORTING boto3 within the FUNCTION and not at the top level to get
+        # it only when we explicitly want it for better performance.
+        import boto3
+
         return boto3.client(
             "s3",
             aws_access_key_id=self.data.artifact_credentials.access_key_id,

--- a/docs/core/logger.md
+++ b/docs/core/logger.md
@@ -741,6 +741,7 @@ Here's an example where we persist `payment_id` not `request_id`. Note that `pay
     ---8<-- "examples/logger/src/append_keys_vs_extra_output.json"
     ```
 
+<!-- markdownlint-disable MD013 -->
 ### How do I aggregate and search Powertools for AWS Lambda (Python) logs across accounts?
 
 As of now, ElasticSearch (ELK) or 3rd party solutions are best suited to this task. Please refer to this [discussion for more details](https://github.com/awslabs/aws-lambda-powertools-python/issues/460)


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
**Issue number:** #2352 

## Summary
Importing `boto3` at top level in `code_pipeline_job_event.py` is affecting performance when import modules that needs `aws_lambda_powertools.utilities.data_classes`.

### Changes

Change the import location of `boto3` in `code_pipeline_job_event.py` to be within function `setup_s3_client` instead of top level, since this is being used to download an artifact from CodePipeline Job and it is not a common use.

### User experience

Decrease of import time when importing modules that uses `aws_lambda_powertools.utilities.data_classes`, such as `ApiGatewayResolver`.

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] [Meet tenets criteria](https://awslabs.github.io/aws-lambda-powertools-python/#tenets)
* [x] I have performed a self-review of this change
* [ ] Changes have been tested
* [x] Changes are documented
* [x] PR title follows [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-python/blob/develop/.github/semantic.yml)

<details>
<summary>Is this a breaking change?</summary>

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
