### PR TITLE
docs(event_sources): fix DynamoDB stream event docstring

### DIFF
--- a/aws_lambda_powertools/utilities/data_classes/common.py
+++ b/aws_lambda_powertools/utilities/data_classes/common.py
@@ -16,7 +16,7 @@ class DictWrapper(Mapping):
         data : Dict[str, Any]
             Lambda Event Source Event payload
         json_deserializer : Callable, optional
-            function to deserialize `str`, `bytes`, bytearray` containing a JSON document to a Python `obj`,
+            function to deserialize `str`, `bytes`, `bytearray` containing a JSON document to a Python `obj`,
             by default json.loads
         """
         self._data = data

--- a/aws_lambda_powertools/utilities/data_classes/dynamo_db_stream_event.py
+++ b/aws_lambda_powertools/utilities/data_classes/dynamo_db_stream_event.py
@@ -39,7 +39,7 @@ class TypeDeserializer:
             --------                                ------
             {'NULL': True}                          None
             {'BOOL': True/False}                    True/False
-            {'N': str(value)}                       str(value)
+            {'N': Decimal(value)}                   Decimal(value)
             {'S': string}                           string
             {'B': bytes}                            bytes
             {'NS': [str(value)]}                    set([str(value)])


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
**Issue number:** #2462

## Summary

### Changes

> Please provide a summary of what's being changed

Updating the dynamodb `deserialize` function's docstring to reflect the proper return type when deserializing `N` attributes. Going from `str` to `Decimal`.

Also added a missing backtick to another docstring.

### User experience

> Please share what the user experience looks like before and after this change

It was a `str` before which was the wrong type.

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] [Meet tenets criteria](https://awslabs.github.io/aws-lambda-powertools-python/#tenets)
* [x] I have performed a self-review of this change
* [ ] Changes have been tested
* [x] Changes are documented
* [x] PR title follows [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-python/blob/develop/.github/semantic.yml)

<details>
<summary>Is this a breaking change?</summary>

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.