### PR TITLE
chore(ci): updates runner names in workflows

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,5 +1,4 @@
 self-hosted-runner:
   labels:
-    - aws-lambda-powertools_ubuntu-latest_4-core
-    - aws-lambda-powertools_ubuntu-latest_8-core
-    - aws-lambda-powertools_ubuntu-latest_16-core
+    - aws-powertools_ubuntu-latest_4-core 
+    - aws-powertools_ubuntu-latest_8-core

--- a/.github/workflows/publish_v2_layer.yml
+++ b/.github/workflows/publish_v2_layer.yml
@@ -57,7 +57,7 @@ jobs:
       id-token: write
       pages: none
       pull-requests: none
-    runs-on: aws-lambda-powertools_ubuntu-latest_8-core
+    runs-on: aws-powertools_ubuntu-latest_8-core
     defaults:
       run:
         working-directory: ./layer

--- a/.github/workflows/run-e2e-tests.yml
+++ b/.github/workflows/run-e2e-tests.yml
@@ -37,7 +37,7 @@ concurrency: e2e
 
 jobs:
   run:
-    runs-on: aws-lambda-powertools_ubuntu-latest_8-core
+    runs-on: aws-powertools_ubuntu-latest_8-core
     permissions:
       id-token: write # needed to request JWT with GitHub's OIDC Token endpoint. docs: https://bit.ly/3MNgQO9
       contents: read  # checkout code


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
**Issue number:** #2302

## Summary

### Changes

> Please provide a summary of what's being changed

As a part of the migration, we have to update the name of our runners.

We've moved to:
- aws-powertools_ubuntu-latest_4-core 
- aws-powertools_ubuntu-latest_8-core

### User experience

> Please share what the user experience looks like before and after this change

No visible change.

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [X] [Meet tenets criteria](https://docs.powertools.aws.dev/lambda-python/#tenets)
* [X] I have performed a self-review of this change
* [X] Changes have been tested
* [X] Changes are documented
* [X] PR title follows [conventional commit semantics](https://github.com/aws-powertools/powertools-lambda-python/blob/develop/.github/semantic.yml)

<details>
<summary>Is this a breaking change?</summary>

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
