### PR TITLE
fix(metrics): proxy service and namespace attrs to provider

### DIFF
--- a/aws_lambda_powertools/metrics/metrics.py
+++ b/aws_lambda_powertools/metrics/metrics.py
@@ -181,6 +181,26 @@ class Metrics:
     def clear_metrics(self) -> None:
         self.provider.clear_metrics()
 
+    # We now allow customers to bring their own instance
+    # of the AmazonCloudWatchEMFProvider provider
+    # So we need to define getter/setter for namespace and service properties
+    # To access these attributes on the provider instance.
+    @property
+    def namespace(self):
+        return self.provider.namespace
+
+    @namespace.setter
+    def namespace(self, namespace):
+        self.provider.namespace = namespace
+
+    @property
+    def service(self):
+        return self.provider.service
+
+    @service.setter
+    def service(self, service):
+        self.provider.service = service
+
 
 # Maintenance: until v3, we can't afford to break customers.
 # AmazonCloudWatchEMFProvider has the exact same functionality (non-singleton)

--- a/tests/functional/test_metrics.py
+++ b/tests/functional/test_metrics.py
@@ -1077,6 +1077,25 @@ def test_clear_default_dimensions(namespace):
     assert not my_metrics.default_dimensions
 
 
+def test_get_and_set_namespace_and_service_properties(namespace, service, metrics, capsys):
+    # GIVEN Metrics instance is initialized without namespace and service
+    my_metrics = Metrics()
+
+    # WHEN we set service and namespace before flushing the metric
+    @my_metrics.log_metrics
+    def lambda_handler(evt, ctx):
+        my_metrics.namespace = namespace
+        my_metrics.service = service
+        for metric in metrics:
+            my_metrics.add_metric(**metric)
+
+    lambda_handler({}, {})
+    invocation = capture_metrics_output(capsys)
+
+    assert service in json.dumps(invocation)
+    assert namespace in json.dumps(invocation)
+
+
 def test_clear_default_dimensions_with_provider(namespace):
     # GIVEN Metrics is initialized with provider and we persist a set of default dimensions
     my_provider = AmazonCloudWatchEMFProvider(namespace=namespace)


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
**Issue number:** #2909

## Summary

### Changes

This PR introduces getter/setter methods.

### User experience

> Please share what the user experience looks like before and after this change

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] [Meet tenets criteria](https://docs.powertools.aws.dev/lambda/python/#tenets)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented
* [x] PR title follows [conventional commit semantics](https://github.com/aws-powertools/powertools-lambda-python/blob/develop/.github/semantic.yml)

<details>
<summary>Is this a breaking change?</summary>

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
