### PR TITLE
docs(maintainers): add cicd pipeline diagram

### DIFF
--- a/.github/workflows/dispatch_analytics.yml
+++ b/.github/workflows/dispatch_analytics.yml
@@ -17,19 +17,8 @@ on:
     - cron: "0 * * * *"
 
 permissions:
-  id-token: write
-  actions: read
-  checks: read
-  contents: write
-  deployments: read
-  issues: read
-  discussions: read
-  packages: read
-  pages: read
-  pull-requests: read
-  repository-projects: read
-  security-events: read
-  statuses: read
+  contents: read
+
 
 jobs:
   dispatch_token:
@@ -38,6 +27,20 @@ jobs:
       group: analytics
     runs-on: ubuntu-latest
     environment: analytics
+    permissions:
+      id-token: write
+      actions: read
+      checks: read
+      contents: read    # previously we needed `write` to use GH_TOKEN in our dispatcher (Lambda)
+      deployments: read
+      issues: read
+      discussions: read
+      packages: read
+      pages: read
+      pull-requests: read
+      repository-projects: read
+      security-events: read
+      statuses: read
     steps:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@5fd3084fc36e372ff1fff382a39b10d03659f355 # v2.2.0

--- a/.github/workflows/ossf_scorecard.yml
+++ b/.github/workflows/ossf_scorecard.yml
@@ -6,7 +6,8 @@ on:
   schedule:
     - cron: "0 9 * * *"
   push:
-    branches: [$default-branch]
+    branches: [develop]
+  workflow_dispatch:
 
 permissions: read-all
 

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -198,7 +198,7 @@ Once complete, you can start drafting the release notes to let customers know **
 
 Every release makes hundreds of checks, security scans, canaries and deployments - all of these are automated.
 
-This is a close visual representation of the main steps (GitHub Actions UI should be the source of truth).
+This is a close visual representation of the main steps (GitHub Actions UI should be the source of truth), along with the approximate time it takes for each key step to complete.
 
 <!-- use 8s to graph steps faster than 8s like seal/checksum that actually takes 0s -->
 
@@ -256,6 +256,106 @@ section Post-release
     Close pending issues        : active, 8s
 
 Release complete : milestone, m6, 10:31,2m
+```
+
+If we combine our CI and CD pipelines into a single diagram, it looks like this:
+
+```mermaid
+timeline
+    title Powertools for AWS Lambda (Python) CI/CD pipeline
+
+    section Continuous Integration
+    Project setup <br> (make dev)   : Code checkout
+                                    : Virtual environment
+                                    : Dependencies
+                                    : Git pre-commit hooks
+                                    : Local branch
+                                    : Local changes
+                                    : Local tests
+
+    Pre-commit checks <br> (git commit)     : Merge conflict check
+                                            : Trailing whitespaces
+                                            : TOML checks
+                                            : Code linting (standards)
+                                            : Markdown linting
+                                            : CloudFormation linting
+                                            : GitHub Actions linting
+                                            : Terraform linting
+                                            : Secrets linting
+
+    Pre-Pull Request <br> (make pr)     : Code linting
+                                        : Docs linting
+                                        : Static typing analysis
+                                        : Tests (unit|functional|perf)
+                                        : Security baseline
+                                        : Complexity baseline
+                                        : +pre-commit checks
+
+    Pull Request <br> (CI checks)   : Semantic PR title check
+                                    : Related issue check
+                                    : Acknowledgment check
+                                    : Code coverage diff
+                                    : Contribution size check
+                                    : Contribution category check
+                                    : Dependency vulnerability check
+                                    : GitHub Actions security check
+                                    : +pre-pull request checks
+
+    After merge <br> (CI checks)    : End-to-end tests
+                                    : Longer SAST check
+                                    : Security posture check (scorecard)
+                                    : GitHub Actions security check
+                                    : Rebuild Changelog
+                                    : Deploy staging docs
+                                    : Update draft release
+
+    section Continuous Delivery
+
+    Source code anti-tampering  : Checkout release commit code
+                                : Bump release version
+                                : Seal and upload artifact
+
+    Quality Assurance           : Restore sealed code
+                                : +Continuous Integration checks
+
+    Build                       : Restore sealed code
+                                : Integrity check
+                                : Build release artifact
+                                : Seal and upload artifact
+
+    Release                     : Restore sealed build
+                                : Integrity check
+                                : PyPi ephemeral credentials
+                                : Publish PyPi
+                                : Baking time
+
+    Git tagging                 : Restore sealed code
+                                : Integrity check
+                                : Bump git tag
+                                : Create temporary branch
+                                : Create PR
+
+    Lambda Layers               : Fetch PyPi release
+                                : Build x86 architecture
+                                : Build ARM architecture
+                                : Deploy Beta
+                                : Canary testing
+                                : Deploy Prod
+
+    Lambda Layers SAR           : Deploy Beta
+                                : Deploy Prod
+
+    Documentation               : Update Lambda Layer ARNs
+                                : Build User Guide
+                                : Build API Guide
+                                : Rebuild Changelog
+                                : Release new version
+                                : Update latest alias
+                                : Create temporary branch
+                                : Create PR
+
+    Post-release                : Close pending-release issues
+                                : Notify customers
 ```
 
 #### Drafting release notes


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
**Issue number:** #2203

## Summary

Add diagram combining our CI and CD pipelines into one image.

Addresses another OSSF recommendation

<img width="1439" alt="image" src="https://github.com/aws-powertools/powertools-lambda-python/assets/3340292/38119f4f-7f29-461d-b8b4-d84880d86234">

### Changes

> Please provide a summary of what's being changed

Unrelated changes:

* [x] enable OSSF Scorecard manual trigger so we don't wait until the next day for feedback
* [x] lower analytics permission with after using fine-grained PAT

### User experience

> Please share what the user experience looks like before and after this change

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [ ] [Meet tenets criteria](https://docs.powertools.aws.dev/lambda/python/#tenets)
* [ ] I have performed a self-review of this change
* [ ] Changes have been tested
* [ ] Changes are documented
* [ ] PR title follows [conventional commit semantics](https://github.com/aws-powertools/powertools-lambda-python/blob/develop/.github/semantic.yml)

<details>
<summary>Is this a breaking change?</summary>

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
