### PR TITLE
fix(parameters): AppConfigProvider when retrieving multiple unique configuration names

### DIFF
--- a/docs/utilities/parameters.md
+++ b/docs/utilities/parameters.md
@@ -92,7 +92,7 @@ You can fetch application configurations in AWS AppConfig using `get_app_config`
 The following will retrieve the latest version and store it in the cache.
 
 ???+ warning
-	When fetching each unique parameter from the AppConfig for the first time, the system executes two API calls, incurring network latency in the process. To enhance performance and caching, it is advisable to consider increasing the `max_age` time.
+	We make two API calls to fetch each unique configuration name during the first time. This is by design in AppConfig. Please consider adjusting `max_age` parameter to enhance performance.
 
 === "getting_started_appconfig.py"
     ```python hl_lines="5 12"

--- a/docs/utilities/parameters.md
+++ b/docs/utilities/parameters.md
@@ -91,6 +91,9 @@ You can fetch application configurations in AWS AppConfig using `get_app_config`
 
 The following will retrieve the latest version and store it in the cache.
 
+???+ warning
+	When fetching each unique parameter from the AppConfig for the first time, the system executes two API calls, incurring network latency in the process. To enhance performance and caching, it is advisable to consider increasing the `max_age` time.
+
 === "getting_started_appconfig.py"
     ```python hl_lines="5 12"
     --8<-- "examples/parameters/src/getting_started_appconfig.py"

--- a/tests/functional/test_utilities_parameters.py
+++ b/tests/functional/test_utilities_parameters.py
@@ -31,6 +31,12 @@ def mock_name():
 
 
 @pytest.fixture(scope="function")
+def mock_name_multiple_calls():
+    # Parameter name must match [a-zA-Z0-9_.-/]+
+    return "".join(random.choices(string.ascii_letters + string.digits + "_.-/", k=random.randrange(3, 200)))
+
+
+@pytest.fixture(scope="function")
 def mock_value():
     # Standard parameters can be up to 4 KB
     return "".join(random.choices(string.printable, k=random.randrange(100, 4000)))
@@ -2175,6 +2181,65 @@ def test_appconf_provider_get_configuration_no_transform(mock_name, config):
         str_value = value.decode("utf-8")
         assert str_value == json.dumps(mock_body_json)
         stubber.assert_no_pending_responses()
+    finally:
+        stubber.deactivate()
+
+
+def test_appconf_provider_multiple_calls_with_same_instance(mock_name, mock_name_multiple_calls, config):
+    """
+    Test appconfigprovider.get with default values
+    """
+
+    # Create a new provider
+    # GIVEN a provider instance, we should be able to retrieve multiple appconfig profiles.
+    environment = "dev"
+    application = "myapp"
+    provider = parameters.AppConfigProvider(environment=environment, application=application, config=config)
+
+    mock_body_json_first_call = {"myenvvar1": "Black Panther", "myenvvar2": 3}
+    encoded_message_first_call = json.dumps(mock_body_json_first_call).encode("utf-8")
+    mock_value_first_call = StreamingBody(BytesIO(encoded_message_first_call), len(encoded_message_first_call))
+
+    mock_body_json_second_call = {"myenvvar1": "Thor", "myenvvar2": 5}
+    encoded_message_second_call = json.dumps(mock_body_json_second_call).encode("utf-8")
+    mock_value_second_call = StreamingBody(BytesIO(encoded_message_second_call), len(encoded_message_second_call))
+
+    # WHEN making two API calls using the same provider instance.
+    stubber = stub.Stubber(provider.client)
+
+    response_get_latest_config_first_call = {
+        "Configuration": mock_value_first_call,
+        "NextPollConfigurationToken": "initial_token",
+        "ContentType": "application/json",
+    }
+
+    response_start_config_session = {"InitialConfigurationToken": "initial_token"}
+    stubber.add_response("start_configuration_session", response_start_config_session)
+    stubber.add_response("get_latest_configuration", response_get_latest_config_first_call)
+
+    response_get_latest_config_second_call = {
+        "Configuration": mock_value_second_call,
+        "NextPollConfigurationToken": "initial_token",
+        "ContentType": "application/json",
+    }
+    response_start_config_session = {"InitialConfigurationToken": "initial_token"}
+    stubber.add_response("start_configuration_session", response_start_config_session)
+    stubber.add_response("get_latest_configuration", response_get_latest_config_second_call)
+
+    stubber.activate()
+
+    try:
+        # THEN we should expect different return values.
+        value_first_call: str = provider.get(mock_name)
+        str_value_first_call = value_first_call.decode("utf-8")
+        assert str_value_first_call == json.dumps(mock_body_json_first_call)
+
+        value_second_call: str = provider.get(mock_name_multiple_calls)
+        str_value_second_call = value_second_call.decode("utf-8")
+        assert str_value_second_call == json.dumps(mock_body_json_second_call)
+
+        stubber.assert_no_pending_responses()
+
     finally:
         stubber.deactivate()
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
**Issue number:** #2362 

## Summary

### Changes

This RP aims to fix the issue with the AppConfig parameter provider retrieving different parameters in the same Lambda execution. The way it is implemented, `self._next_token` caches token globally and retrieves only the value of the first call, and discards the others.

### User experience

```python
from typing import Any

import requests

from aws_lambda_powertools import Logger
from aws_lambda_powertools.utilities import parameters
from aws_lambda_powertools.utilities.typing import LambdaContext

logger = Logger()

def lambda_handler(event: dict, context: LambdaContext):
    endpoint_comments_config: Any = parameters.get_app_config(name="config", environment="dev", application="comments", max_age=0)
    
    endpoint_comments_features: Any = parameters.get_app_config(name="features", environment="dev", application="comments", max_age=0)

    logger.info(endpoint_comments_config)
    logger.info(endpoint_comments_features) # <- THIS will print the value of name="config" instead of name="features"
```

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] [Meet tenets criteria](https://awslabs.github.io/aws-lambda-powertools-python/#tenets)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented
* [x] PR title follows [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-python/blob/develop/.github/semantic.yml)

<details>
<summary>Is this a breaking change?</summary>

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
