### PR TITLE
chore(ci): add baking time for layer build

### DIFF
--- a/.github/workflows/publish_v2_layer.yml
+++ b/.github/workflows/publish_v2_layer.yml
@@ -115,11 +115,13 @@ jobs:
         run: |
           poetry export --format requirements.txt --output requirements.txt
           pip install --require-hashes -r requirements.txt
+
       - name: Set up QEMU
         uses: docker/setup-qemu-action@2b82ce82d56a2a04d2637cd93a637ae1b359c0a7 # v2.0.0
         with:
           platforms: arm64
         # NOTE: we need QEMU to build Layer against a different architecture (e.g., ARM)
+
       - name: Set up Docker Buildx
         id: builder
         uses: docker/setup-buildx-action@4c0219f9ac95b02789c1075625400b2acbff50b1 # v2.9.1
@@ -127,11 +129,18 @@ jobs:
           install: true
           driver: docker
           platforms: linux/amd64,linux/arm64
-      - name: install cdk and deps
+
+      - name: Install CDK
         working-directory: ./
         run: |
           npm ci
           npx cdk --version
+
+      # Baking time for PyPi eventual consistency; 60s seemed more than enough
+      # https://github.com/aws-powertools/powertools-lambda-python/issues/2491
+      - name: Baking time (PyPi)
+        run: sleep 60
+
       - name: CDK build
         run: npx cdk synth --verbose --context version="${{ inputs.latest_published_version }}" -o cdk.out
       - name: zip output


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
**Issue number:** #2491

## Summary

Due to PyPi eventual consistency, this PR adds a 60s baking time before building Lambda Layer

### Changes

> Please provide a summary of what's being changed

- [x] Add 60s baking time before build
- [x] Minor casing and title fixes

### User experience

> Please share what the user experience looks like before and after this change

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] [Meet tenets criteria](https://docs.powertools.aws.dev/lambda/python/#tenets)
* [x] I have performed a self-review of this change
* [ ] Changes have been tested
* [x] Changes are documented
* [x] PR title follows [conventional commit semantics](https://github.com/aws-powertools/powertools-lambda-python/blob/develop/.github/semantic.yml)

<details>
<summary>Is this a breaking change?</summary>

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
