### PR TITLE
chore(ci): enable Ruff rules ISC, I001, B018 and fix the errors

### DIFF
--- a/aws_lambda_powertools/utilities/batch/types.py
+++ b/aws_lambda_powertools/utilities/batch/types.py
@@ -11,11 +11,10 @@ has_pydantic = "pydantic" in sys.modules
 # For IntelliSense and Mypy to work, we need to account for possible SQS subclasses
 # We need them as subclasses as we must access their message ID or sequence number metadata via dot notation
 if has_pydantic:
-    from aws_lambda_powertools.utilities.parser.models import DynamoDBStreamRecordModel
+    from aws_lambda_powertools.utilities.parser.models import DynamoDBStreamRecordModel, SqsRecordModel
     from aws_lambda_powertools.utilities.parser.models import (
         KinesisDataStreamRecord as KinesisDataStreamRecordModel,
     )
-    from aws_lambda_powertools.utilities.parser.models import SqsRecordModel
 
     BatchTypeModels = Optional[
         Union[Type[SqsRecordModel], Type[DynamoDBStreamRecordModel], Type[KinesisDataStreamRecordModel]]

--- a/aws_lambda_powertools/utilities/idempotency/persistence/dynamodb.py
+++ b/aws_lambda_powertools/utilities/idempotency/persistence/dynamodb.py
@@ -247,7 +247,7 @@ class DynamoDBPersistenceLayer(BasePersistenceLayer):
 
     def _update_record(self, data_record: DataRecord):
         logger.debug(f"Updating record for idempotency key: {data_record.idempotency_key}")
-        update_expression = "SET #response_data = :response_data, #expiry = :expiry, " "#status = :status"
+        update_expression = "SET #response_data = :response_data, #expiry = :expiry, #status = :status"
         expression_attr_values: Dict[str, "AttributeValueTypeDef"] = {
             ":expiry": {"N": str(data_record.expiry_timestamp)},
             ":response_data": {"S": data_record.response_data},

--- a/aws_lambda_powertools/utilities/parser/models/sns.py
+++ b/aws_lambda_powertools/utilities/parser/models/sns.py
@@ -1,7 +1,6 @@
 from datetime import datetime
-from typing import Dict, List, Optional
+from typing import Dict, List, Optional, Union
 from typing import Type as TypingType
-from typing import Union
 
 from pydantic import BaseModel, root_validator
 from pydantic.networks import HttpUrl

--- a/examples/parameters/tests/test_clear_cache_global.py
+++ b/examples/parameters/tests/test_clear_cache_global.py
@@ -1,5 +1,4 @@
 import pytest
-
 from src import app
 
 from aws_lambda_powertools.utilities import parameters

--- a/examples/parameters/tests/test_clear_cache_method.py
+++ b/examples/parameters/tests/test_clear_cache_method.py
@@ -1,5 +1,4 @@
 import pytest
-
 from src import app
 
 

--- a/examples/parameters/tests/test_with_fixture.py
+++ b/examples/parameters/tests/test_with_fixture.py
@@ -1,5 +1,4 @@
 import pytest
-
 from src import single_mock
 
 

--- a/ruff.toml
+++ b/ruff.toml
@@ -34,10 +34,7 @@ ignore = [
     "PLR2004", #https://beta.ruff.rs/docs/rules/magic-value-comparison/
     "PLW0603", #https://beta.ruff.rs/docs/rules/global-statement/
     "B904", # raise-without-from-inside-except - disabled temporarily
-    "B018", # useless-expression - disabled temporarily
     "PLC1901", # Compare-to-empty-string - disabled temporarily
-    "ISC", # flake8-implicit-str-concat - disabled temporarily
-    "I001", # isort - disabled temporarily
     ]
 
 # Exclude files and directories

--- a/tests/functional/idempotency/conftest.py
+++ b/tests/functional/idempotency/conftest.py
@@ -91,7 +91,7 @@ def expected_params_update_item(serialized_lambda_response, hashed_idempotency_k
         },
         "Key": {"id": {"S": hashed_idempotency_key}},
         "TableName": "TEST_TABLE",
-        "UpdateExpression": "SET #response_data = :response_data, " "#expiry = :expiry, #status = :status",
+        "UpdateExpression": "SET #response_data = :response_data, #expiry = :expiry, #status = :status",
     }
 
 

--- a/tests/functional/idempotency/utils.py
+++ b/tests/functional/idempotency/utils.py
@@ -72,5 +72,5 @@ def build_idempotency_update_item_stub(
         },
         "Key": {"id": {"S": idempotency_key_hash}},
         "TableName": "TEST_TABLE",
-        "UpdateExpression": "SET #response_data = :response_data, " "#expiry = :expiry, #status = :status",
+        "UpdateExpression": "SET #response_data = :response_data, #expiry = :expiry, #status = :status",
     }

--- a/tests/unit/data_classes/test_code_pipeline_job_event.py
+++ b/tests/unit/data_classes/test_code_pipeline_job_event.py
@@ -105,7 +105,7 @@ def test_code_pipeline_event_non_json_user_parameters():
     assert configuration.user_parameters is not None
 
     with pytest.raises(json.decoder.JSONDecodeError):
-        configuration.decoded_user_parameters
+        assert configuration.decoded_user_parameters is not None
 
 
 def test_code_pipeline_event_decoded_data():

--- a/tests/unit/test_data_classes.py
+++ b/tests/unit/test_data_classes.py
@@ -180,7 +180,7 @@ def test_dict_wrapper_str_property_list_exception():
     event_source = DataClassSample({})
     event_str = (
         "{'data_property': ['string', 0, 0.0, {'broken_data_property': "
-        + "'[Cannot be deserialized]', 'raw_event': '[SENSITIVE]'}], 'raw_event': '[SENSITIVE]'}"
+        "'[Cannot be deserialized]', 'raw_event': '[SENSITIVE]'}], 'raw_event': '[SENSITIVE]'}"
     )
     assert str(event_source) == event_str
 
@@ -213,9 +213,8 @@ def test_dict_wrapper_str_recursive_property():
 
     event_source = DataClassRecursive({})
     assert (
-        str(event_source)
-        == "{'data_property': {'raw_event': '[SENSITIVE]', 'terminal_property': 'end-recursion'},"
-        + " 'raw_event': '[SENSITIVE]'}"
+        str(event_source) == "{'data_property': {'raw_event': '[SENSITIVE]', 'terminal_property': 'end-recursion'},"
+        " 'raw_event': '[SENSITIVE]'}"
     )
 
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
**Issue number:** #2534 

## Summary

### Changes

Enabling Ruff rules
- https://beta.ruff.rs/docs/rules/#flake8-implicit-str-concat-isc
- https://beta.ruff.rs/docs/rules/unsorted-imports/
- https://beta.ruff.rs/docs/rules/useless-expression/


### User experience

> Please share what the user experience looks like before and after this change

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] [Meet tenets criteria](https://docs.powertools.aws.dev/lambda/python/#tenets)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [ ] Changes are documented
* [x] PR title follows [conventional commit semantics](https://github.com/aws-powertools/powertools-lambda-python/blob/develop/.github/semantic.yml)

<details>
<summary>Is this a breaking change?</summary>

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
