### PR TITLE
chore(analytics): update docs base origin url

### DIFF
--- a/docs/javascript/extra.js
+++ b/docs/javascript/extra.js
@@ -10,7 +10,7 @@ const awsconfig = {
 };
 
 const RUNTIME = "python"
-const BASE_ORIGIN = "awslabs.github.io"
+const BASE_ORIGIN = "docs.powertools.aws.dev"
 
 function copyToClipboard(e) {
 	e.preventDefault()


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
**Issue number:** #2559 

## Summary

Update base origin variable in mkdocs javascript

### Changes

> Please provide a summary of what's being changed

Change `awslabs.github.io` to `docs.powertools.aws.dev`

### User experience

> Please share what the user experience looks like before and after this change

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] [Meet tenets criteria](https://docs.powertools.aws.dev/lambda/python/#tenets)
* [x] I have performed a self-review of this change
* [ ] Changes have been tested
* [ ] Changes are documented
* [x] PR title follows [conventional commit semantics](https://github.com/aws-powertools/powertools-lambda-python/blob/develop/.github/semantic.yml)

<details>
<summary>Is this a breaking change?</summary>

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
