### PR TITLE
fix(event_handler): prioritize static over dynamic route to prevent order of route registration mismatch

### DIFF
--- a/aws_lambda_powertools/event_handler/api_gateway.py
+++ b/aws_lambda_powertools/event_handler/api_gateway.py
@@ -518,10 +518,10 @@ class ApiGatewayResolver(BaseRouter):
             for item in methods:
                 _route = Route(item, self._compile_regex(rule), func, cors_enabled, compress, cache_control)
 
-                # To prioritize routes based on specificity, we handle dynamic and static routes differently. Dynamic
-                # routes, which contain variable parts, are stored separately from static routes. This allows us to
-                # first check the static routes for a match before attempting to match the dynamic routes. By
-                # following this approach, we ensure that the most specific route is prioritized and processed first.
+                # The more specific route wins.
+                # We store dynamic (/studies/{studyid}) and static routes (/studies/fetch) separately.
+                # Then attempt a match for static routes before dynamic routes.
+                # This ensures that the most specific route is prioritized and processed first (studies/fetch).
                 if _route.rule.groups > 0:
                     self._dynamic_routes.append(_route)
                 else:

--- a/aws_lambda_powertools/event_handler/api_gateway.py
+++ b/aws_lambda_powertools/event_handler/api_gateway.py
@@ -515,7 +515,18 @@ class ApiGatewayResolver(BaseRouter):
                 cors_enabled = cors
 
             for item in methods:
-                self._routes.append(Route(item, self._compile_regex(rule), func, cors_enabled, compress, cache_control))
+                _route = Route(item, self._compile_regex(rule), func, cors_enabled, compress, cache_control)
+
+                # If the compiled regex contains groups, we want to prioritize routes that will fully match the path
+                # directly. To achieve this, we add routes with groups at the end of the list, while routes without
+                # groups are added at the beginning of the list.
+                if _route.rule.groups > 0:
+                    # Insert route at the end of the list
+                    self._routes.append(_route)
+                else:
+                    # Insert route at the beginning of the list
+                    self._routes.insert(0, _route)
+
                 route_key = item + rule
                 if route_key in self._route_keys:
                     warnings.warn(

--- a/tests/functional/event_handler/test_api_gateway.py
+++ b/tests/functional/event_handler/test_api_gateway.py
@@ -298,7 +298,7 @@ def test_no_matches():
         return app.resolve(event, context)
 
     # Also check the route configurations
-    routes = app._routes
+    routes = app._static_routes
     assert len(routes) == 5
     for route in routes:
         if route.func == get_func:
@@ -1205,7 +1205,7 @@ def test_api_gateway_app_router_with_different_methods():
     app.include_router(router)
 
     # Also check check the route configurations
-    routes = app._routes
+    routes = app._static_routes
     assert len(routes) == 5
     for route in routes:
         if route.func == get_func:

--- a/tests/functional/event_handler/test_api_gateway.py
+++ b/tests/functional/event_handler/test_api_gateway.py
@@ -1647,3 +1647,26 @@ def test_dict_response_with_status_code():
     assert response["multiValueHeaders"]["Content-Type"] == [content_types.APPLICATION_JSON]
     response_body = json.loads(response["body"])
     assert response_body["message"] == "success"
+
+
+def test_route_match_prioritize_full_match():
+    # GIVEN a Http API V1, with a function registered with two routes
+    app = APIGatewayRestResolver()
+    router = Router()
+
+    @router.get("/my/{path}")
+    def dynamic_handler() -> Response:
+        return Response(200, content_types.APPLICATION_JSON, json.dumps({"hello": "dynamic"}))
+
+    @router.get("/my/path")
+    def static_handler() -> Response:
+        return Response(200, content_types.APPLICATION_JSON, json.dumps({"hello": "static"}))
+
+    app.include_router(router)
+
+    # WHEN calling the event handler with /foo/dynamic
+    response = app(LOAD_GW_EVENT, {})
+
+    # THEN the static_handler should have been called, because it fully matches the path directly
+    response_body = json.loads(response["body"])
+    assert response_body["hello"] == "static"


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->

**Issue number:** #2439

## Summary

### Changes

> Please provide a summary of what's being changed

This PR changes the priority of route matching, so that the most specific route is matched first.

### User experience

> Please share what the user experience looks like before and after this change

Take into consideration the following code:

```python
from aws_lambda_powertools.event_handler import APIGatewayRestResolver

app = APIGatewayRestResolver()


@app.get("/studies/<studyid>")
def get_study(studyid):
    return "get_study"


@app.get("/studies/fetch")
def fetch_studies():
    return "fetch_studies"


def handler(event, context):
    return app.resolve(event, context)
```

Before this change, `/studies/fetch` would match the first route, because it's a prefix of `/studies/<studyid>`. After this change, the most specific route is matched first, so `/studies/fetch` will match the second route.

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

- [x] [Meet tenets criteria](https://awslabs.github.io/aws-lambda-powertools-python/#tenets)
- [x] I have performed a self-review of this change
- [x] Changes have been tested
- [ ] Changes are documented
- [ ] PR title follows [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-python/blob/develop/.github/semantic.yml)

<details>
<summary>Is this a breaking change?</summary>

**RFC issue number**:

Checklist:

- [ ] Migration process documented
- [ ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
