### PR TITLE
docs(batch): fix custom batch processor example

### DIFF
--- a/docs/utilities/batch.md
+++ b/docs/utilities/batch.md
@@ -346,7 +346,7 @@ You can create your own partial batch processor from scratch by inheriting the `
 
 You can then use this class as a context manager, or pass it to `batch_processor` to use as a decorator on your Lambda handler function.
 
-```python hl_lines="9-12 20 35 41 48 59 64 68 76" title="Creating a custom batch processor"
+```python hl_lines="9-11 19 33 39 46 57 62 66 74" title="Creating a custom batch processor"
 --8<-- "examples/batch_processing/src/custom_partial_processor.py"
 ```
 

--- a/examples/batch_processing/src/custom_partial_processor.py
+++ b/examples/batch_processing/src/custom_partial_processor.py
@@ -7,8 +7,7 @@ import boto3
 
 from aws_lambda_powertools import Logger
 from aws_lambda_powertools.utilities.batch import (
-    BasePartialBatchProcessor,
-    EventType,
+    BasePartialProcessor,
     process_partial_response,
 )
 
@@ -17,7 +16,7 @@ table_name = os.getenv("TABLE_NAME", "table_not_found")
 logger = Logger()
 
 
-class MyPartialProcessor(BasePartialBatchProcessor):
+class MyPartialProcessor(BasePartialProcessor):
     """
     Process a record and stores successful results at a Amazon DynamoDB Table
 
@@ -29,8 +28,7 @@ class MyPartialProcessor(BasePartialBatchProcessor):
 
     def __init__(self, table_name: str):
         self.table_name = table_name
-
-        super().__init__(event_type=EventType.SQS)
+        super().__init__()
 
     def _prepare(self):
         # It's called once, *before* processing


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
**Issue number:** #2688

## Summary

As @erikayao93 pointed out, this change corrects Batch custom processor example to use `BasePartialProcessor` super class.

### Changes

> Please provide a summary of what's being changed

### User experience

> Please share what the user experience looks like before and after this change

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] [Meet tenets criteria](https://docs.powertools.aws.dev/lambda/python/#tenets)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented
* [x] PR title follows [conventional commit semantics](https://github.com/aws-powertools/powertools-lambda-python/blob/develop/.github/semantic.yml)

<details>
<summary>Is this a breaking change?</summary>

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
