### PR TITLE
chore(ci): prevent merging PRs that do not meet minimum requirements

### DIFF
--- a/.github/workflows/on_pr_updates.yml
+++ b/.github/workflows/on_pr_updates.yml
@@ -1,0 +1,36 @@
+# Fail PR check if do-not-merge label is present
+name: PR requirements
+
+# PROCESS
+#
+# 1. Verify whether 'do-not-merge' label is present
+# 2. Fail PR to prevent merging until resolved
+# 3. Pass PR if do-not-merge label is removed by a maintainer
+
+# USAGE
+#
+# Always triggered on PR labeling changes.
+
+# NOTES
+#
+# PR requirements are checked async in on_opened_pr.yml and enforced here synchronously
+# due to limitations in GH API.
+
+on:
+ pull_request:
+    types:
+      - opened
+      - labeled
+      - unlabeled
+
+permissions: {}  # no permission required
+
+jobs:
+  fail-for-draft:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Block if it doesn't minimum requirements
+        if: contains(github.event.pull_request.labels.*.name, 'do-not-merge')
+        run: |
+          echo "This PR does not meet minimum requirements (check PR comments)."
+          exit 1


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
**Issue number:** #2203

## Summary

PRs labeled with `do-not-merge` should fail status checks to prevent merging them until approved by maintainers. This ensures our minimum requirements like issues and legal acknowledgement are adhered.

### Changes

> Please provide a summary of what's being changed

### User experience

> Please share what the user experience looks like before and after this change

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] [Meet tenets criteria](https://docs.powertools.aws.dev/lambda/python/#tenets)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented
* [x] PR title follows [conventional commit semantics](https://github.com/aws-powertools/powertools-lambda-python/blob/develop/.github/semantic.yml)

<details>
<summary>Is this a breaking change?</summary>

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
