### PR TITLE
fix(parameters): distinct cache key for single vs path with same name

### DIFF
--- a/aws_lambda_powertools/utilities/parameters/types.py
+++ b/aws_lambda_powertools/utilities/parameters/types.py
@@ -1,3 +1,4 @@
 from typing_extensions import Literal
 
 TransformOptions = Literal["json", "binary", "auto", None]
+RecursiveOptions = Literal[True, False]

--- a/aws_lambda_powertools/utilities/parameters/types.py
+++ b/aws_lambda_powertools/utilities/parameters/types.py
@@ -1,4 +1,3 @@
 from typing_extensions import Literal
 
 TransformOptions = Literal["json", "binary", "auto", None]
-RecursiveOptions = Literal[True, False]

--- a/tests/functional/test_utilities_parameters.py
+++ b/tests/functional/test_utilities_parameters.py
@@ -139,7 +139,8 @@ def test_dynamodb_provider_get_cached(mock_name, mock_value, config):
     provider = parameters.DynamoDBProvider(table_name, config=config)
 
     # Inject value in the internal store
-    provider.store[(mock_name, None)] = ExpirableValue(mock_value, datetime.now() + timedelta(seconds=60))
+    cache_key = provider._build_cache_key(name=mock_name)
+    provider.add_to_cache(key=cache_key, value=mock_value, max_age=60)
 
     # Stub the boto3 client
     stubber = stub.Stubber(provider.table.meta.client)
@@ -631,7 +632,8 @@ def test_ssm_provider_get_cached(mock_name, mock_value, config):
     provider = parameters.SSMProvider(config=config)
 
     # Inject value in the internal store
-    provider.store[(mock_name, None)] = ExpirableValue(mock_value, datetime.now() + timedelta(seconds=60))
+    cache_key = provider._build_cache_key(name=mock_name)
+    provider.add_to_cache(key=cache_key, value=mock_value, max_age=60)
 
     # Stub the boto3 client
     stubber = stub.Stubber(provider.client)
@@ -1332,7 +1334,8 @@ def test_secrets_provider_get_cached(mock_name, mock_value, config):
     provider = parameters.SecretsProvider(config=config)
 
     # Inject value in the internal store
-    provider.store[(mock_name, None)] = ExpirableValue(mock_value, datetime.now() + timedelta(seconds=60))
+    cache_key = provider._build_cache_key(name=mock_name)
+    provider.add_to_cache(key=cache_key, value=mock_value, max_age=60)
 
     # Stub the boto3 client
     stubber = stub.Stubber(provider.client)
@@ -1734,7 +1737,8 @@ def test_base_provider_get_multiple_cached(mock_name, mock_value):
 
     provider = TestProvider()
 
-    provider.store[(mock_name, None)] = ExpirableValue({"A": mock_value}, datetime.now() + timedelta(seconds=60))
+    cache_key = provider._build_cache_key(name=mock_name, is_recursive=True)
+    provider.add_to_cache(key=cache_key, value={"A": mock_value}, max_age=60)
 
     value = provider.get_multiple(mock_name)
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
**Issue number:** #2438

## Summary

This PR addresses an edge case that a customer tries to get multiple parameters by path followed by getting a single 
parameter using the path name, where `GetParameterError` isn't raised in the latter due to cache.

Previously reproduced as:

```python
from aws_lambda_powertools.utilities.parameters import get_parameters, get_parameter

get_parameters("/dev")  # get all parameters under path
get_parameter("/dev")    # mistakenly tries to get /dev but no error raised; it gets cache results instead
```

### Changes

> Please provide a summary of what's being changed

* [x] Update code to use newer `self.add_to_cache()`
* [x] Add `self.fetch_from_cache` to isolate getter
* [x] Centralize cache key naming in new method: `_build_cache_key`
* [x] Add defaults to build_cache_key - transform, recursive
* [x] Update cache test to use new `_build_cache_key`
* [x] Think of a better name to differentiate cache key name
  * `Context` futureproofs it, but impacts readability
  * `is_recursive`, `is_multiple`

### User experience

> Please share what the user experience looks like before and after this change

Exception raised as it should

```python
Traceback (most recent call last):
  File "DEV/aws-lambda-powertools-python/aws_lambda_powertools/utilities/parameters/base.py", line 135, in get
    value = self._get(name, **sdk_options)
  File "DEV/aws-lambda-powertools-python/aws_lambda_powertools/utilities/parameters/ssm.py", line 189, in _get
    return self.client.get_parameter(**sdk_options)["Parameter"]["Value"]
  File "DEV/aws-lambda-powertools-python/.venv/lib/python3.9/site-packages/botocore/client.py", line 534, in _api_call
    return self._make_api_call(operation_name, kwargs)
  File "DEV/aws-lambda-powertools-python/.venv/lib/python3.9/site-packages/botocore/client.py", line 976, in _make_api_call
    raise error_class(parsed_response, operation_name)
botocore.errorfactory.ParameterNotFound: An error occurred (ParameterNotFound) when calling the GetParameter operation: 

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "DEV/aws-lambda-powertools-python/bla.py", line 4, in <module>
    get_parameter("/dev", max_age=100)
  File "DEV/aws-lambda-powertools-python/aws_lambda_powertools/utilities/parameters/ssm.py", line 607, in get_parameter
    return DEFAULT_PROVIDERS["ssm"].get(
  File "DEV/aws-lambda-powertools-python/aws_lambda_powertools/utilities/parameters/ssm.py", line 169, in get
    return super().get(name, max_age, transform, force_fetch, **sdk_options)
  File "DEV/aws-lambda-powertools-python/aws_lambda_powertools/utilities/parameters/base.py", line 138, in get
    raise GetParameterError(str(exc))
aws_lambda_powertools.utilities.parameters.exceptions.GetParameterError: An error occurred (ParameterNotFound) when calling the GetParameter operation:
```

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] [Meet tenets criteria](https://docs.powertools.aws.dev/lambda/python/#tenets)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented
* [x] PR title follows [conventional commit semantics](https://github.com/aws-powertools/powertools-lambda-python/blob/develop/.github/semantic.yml)

<details>
<summary>Is this a breaking change?</summary>

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
