### PR TITLE
chore(user-agent): support patching botocore session

### DIFF
--- a/aws_lambda_powertools/shared/user_agent.py
+++ b/aws_lambda_powertools/shared/user_agent.py
@@ -111,8 +111,10 @@ def register_feature_to_session(session, feature):
 # Add feature user-agent to given sdk botocore.session.Session
 def register_feature_to_botocore_session(botocore_session, feature):
     """
-    Register the given feature string to the event system of the provided boto3 session
-    and append the feature to the User-Agent header of the request
+    Register the given feature string to the event system of the provided botocore session
+    
+    Please Notice this is for patching botocore session and is different from the previous one 
+    which is for patching boto3 session
 
     Parameters
     ----------
@@ -125,7 +127,19 @@ def register_feature_to_botocore_session(botocore_session, feature):
     ------
     AttributeError
         If the provided session does not have an event system.
+        
+    Examples
+    --------
+    **register data-masking user-agent to botocore session**
 
+        >>> from aws_lambda_powertools.shared.user_agent import (
+        >>>    register_feature_to_botocore_session
+        >>> )
+        >>>
+        >>> session = botocore.session.Session()
+        >>> register_feature_to_botocore_session(botocore_session=session, feature="data-masking")
+        >>> key_provider = StrictAwsKmsMasterKeyProvider(key_ids=self.keys, botocore_session=self.session)
+    
     """
     try:
         botocore_session.register(TARGET_SDK_EVENT, _create_feature_function(feature))

--- a/aws_lambda_powertools/shared/user_agent.py
+++ b/aws_lambda_powertools/shared/user_agent.py
@@ -113,8 +113,8 @@ def register_feature_to_botocore_session(botocore_session, feature):
     """
     Register the given feature string to the event system of the provided botocore session
     
-    Please Notice this is for patching botocore session and is different from the previous one 
-    which is for patching boto3 session
+    Please notice this function is for patching botocore session and is different from
+    previous one which is for patching boto3 session
 
     Parameters
     ----------
@@ -138,7 +138,7 @@ def register_feature_to_botocore_session(botocore_session, feature):
         >>>
         >>> session = botocore.session.Session()
         >>> register_feature_to_botocore_session(botocore_session=session, feature="data-masking")
-        >>> key_provider = StrictAwsKmsMasterKeyProvider(key_ids=self.keys, botocore_session=self.session)
+        >>> key_provider = StrictAwsKmsMasterKeyProvider(key_ids=self.keys, botocore_session=session)
     
     """
     try:

--- a/aws_lambda_powertools/shared/user_agent.py
+++ b/aws_lambda_powertools/shared/user_agent.py
@@ -108,6 +108,31 @@ def register_feature_to_session(session, feature):
         logger.debug(f"session passed in doesn't have a event system:{e}")
 
 
+# Add feature user-agent to given sdk botocore.session.Session
+def register_feature_to_botocore_session(botocore_session, feature):
+    """
+    Register the given feature string to the event system of the provided boto3 session
+    and append the feature to the User-Agent header of the request
+
+    Parameters
+    ----------
+    botocore_session : botocore.session.Session
+        The botocore session to which the feature will be registered.
+    feature : str
+        The feature string to be appended to the User-Agent header, e.g., "data-masking" in Powertools.
+
+    Raises
+    ------
+    AttributeError
+        If the provided session does not have an event system.
+
+    """
+    try:
+        botocore_session.register(TARGET_SDK_EVENT, _create_feature_function(feature))
+    except AttributeError as e:
+        logger.debug(f"botocore session passed in doesn't have a event system:{e}")
+
+
 # Add feature user-agent to given sdk boto3.client
 def register_feature_to_client(client, feature):
     """


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
**Issue number:**
https://github.com/aws-powertools/powertools-lambda-python/issues/2626
Support patching botocore for [data-masking](https://github.com/aws-powertools/powertools-lambda-python/pull/2197)
- Where do we use this function?
  - For supporting Seshu's data-masking pr. Which uses AWS KMS as one of it's provider [here](https://github.com/aws-powertools/powertools-lambda-python/pull/2197/files#diff-d258c64782d47c37745e1f7cbba3914710a0ec9832ae1a3e9b3e377b5c896d55R40).
- IIRC we already had one function to add user-agent to the session.
  - The special thing about kms is it uses a botocore session instead of boto3 session to [init it's client](https://github.com/aws/aws-encryption-sdk-python/blob/560e7143ac7caf98e190b17ce2af97b7eea6be16/src/aws_encryption_sdk/key_providers/kms.py#L671C60-L671C60). So we need a new function to patch the new botocore session.

## Summary

### Changes

> Please provide a summary of what's being changed

Add `register_feature_to_botocore_session` to `shared.user_agent`

### User experience

> Please share what the user experience looks like before and after this change

No UX impact

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] [Meet tenets criteria](https://docs.powertools.aws.dev/lambda/python/#tenets)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented
* [x] PR title follows [conventional commit semantics](https://github.com/aws-powertools/powertools-lambda-python/blob/develop/.github/semantic.yml)

<details>
<summary>Is this a breaking change?</summary>

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
