### PR TITLE
fix(logger): ensure logs stream to stdout by default, not stderr

### DIFF
--- a/aws_lambda_powertools/logging/logger.py
+++ b/aws_lambda_powertools/logging/logger.py
@@ -232,7 +232,8 @@ class Logger:
         )
         self.child = child
         self.logger_formatter = logger_formatter
-        self.logger_handler = logger_handler or logging.StreamHandler(stream)
+        self._stream = stream or sys.stdout
+        self.logger_handler = logger_handler or logging.StreamHandler(self._stream)
         self.log_uncaught_exceptions = log_uncaught_exceptions
 
         self._is_deduplication_disabled = resolve_truthy_env_var_choice(

--- a/tests/functional/test_logger.py
+++ b/tests/functional/test_logger.py
@@ -945,3 +945,17 @@ def test_logger_log_uncaught_exceptions(service_name, stdout):
     # THEN it should contain our custom exception hook with a copy of our logger
     assert isinstance(exception_hook, functools.partial)
     assert exception_hook.keywords.get("logger") == logger
+
+
+def test_stream_defaults_to_stdout(service_name, capsys):
+    # GIVEN Logger is initialized without any explicit stream
+    logger = Logger(service=service_name)
+    msg = "testing stdout"
+
+    # WHEN logging statements are issued
+    logger.info(msg)
+
+    # THEN we should default to standard output, not standard error.
+    # NOTE: we can't assert on capsys.readouterr().err due to a known bug: https://github.com/pytest-dev/pytest/issues/5997
+    log = json.loads(capsys.readouterr().out.strip())
+    assert log["message"] == msg


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
**Issue number:** #2735

## Summary

This PR addresses an old regression where logs are sent to stderr instead of stdout. While Lambda streams both it is not semantically correct and may impact non-Lambda usage (unsupported).

### Changes

> Please provide a summary of what's being changed

### User experience

> Please share what the user experience looks like before and after this change

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] [Meet tenets criteria](https://docs.powertools.aws.dev/lambda/python/#tenets)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented
* [x] PR title follows [conventional commit semantics](https://github.com/aws-powertools/powertools-lambda-python/blob/develop/.github/semantic.yml)

<details>
<summary>Is this a breaking change?</summary>

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
