### PR TITLE
chore(ci): propagate checkout permission to nested workflows

### DIFF
--- a/.github/workflows/label_pr_on_title.yml
+++ b/.github/workflows/label_pr_on_title.yml
@@ -33,6 +33,7 @@ jobs:
   get_pr_details:
     permissions:
       actions: read  # download PR artifact
+      contents: read # checkout code
     # Guardrails to only ever run if PR recording workflow was indeed
     # run in a PR event and ran successfully
     if: ${{ github.event.workflow_run.conclusion == 'success' }}

--- a/.github/workflows/on_label_added.yml
+++ b/.github/workflows/on_label_added.yml
@@ -32,6 +32,7 @@ jobs:
   get_pr_details:
     permissions:
       actions: read  # download PR artifact
+      contents: read # checkout code
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
     uses: ./.github/workflows/reusable_export_pr_details.yml
     with:

--- a/.github/workflows/on_merged_pr.yml
+++ b/.github/workflows/on_merged_pr.yml
@@ -33,6 +33,7 @@ jobs:
   get_pr_details:
     permissions:
       actions: read  # download PR artifact
+      contents: read # checkout code
     if: github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.conclusion == 'success'
     uses: ./.github/workflows/reusable_export_pr_details.yml
     with:

--- a/.github/workflows/on_opened_pr.yml
+++ b/.github/workflows/on_opened_pr.yml
@@ -33,6 +33,7 @@ jobs:
   get_pr_details:
     permissions:
       actions: read  # download PR artifact
+      contents: read # checkout code
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
     uses: ./.github/workflows/reusable_export_pr_details.yml
     with:

--- a/.github/workflows/on_pr_updates.yml
+++ b/.github/workflows/on_pr_updates.yml
@@ -17,7 +17,7 @@ name: PR requirements
 # due to limitations in GH API.
 
 on:
- pull_request:
+  pull_request:
     types:
       - opened
       - labeled
@@ -26,7 +26,7 @@ on:
 permissions: {}  # no permission required
 
 jobs:
-  fail-for-draft:
+  check-requirements:
     runs-on: ubuntu-latest
     steps:
       - name: Block if it doesn't minimum requirements


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
**Issue number:** #2203 

## Summary

After setting top-level permissions, `reusable_export_pr_details.yml` nested workflow didn't receive the correct permission from its parents, thus failing fast at the privilege escalation check.

### Changes

> Please provide a summary of what's being changed

### User experience

> Please share what the user experience looks like before and after this change

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] [Meet tenets criteria](https://docs.powertools.aws.dev/lambda/python/#tenets)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented
* [x] PR title follows [conventional commit semantics](https://github.com/aws-powertools/powertools-lambda-python/blob/develop/.github/semantic.yml)

<details>
<summary>Is this a breaking change?</summary>

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
