### PR TITLE
chore(governance): update active maintainers list

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -51,8 +51,6 @@ This is document explains who the maintainers are (see below), what they do in t
 | Maintainer        | GitHub ID                                               | Affiliation |
 | ----------------- | ------------------------------------------------------- | ----------- |
 | Heitor Lessa      | [heitorlessa](https://github.com/heitorlessa)           | Amazon      |
-| Alexander Melnyk  | [am29d](https://github.com/am29d)                       | Amazon      |
-| Michal Ploski     | [mploski](https://github.com/mploski)                   | Amazon      |
 | Simon Thulbourn   | [sthulb](https://github.com/sthulb)                     | Amazon      |
 | Ruben Fonseca     | [rubenfonseca](https://github.com/rubenfonseca)         | Amazon      |
 | Leandro Damascena | [leandrodamascena](https://github.com/leandrodamascena) | Amazon      |
@@ -65,6 +63,8 @@ Previous active maintainers who contributed to this project.
 | ----------------- | ----------------------------------------------- | ----------- |
 | Tom McCarthy      | [cakepietoast](https://github.com/cakepietoast) | MongoDB     |
 | Nicolas Moutschen | [nmoutschen](https://github.com/nmoutschen)     | Apollo      |
+| Alexander Melnyk  | [am29d](https://github.com/am29d)               | Amazon      |
+| Michal Ploski     | [mploski](https://github.com/mploski)           | Amazon      |
 
 ## Labels
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
**Issue number:** #2203 

## Summary

Updating current active maintainers list ahead of announcements. 

### Changes

> Please provide a summary of what's being changed

### User experience

> Please share what the user experience looks like before and after this change

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] [Meet tenets criteria](https://docs.powertools.aws.dev/lambda/python/#tenets)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented
* [x] PR title follows [conventional commit semantics](https://github.com/aws-powertools/powertools-lambda-python/blob/develop/.github/semantic.yml)

<details>
<summary>Is this a breaking change?</summary>

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
