### PR TITLE
feat(metrics): support to set default dimension in EphemeralMetrics

### DIFF
--- a/aws_lambda_powertools/shared/user_agent.py
+++ b/aws_lambda_powertools/shared/user_agent.py
@@ -112,7 +112,7 @@ def register_feature_to_session(session, feature):
 def register_feature_to_botocore_session(botocore_session, feature):
     """
     Register the given feature string to the event system of the provided botocore session
-    
+
     Please notice this function is for patching botocore session and is different from
     previous one which is for patching boto3 session
 
@@ -127,7 +127,7 @@ def register_feature_to_botocore_session(botocore_session, feature):
     ------
     AttributeError
         If the provided session does not have an event system.
-        
+
     Examples
     --------
     **register data-masking user-agent to botocore session**
@@ -139,7 +139,7 @@ def register_feature_to_botocore_session(botocore_session, feature):
         >>> session = botocore.session.Session()
         >>> register_feature_to_botocore_session(botocore_session=session, feature="data-masking")
         >>> key_provider = StrictAwsKmsMasterKeyProvider(key_ids=self.keys, botocore_session=session)
-    
+
     """
     try:
         botocore_session.register(TARGET_SDK_EVENT, _create_feature_function(feature))

--- a/docs/core/metrics.md
+++ b/docs/core/metrics.md
@@ -274,12 +274,11 @@ You can use `EphemeralMetrics` class when looking to isolate multiple instances 
 
 **Differences between `EphemeralMetrics` and `Metrics`**
 
-`EphemeralMetrics` has only two differences while keeping nearly the exact same set of features:
+`EphemeralMetrics` has only one difference while keeping nearly the exact same set of features:
 
 | Feature                                                                                                     | Metrics | EphemeralMetrics |
 | ----------------------------------------------------------------------------------------------------------- | ------- | ---------------- |
 | **Share data across instances** (metrics, dimensions, metadata, etc.)                                       | Yes     | -                |
-| **[Default dimensions](#adding-default-dimensions) that persists across Lambda invocations** (metric flush) | Yes     | -                |
 
 !!! question "Why not changing the default `Metrics` behaviour to not share data across instances?"
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
**Issue number:** #2676 

## Summary

### Changes

This PR introduces the enhancement of the EphemeralMetrics class. You can now use the `set_default_dimensions` method or the `default_dimensions` parameter in the `log_metrics` decorator to persist dimensions across Lambda invocations.
If you'd like to remove them at some point, you can use `clear_default_dimensions` method.


### User experience

**Using log_metrics decorator**
```python
from aws_lambda_powertools.metrics import MetricUnit, EphemeralMetrics
from aws_lambda_powertools.utilities.typing import LambdaContext

ephemeral = EphemeralMetrics(namespace="POWERTOOLS")


@ephemeral.log_metrics(
    default_dimensions={'stage': 'prod'}
)
def lambda_handler(event: dict, context: LambdaContext):
    ephemeral.add_metric(name="OrderCount", unit=MetricUnit.Count, value=8)
```

**Using set_default_dimensions**

```python
from aws_lambda_powertools.metrics import MetricUnit, EphemeralMetrics
from aws_lambda_powertools.utilities.typing import LambdaContext

ephemeral = EphemeralMetrics(namespace="POWERTOOLS")
ephemeral.set_default_dimensions(stage="prod")


@ephemeral.log_metrics
def lambda_handler(event: dict, context: LambdaContext):
    ephemeral.add_metric(name="OrderCount", unit=MetricUnit.Count, value=8)
```

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] [Meet tenets criteria](https://docs.powertools.aws.dev/lambda/python/#tenets)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented
* [x] PR title follows [conventional commit semantics](https://github.com/aws-powertools/powertools-lambda-python/blob/develop/.github/semantic.yml)

<details>
<summary>Is this a breaking change?</summary>

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
