### PR TITLE
feat(parser): add support to VpcLatticeModel

### DIFF
--- a/aws_lambda_powertools/utilities/parser/envelopes/__init__.py
+++ b/aws_lambda_powertools/utilities/parser/envelopes/__init__.py
@@ -10,7 +10,7 @@ from .kinesis_firehose import KinesisFirehoseEnvelope
 from .lambda_function_url import LambdaFunctionUrlEnvelope
 from .sns import SnsEnvelope, SnsSqsEnvelope
 from .sqs import SqsEnvelope
-from .vpc_lattice import VPCLatticeEnvelope
+from .vpc_lattice import VpcLatticeEnvelope
 
 __all__ = [
     "ApiGatewayEnvelope",
@@ -26,5 +26,5 @@ __all__ = [
     "SqsEnvelope",
     "KafkaEnvelope",
     "BaseEnvelope",
-    "VPCLatticeEnvelope",
+    "VpcLatticeEnvelope",
 ]

--- a/aws_lambda_powertools/utilities/parser/envelopes/__init__.py
+++ b/aws_lambda_powertools/utilities/parser/envelopes/__init__.py
@@ -10,6 +10,7 @@ from .kinesis_firehose import KinesisFirehoseEnvelope
 from .lambda_function_url import LambdaFunctionUrlEnvelope
 from .sns import SnsEnvelope, SnsSqsEnvelope
 from .sqs import SqsEnvelope
+from .vpc_lattice import VPCLatticeEnvelope
 
 __all__ = [
     "ApiGatewayEnvelope",
@@ -25,4 +26,5 @@ __all__ = [
     "SqsEnvelope",
     "KafkaEnvelope",
     "BaseEnvelope",
+    "VPCLatticeEnvelope",
 ]

--- a/aws_lambda_powertools/utilities/parser/envelopes/vpc_lattice.py
+++ b/aws_lambda_powertools/utilities/parser/envelopes/vpc_lattice.py
@@ -28,6 +28,5 @@ class VpcLatticeEnvelope(BaseEnvelope):
         """
         logger.debug(f"Parsing incoming data with VPC Lattice model {VpcLatticeModel}")
         parsed_envelope: VpcLatticeModel = VpcLatticeModel.parse_obj(data)
-        print(parsed_envelope.body)
         logger.debug(f"Parsing event payload in `detail` with {model}")
         return self._parse(data=parsed_envelope.body, model=model)

--- a/aws_lambda_powertools/utilities/parser/envelopes/vpc_lattice.py
+++ b/aws_lambda_powertools/utilities/parser/envelopes/vpc_lattice.py
@@ -23,7 +23,7 @@ class VpcLatticeEnvelope(BaseEnvelope):
 
         Returns
         -------
-        Any
+        Optional[Model]
             Parsed detail payload with model provided
         """
         logger.debug(f"Parsing incoming data with VPC Lattice model {VpcLatticeModel}")

--- a/aws_lambda_powertools/utilities/parser/envelopes/vpc_lattice.py
+++ b/aws_lambda_powertools/utilities/parser/envelopes/vpc_lattice.py
@@ -1,0 +1,33 @@
+import logging
+from typing import Any, Dict, Optional, Type, Union
+
+from ..models import VPCLatticeModel
+from ..types import Model
+from .base import BaseEnvelope
+
+logger = logging.getLogger(__name__)
+
+
+class VPCLatticeEnvelope(BaseEnvelope):
+    """VPC Lattice envelope to extract data within body key"""
+
+    def parse(self, data: Optional[Union[Dict[str, Any], Any]], model: Type[Model]) -> Optional[Model]:
+        """Parses data found with model provided
+
+        Parameters
+        ----------
+        data : Dict
+            Lambda event to be parsed
+        model : Type[Model]
+            Data model provided to parse after extracting data using envelope
+
+        Returns
+        -------
+        Any
+            Parsed detail payload with model provided
+        """
+        logger.debug(f"Parsing incoming data with VPC Lattice model {VPCLatticeModel}")
+        parsed_envelope: VPCLatticeModel = VPCLatticeModel.parse_obj(data)
+        print(parsed_envelope.body)
+        logger.debug(f"Parsing event payload in `detail` with {model}")
+        return self._parse(data=parsed_envelope.body, model=model)

--- a/aws_lambda_powertools/utilities/parser/envelopes/vpc_lattice.py
+++ b/aws_lambda_powertools/utilities/parser/envelopes/vpc_lattice.py
@@ -1,15 +1,15 @@
 import logging
 from typing import Any, Dict, Optional, Type, Union
 
-from ..models import VPCLatticeModel
+from ..models import VpcLatticeModel
 from ..types import Model
 from .base import BaseEnvelope
 
 logger = logging.getLogger(__name__)
 
 
-class VPCLatticeEnvelope(BaseEnvelope):
-    """VPC Lattice envelope to extract data within body key"""
+class VpcLatticeEnvelope(BaseEnvelope):
+    """Amazon VPC Lattice envelope to extract data within body key"""
 
     def parse(self, data: Optional[Union[Dict[str, Any], Any]], model: Type[Model]) -> Optional[Model]:
         """Parses data found with model provided
@@ -26,8 +26,8 @@ class VPCLatticeEnvelope(BaseEnvelope):
         Any
             Parsed detail payload with model provided
         """
-        logger.debug(f"Parsing incoming data with VPC Lattice model {VPCLatticeModel}")
-        parsed_envelope: VPCLatticeModel = VPCLatticeModel.parse_obj(data)
+        logger.debug(f"Parsing incoming data with VPC Lattice model {VpcLatticeModel}")
+        parsed_envelope: VpcLatticeModel = VpcLatticeModel.parse_obj(data)
         print(parsed_envelope.body)
         logger.debug(f"Parsing event payload in `detail` with {model}")
         return self._parse(data=parsed_envelope.body, model=model)

--- a/aws_lambda_powertools/utilities/parser/models/__init__.py
+++ b/aws_lambda_powertools/utilities/parser/models/__init__.py
@@ -84,7 +84,7 @@ from .ses import (
 )
 from .sns import SnsModel, SnsNotificationModel, SnsRecordModel
 from .sqs import SqsAttributesModel, SqsModel, SqsMsgAttributeModel, SqsRecordModel
-from .vpc_lattice import VPCLatticeModel
+from .vpc_lattice import VpcLatticeModel
 
 __all__ = [
     "APIGatewayProxyEventV2Model",
@@ -158,5 +158,5 @@ __all__ = [
     "CloudFormationCustomResourceDeleteModel",
     "CloudFormationCustomResourceCreateModel",
     "CloudFormationCustomResourceBaseModel",
-    "VPCLatticeModel",
+    "VpcLatticeModel",
 ]

--- a/aws_lambda_powertools/utilities/parser/models/__init__.py
+++ b/aws_lambda_powertools/utilities/parser/models/__init__.py
@@ -84,6 +84,7 @@ from .ses import (
 )
 from .sns import SnsModel, SnsNotificationModel, SnsRecordModel
 from .sqs import SqsAttributesModel, SqsModel, SqsMsgAttributeModel, SqsRecordModel
+from .vpc_lattice import VPCLatticeModel
 
 __all__ = [
     "APIGatewayProxyEventV2Model",
@@ -157,4 +158,5 @@ __all__ = [
     "CloudFormationCustomResourceDeleteModel",
     "CloudFormationCustomResourceCreateModel",
     "CloudFormationCustomResourceBaseModel",
+    "VPCLatticeModel",
 ]

--- a/aws_lambda_powertools/utilities/parser/models/vpc_lattice.py
+++ b/aws_lambda_powertools/utilities/parser/models/vpc_lattice.py
@@ -1,0 +1,12 @@
+from typing import Dict, Type, Union
+
+from pydantic import BaseModel
+
+
+class VPCLatticeModel(BaseModel):
+    method: str
+    raw_path: str
+    body: Union[str, Type[BaseModel]]
+    is_base64_encoded: bool
+    headers: Dict[str, str]
+    query_string_parameters: Dict[str, str]

--- a/aws_lambda_powertools/utilities/parser/models/vpc_lattice.py
+++ b/aws_lambda_powertools/utilities/parser/models/vpc_lattice.py
@@ -3,7 +3,7 @@ from typing import Dict, Type, Union
 from pydantic import BaseModel
 
 
-class VPCLatticeModel(BaseModel):
+class VpcLatticeModel(BaseModel):
     method: str
     raw_path: str
     body: Union[str, Type[BaseModel]]

--- a/docs/utilities/parser.md
+++ b/docs/utilities/parser.md
@@ -180,7 +180,7 @@ Parser comes with the following built-in models:
 | **SesModel**                                | Lambda Event Source payload for Amazon Simple Email Service                           |
 | **SnsModel**                                | Lambda Event Source payload for Amazon Simple Notification Service                    |
 | **SqsModel**                                | Lambda Event Source payload for Amazon SQS                                            |
-| **VPCLatticeModel**                         | Lambda Event Source payload for Amazon VPC Lattice                                    |
+| **VpcLatticeModel**                         | Lambda Event Source payload for Amazon VPC Lattice                                    |
 
 #### Extending built-in models
 
@@ -337,7 +337,7 @@ Parser comes with the following built-in envelopes, where `Model` in the return 
 | **ApiGatewayV2Envelope**      | 1. Parses data using `APIGatewayProxyEventV2Model`. <br/> 2. Parses `body` key using your model and returns it.                                                                                             | `Model`                            |
 | **LambdaFunctionUrlEnvelope** | 1. Parses data using `LambdaFunctionUrlModel`. <br/> 2. Parses `body` key using your model and returns it.                                                                                                  | `Model`                            |
 | **KafkaEnvelope**             | 1. Parses data using `KafkaRecordModel`. <br/> 2. Parses `value` key using your model and returns it.                                                                                                       | `Model`                            |
-| **VPCLatticeEnvelope**        | 1. Parses data using `VPCLatticeModel`. <br/> 2. Parses `value` key using your model and returns it.                                                                                                       | `Model`                            |
+| **VpcLatticeEnvelope**        | 1. Parses data using `VpcLatticeModel`. <br/> 2. Parses `value` key using your model and returns it.                                                                                                       | `Model`                            |
 
 #### Bringing your own envelope
 

--- a/docs/utilities/parser.md
+++ b/docs/utilities/parser.md
@@ -180,6 +180,7 @@ Parser comes with the following built-in models:
 | **SesModel**                                | Lambda Event Source payload for Amazon Simple Email Service                           |
 | **SnsModel**                                | Lambda Event Source payload for Amazon Simple Notification Service                    |
 | **SqsModel**                                | Lambda Event Source payload for Amazon SQS                                            |
+| **VPCLatticeModel**                         | Lambda Event Source payload for Amazon VPC Lattice                                    |
 
 #### Extending built-in models
 
@@ -336,6 +337,7 @@ Parser comes with the following built-in envelopes, where `Model` in the return 
 | **ApiGatewayV2Envelope**      | 1. Parses data using `APIGatewayProxyEventV2Model`. <br/> 2. Parses `body` key using your model and returns it.                                                                                             | `Model`                            |
 | **LambdaFunctionUrlEnvelope** | 1. Parses data using `LambdaFunctionUrlModel`. <br/> 2. Parses `body` key using your model and returns it.                                                                                                  | `Model`                            |
 | **KafkaEnvelope**             | 1. Parses data using `KafkaRecordModel`. <br/> 2. Parses `value` key using your model and returns it.                                                                                                       | `Model`                            |
+| **VPCLatticeEnvelope**        | 1. Parses data using `VPCLatticeModel`. <br/> 2. Parses `value` key using your model and returns it.                                                                                                       | `Model`                            |
 
 #### Bringing your own envelope
 

--- a/tests/functional/parser/schemas.py
+++ b/tests/functional/parser/schemas.py
@@ -99,3 +99,8 @@ class MyLambdaKafkaBusiness(BaseModel):
 
 class MyKinesisFirehoseBusiness(BaseModel):
     Hello: str
+
+
+class myVPCLatticeBusiness(BaseModel):
+    username: str
+    name: str

--- a/tests/functional/parser/schemas.py
+++ b/tests/functional/parser/schemas.py
@@ -101,6 +101,6 @@ class MyKinesisFirehoseBusiness(BaseModel):
     Hello: str
 
 
-class myVPCLatticeBusiness(BaseModel):
+class MyVpcLatticeBusiness(BaseModel):
     username: str
     name: str

--- a/tests/unit/parser/test_vpc_lattice.py
+++ b/tests/unit/parser/test_vpc_lattice.py
@@ -1,0 +1,53 @@
+import pytest
+
+from aws_lambda_powertools.utilities.parser import (
+    ValidationError,
+    envelopes,
+    event_parser,
+)
+from aws_lambda_powertools.utilities.parser.models import VPCLatticeModel
+from aws_lambda_powertools.utilities.typing import LambdaContext
+from tests.functional.parser.schemas import myVPCLatticeBusiness
+from tests.functional.utils import load_event
+
+
+@event_parser(model=myVPCLatticeBusiness, envelope=envelopes.VPCLatticeEnvelope)
+def handle_lambda_vpclattice_with_envelope(event: myVPCLatticeBusiness, context: LambdaContext):
+    assert event.username == "Leandro"
+    assert event.name == "Damascena"
+
+
+def test_vpclattice_event_with_envelope():
+    event = load_event("vpcLatticeEvent.json")
+    event["body"] = '{"username": "Leandro", "name": "Damascena"}'
+    handle_lambda_vpclattice_with_envelope(event, LambdaContext())
+
+
+def test_vpclattice_event():
+    raw_event = load_event("vpcLatticeEvent.json")
+    model = VPCLatticeModel(**raw_event)
+
+    assert model.body == raw_event["body"]
+    assert model.method == raw_event["method"]
+    assert model.raw_path == raw_event["raw_path"]
+    assert model.is_base64_encoded == raw_event["is_base64_encoded"]
+    assert model.headers == raw_event["headers"]
+    assert model.query_string_parameters == raw_event["query_string_parameters"]
+
+
+def test_vpclattice_event_custom_model():
+    class MyCustomResource(VPCLatticeModel):
+        body: str
+
+    raw_event = load_event("vpcLatticeEvent.json")
+    model = MyCustomResource(**raw_event)
+
+    assert model.body == raw_event["body"]
+
+
+def test_vpclattice_event_invalid():
+    raw_event = load_event("vpcLatticeEvent.json")
+    raw_event["body"] = ["some_data"]
+
+    with pytest.raises(ValidationError):
+        VPCLatticeModel(**raw_event)

--- a/tests/unit/parser/test_vpc_lattice.py
+++ b/tests/unit/parser/test_vpc_lattice.py
@@ -5,27 +5,27 @@ from aws_lambda_powertools.utilities.parser import (
     envelopes,
     event_parser,
 )
-from aws_lambda_powertools.utilities.parser.models import VPCLatticeModel
+from aws_lambda_powertools.utilities.parser.models import VpcLatticeModel
 from aws_lambda_powertools.utilities.typing import LambdaContext
-from tests.functional.parser.schemas import myVPCLatticeBusiness
+from tests.functional.parser.schemas import MyVpcLatticeBusiness
 from tests.functional.utils import load_event
 
 
-@event_parser(model=myVPCLatticeBusiness, envelope=envelopes.VPCLatticeEnvelope)
-def handle_lambda_vpclattice_with_envelope(event: myVPCLatticeBusiness, context: LambdaContext):
+@event_parser(model=MyVpcLatticeBusiness, envelope=envelopes.VpcLatticeEnvelope)
+def handle_lambda_vpclattice_with_envelope(event: MyVpcLatticeBusiness, context: LambdaContext):
     assert event.username == "Leandro"
     assert event.name == "Damascena"
 
 
-def test_vpclattice_event_with_envelope():
+def test_vpc_lattice_event_with_envelope():
     event = load_event("vpcLatticeEvent.json")
     event["body"] = '{"username": "Leandro", "name": "Damascena"}'
     handle_lambda_vpclattice_with_envelope(event, LambdaContext())
 
 
-def test_vpclattice_event():
+def test_vpc_lattice_event():
     raw_event = load_event("vpcLatticeEvent.json")
-    model = VPCLatticeModel(**raw_event)
+    model = VpcLatticeModel(**raw_event)
 
     assert model.body == raw_event["body"]
     assert model.method == raw_event["method"]
@@ -35,8 +35,8 @@ def test_vpclattice_event():
     assert model.query_string_parameters == raw_event["query_string_parameters"]
 
 
-def test_vpclattice_event_custom_model():
-    class MyCustomResource(VPCLatticeModel):
+def test_vpc_lattice_event_custom_model():
+    class MyCustomResource(VpcLatticeModel):
         body: str
 
     raw_event = load_event("vpcLatticeEvent.json")
@@ -45,9 +45,9 @@ def test_vpclattice_event_custom_model():
     assert model.body == raw_event["body"]
 
 
-def test_vpclattice_event_invalid():
+def test_vpc_lattice_event_invalid():
     raw_event = load_event("vpcLatticeEvent.json")
     raw_event["body"] = ["some_data"]
 
     with pytest.raises(ValidationError):
-        VPCLatticeModel(**raw_event)
+        VpcLatticeModel(**raw_event)


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
**Issue number:** #2579 

## Summary

### Changes

**Use case:**
Customers can integrate VPC Lattice with Lambda and might need to parser events using Pydantic. 

**Changes:**
This pull request introduces support to the VPCLatticeModel and envelope. 

### User experience

```python
import pytest

from aws_lambda_powertools.utilities.parser import (
    event_parser,
)
from aws_lambda_powertools.utilities.parser.models import VPCLatticeModel
from aws_lambda_powertools.utilities.typing import LambdaContext
from aws_lambda_powertools import Logger

logger = Logger()

@event_parser(model=VPCLatticeModel)
def handle_lambda_vpclattice_with_envelope(event: VPCLatticeModel, context: LambdaContext):
    logger.info(event.raw_path)
```


## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] [Meet tenets criteria](https://docs.powertools.aws.dev/lambda/python/#tenets)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented
* [x] PR title follows [conventional commit semantics](https://github.com/aws-powertools/powertools-lambda-python/blob/develop/.github/semantic.yml)

<details>
<summary>Is this a breaking change?</summary>

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
