### PR TITLE
chore(ci): address ossf scorecard findings on npm, pip, and top-level permission leftover

### DIFF
--- a/.github/workflows/publish_v2_layer.yml
+++ b/.github/workflows/publish_v2_layer.yml
@@ -85,7 +85,7 @@ jobs:
         # therefore it ignores both activated virtual env and cached interpreter by GH
         run: |
           poetry export --format requirements.txt --output requirements.txt
-          pip install -r requirements.txt
+          pip install --require-hashes -r requirements.txt
       - name: Set up QEMU
         uses: docker/setup-qemu-action@2b82ce82d56a2a04d2637cd93a637ae1b359c0a7 # v2.0.0
         with:
@@ -101,7 +101,7 @@ jobs:
       - name: install cdk and deps
         working-directory: ./
         run: |
-          npm install
+          npm ci
           npx cdk --version
       - name: CDK build
         run: npx cdk synth --verbose --context version="${{ inputs.latest_published_version }}" -o cdk.out

--- a/.github/workflows/reusable_deploy_v2_layer_stack.yml
+++ b/.github/workflows/reusable_deploy_v2_layer_stack.yml
@@ -147,11 +147,11 @@ jobs:
         # therefore it ignores both activated virtual env and cached interpreter by GH
         run: |
           poetry export --format requirements.txt --output requirements.txt
-          pip install -r requirements.txt
+          pip install --require-hashes -r requirements.txt
       - name: install cdk and deps
         working-directory: ./
         run: |
-          npm install
+          npm ci
           npx cdk --version
       - name: install deps
         run: poetry install

--- a/.github/workflows/reusable_publish_docs.yml
+++ b/.github/workflows/reusable_publish_docs.yml
@@ -28,9 +28,7 @@ on:
         default: develop
 
 permissions:
-  id-token: write  # trade JWT token for AWS credentials in AWS Docs account
-  contents: write  # push to gh-pages
-  pages: write     # deploy gh-pages website
+  contents: read
 
 jobs:
   publish_docs:
@@ -40,6 +38,10 @@ jobs:
       group: on-docs-rebuild
     runs-on: ubuntu-latest
     environment: "Docs"
+    permissions:
+      contents: write  # push to gh-pages
+      id-token: write  # trade JWT token for AWS credentials in AWS Docs account
+      pages: write     # uncomment if mike fails as we migrated to S3 hosting
     steps:
       - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9  # v3.5.3
         with:
@@ -110,7 +112,7 @@ jobs:
         #   1. Download the versions.json file from S3
         #   2. Find any reference to the alias and delete it from the versions file
         #   3. This is voodoo (don't use JQ):
-        #      - we assign the input as $o and the new version/alias as $n, 
+        #      - we assign the input as $o and the new version/alias as $n,
         #      - we check if the version number exists in the file already (for republishing docs)
         #      - if it's an alias (stage/latest/*) or old version, we do nothing and output $o (original input)
         #      - if it's a new version number, we add it at position 0 in the array.

--- a/.github/workflows/run-e2e-tests.yml
+++ b/.github/workflows/run-e2e-tests.yml
@@ -66,7 +66,7 @@ jobs:
           node-version: "16.12"
       - name: Install CDK CLI
         run: |
-          npm install
+          npm ci
           npx cdk --version
       - name: Install dependencies
         run: make dev

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,9 @@
     "": {
       "name": "aws-lambda-powertools-python-e2e",
       "version": "1.0.0",
+      "dependencies": {
+        "package-lock.json": "^1.0.0"
+      },
       "devDependencies": {
         "aws-cdk": "^2.86.0"
       }
@@ -39,6 +42,11 @@
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
+    },
+    "node_modules/package-lock.json": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/package-lock.json/-/package-lock.json-1.0.0.tgz",
+      "integrity": "sha512-+yEXtNdlCs5N0Zy/9uvkifgf/RqnGu0WqP4j9Wu1Us4YReFe1YNBh2Krmf8B1xGxjpYnta63K55QP8bkafnOzA=="
     }
   },
   "dependencies": {
@@ -57,6 +65,11 @@
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
       "dev": true,
       "optional": true
+    },
+    "package-lock.json": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/package-lock.json/-/package-lock.json-1.0.0.tgz",
+      "integrity": "sha512-+yEXtNdlCs5N0Zy/9uvkifgf/RqnGu0WqP4j9Wu1Us4YReFe1YNBh2Krmf8B1xGxjpYnta63K55QP8bkafnOzA=="
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -3,5 +3,8 @@
   "version": "1.0.0",
   "devDependencies": {
     "aws-cdk": "^2.86.0"
+  },
+  "dependencies": {
+    "package-lock.json": "^1.0.0"
   }
 }


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
**Issue number:** #2203

## Summary

https://github.com/ossf/scorecard/blob/4edb07802fdad892fa8d10f8fd47666b6ccc27c9/docs/checks.md#pinned-dependencies

We should be using `npm ci` instead of `npm install`. Apparently, `npm install` for our dev dependencies use `package.json` instead of `package-lock.json`... 🤦🏻 

### Changes

> Please provide a summary of what's being changed

### User experience

> Please share what the user experience looks like before and after this change

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] [Meet tenets criteria](https://docs.powertools.aws.dev/lambda/python/#tenets)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented
* [x] PR title follows [conventional commit semantics](https://github.com/aws-powertools/powertools-lambda-python/blob/develop/.github/semantic.yml)

<details>
<summary>Is this a breaking change?</summary>

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
