### PR TITLE
chore(ci): prevent sast codeql to run in forks

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -20,6 +20,7 @@ permissions:
 jobs:
   analyze:
     name: Analyze
+    if: github.repository == 'aws-powertools/powertools-lambda-python'
     runs-on: ubuntu-latest
     permissions:
       security-events: write


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
**Issue number:** #2203

## Summary

CodeQL (SAST) is running on forks pull requests. This PR ensures it only runs for the origin.

This is part of the OSSF Scorecard investigation to understand why SAST isn't running on our commits: https://gist.github.com/heitorlessa/04a4f1bd6b9c9185455c85ce77f13147

### Changes

> Please provide a summary of what's being changed

### User experience

> Please share what the user experience looks like before and after this change

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] [Meet tenets criteria](https://docs.powertools.aws.dev/lambda/python/#tenets)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented
* [x] PR title follows [conventional commit semantics](https://github.com/aws-powertools/powertools-lambda-python/blob/develop/.github/semantic.yml)

<details>
<summary>Is this a breaking change?</summary>

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
