### PR TITLE
chore(ci): build changelog on a schedule only

### DIFF
--- a/.github/workflows/build_changelog.yml
+++ b/.github/workflows/build_changelog.yml
@@ -13,9 +13,12 @@ name: Build changelog
 
 on:
   workflow_dispatch:
-  push:
-    branches:
-      - develop
+#  push:
+#    branches:
+#      - develop
+  schedule:
+    # Note: run daily at 7am UTC time until upstream git-chlog uses stable sorting
+    - cron: "0 7 * * *"
 
 permissions:
   contents: read


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
**Issue number:** #2831

## Summary

### Changes

> Please provide a summary of what's being changed

Temporarily disables `push` trigger in favour of `schedule`.

### User experience

> Please share what the user experience looks like before and after this change

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] [Meet tenets criteria](https://docs.powertools.aws.dev/lambda/python/#tenets)
* [ ] I have performed a self-review of this change
* [ ] Changes have been tested
* [ ] Changes are documented
* [x] PR title follows [conventional commit semantics](https://github.com/aws-powertools/powertools-lambda-python/blob/develop/.github/semantic.yml)

<details>
<summary>Is this a breaking change?</summary>

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
