### PR TITLE
fix(shared): skip user agent on much older botocore versions

### DIFF
--- a/aws_lambda_powertools/shared/user_agent.py
+++ b/aws_lambda_powertools/shared/user_agent.py
@@ -160,6 +160,10 @@ def register_feature_to_resource(resource, feature):
 
 def inject_user_agent():
     if inject_header:
+        # Some older botocore versions doesn't support register_initializer. In those cases, we disable the feature.
+        if not hasattr(botocore, "register_initializer"):
+            return
+
         # Customize botocore session to inject Powertools header
         # See: https://github.com/boto/botocore/pull/2682
         botocore.register_initializer(_initializer_botocore_session)


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->

**Issue number:** #2365

## Summary

### Changes

> Please provide a summary of what's being changed

With this change, we will not crash when the botocore version is old.

### User experience

> Please share what the user experience looks like before and after this change

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

- [x] [Meet tenets criteria](https://awslabs.github.io/aws-lambda-powertools-python/#tenets)
- [x] I have performed a self-review of this change
- [ ] Changes have been tested
- [ ] Changes are documented
- [x] PR title follows [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-python/blob/develop/.github/semantic.yml)

<details>
<summary>Is this a breaking change?</summary>

**RFC issue number**:

Checklist:

- [ ] Migration process documented
- [ ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
