### PR TITLE
docs(navigation): make Key Feature the first section

### DIFF
--- a/docs/utilities/batch.md
+++ b/docs/utilities/batch.md
@@ -5,7 +5,7 @@ description: Utility
 
 The batch processing utility handles partial failures when processing batches from Amazon SQS, Amazon Kinesis Data Streams, and Amazon DynamoDB Streams.
 
-## Key Features
+## Key features
 
 * Reports batch item failures to reduce number of retries for a record upon errors
 * Simple interface to process each batch record

--- a/docs/utilities/data_classes.md
+++ b/docs/utilities/data_classes.md
@@ -7,7 +7,7 @@ description: Utility
 
 Event Source Data Classes utility provides classes self-describing Lambda event sources.
 
-## Key Features
+## Key features
 
 * Type hinting and code completion for common event types
 * Helper functions for decoding/deserializing nested fields

--- a/docs/utilities/feature_flags.md
+++ b/docs/utilities/feature_flags.md
@@ -8,6 +8,14 @@ The feature flags utility provides a simple rule engine to define when one or mu
 ???+ info
     When using `AppConfigStore`, we currently only support AppConfig using [freeform configuration profile](https://docs.aws.amazon.com/appconfig/latest/userguide/appconfig-creating-configuration-and-profile.html#appconfig-creating-configuration-and-profile-free-form-configurations){target="_blank"}  .
 
+## Key features
+
+* Define simple feature flags to dynamically decide when to enable a feature
+* Fetch one or all feature flags enabled for a given application context
+* Support for static feature flags to simply turn on/off a feature without rules
+* Support for time based feature flags
+* Bring your own Feature Flags Store Provider
+
 ## Terminology
 
 Feature flags are used to modify behaviour without changing the application's code. These flags can be **static** or **dynamic**.
@@ -30,14 +38,6 @@ If you want to learn more about feature flags, their variations and trade-offs, 
 
 ???+ note
     AWS AppConfig requires two API calls to fetch configuration for the first time. You can improve latency by consolidating your feature settings in a single [Configuration](https://docs.aws.amazon.com/appconfig/latest/userguide/appconfig-creating-configuration-and-profile.html){target="_blank"}.
-
-## Key features
-
-* Define simple feature flags to dynamically decide when to enable a feature
-* Fetch one or all feature flags enabled for a given application context
-* Support for static feature flags to simply turn on/off a feature without rules
-* Support for time based feature flags
-* Bring your own Feature Flags Store Provider
 
 ## Getting started
 

--- a/docs/utilities/idempotency.md
+++ b/docs/utilities/idempotency.md
@@ -8,6 +8,14 @@ description: Utility
 The idempotency utility provides a simple solution to convert your Lambda functions into idempotent operations which
 are safe to retry.
 
+## Key features
+
+* Prevent Lambda handler from executing more than once on the same event payload during a time window
+* Ensure Lambda handler returns the same result when called with the same payload
+* Select a subset of the event as the idempotency key using JMESPath expressions
+* Set a time window in which records with the same payload should be considered duplicates
+* Expires in-progress executions if the Lambda function times out halfway through
+
 ## Terminology
 
 The property of idempotency means that an operation does not cause additional side effects if it is called more than
@@ -43,14 +51,6 @@ classDiagram
 
 <i>Idempotency record representation</i>
 </center>
-
-## Key features
-
-* Prevent Lambda handler from executing more than once on the same event payload during a time window
-* Ensure Lambda handler returns the same result when called with the same payload
-* Select a subset of the event as the idempotency key using JMESPath expressions
-* Set a time window in which records with the same payload should be considered duplicates
-* Expires in-progress executions if the Lambda function times out halfway through
 
 ## Getting started
 

--- a/docs/utilities/streaming.md
+++ b/docs/utilities/streaming.md
@@ -5,7 +5,7 @@ description: Utility
 
 The streaming utility handles datasets larger than the available memory as streaming data.
 
-## Key Features
+## Key features
 
 * Stream Amazon S3 objects with a file-like interface with minimal memory consumption
 * Built-in popular data transformations to decompress and deserialize (gzip, CSV, and ZIP)


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
**Issue number:** #2514 

## Summary

### Changes

Make `Key features` default first as a navigation anchor in all documents and fix a capitalization issue.

### User experience

> Please share what the user experience looks like before and after this change

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] [Meet tenets criteria](https://docs.powertools.aws.dev/lambda-python/#tenets)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented
* [x] PR title follows [conventional commit semantics](https://github.com/aws-powertools/powertools-lambda-python/blob/develop/.github/semantic.yml)

<details>
<summary>Is this a breaking change?</summary>

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
