### PR TITLE
fix(docs): ensure version alias is in an array to prevent "you're not viewing the latest version" incorrect message

### DIFF
--- a/.github/workflows/reusable_publish_docs.yml
+++ b/.github/workflows/reusable_publish_docs.yml
@@ -120,7 +120,7 @@ jobs:
             s3://${{ secrets.AWS_DOCS_BUCKET }}/lambda-python/versions.json \
             versions_old.json
           jq 'del(.[].aliases[] | select(. == "${{ env.ALIAS }}"))' < versions_old.json > versions_proc.json
-          jq '. as $o | [{"title": "${{ env.VERSION }}", "version": "${{ env.VERSION }}", "aliases": "${{env.ALIAS}}" }] as $n | $n | if .[0].title | test("[a-z]+") or any($o[].title == "${{ env.VERSION }}";.) then $o else $n + $o end' < versions_proc.json > versions.json
+          jq '. as $o | [{"title": "${{ env.VERSION }}", "version": "${{ env.VERSION }}", "aliases": ["${{env.ALIAS}}"] }] as $n | $n | if .[0].title | test("[a-z]+") or any($o[].title == "${{ env.VERSION }}";.) then $o else $n + $o end' < versions_proc.json > versions.json
           aws s3 cp \
             versions.json \
             s3://${{ secrets.AWS_DOCS_BUCKET }}/lambda-python/versions.json


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
**Issue number:** #2628

## Summary

### Changes

> Please provide a summary of what's being changed

The docs currently show an error to users despite them being on the latest version.
<img width="672" alt="Screenshot 2023-07-03 at 14 10 54" src="https://github.com/aws-powertools/powertools-lambda-python/assets/103217/f9a4b2e4-a677-4cac-815d-9d2ff2b2daa2">

Ensures the alias is wrapped as an array in `versions.json` for the docs which will ensure the error doesn't show when people are on the latest version of the docs

### User experience

> Please share what the user experience looks like before and after this change

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [X] [Meet tenets criteria](https://docs.powertools.aws.dev/lambda/python/#tenets)
* [X] I have performed a self-review of this change
* [X] Changes have been tested
* [X] Changes are documented
* [X] PR title follows [conventional commit semantics](https://github.com/aws-powertools/powertools-lambda-python/blob/develop/.github/semantic.yml)

<details>
<summary>Is this a breaking change?</summary>

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
