### PR TITLE
docs(tracer): include environment variables

### DIFF
--- a/docs/core/tracer.md
+++ b/docs/core/tracer.md
@@ -21,6 +21,16 @@ Tracer is an opinionated thin wrapper for [AWS X-Ray Python SDK](https://github.
 
 !!! note "Tracer relies on AWS X-Ray SDK over [OpenTelememetry Distro (ADOT)](https://aws-otel.github.io/docs/getting-started/lambda){target="_blank" rel="nofollow"} for optimal cold start (lower latency)."
 
+Tracer uses the following environment variables to globally set its configuration:
+
+| Setting               | Description                                      | Environment variable                 | Default |
+|-----------------------|--------------------------------------------------|--------------------------------------|---------|
+| **Disable Tracing**   | Explicitly disables all tracing.                 | `POWERTOOLS_TRACE_DISABLED`          | `false` |
+| **Response Capture**  | Captures Lambda or method return as metadata.    | `POWERTOOLS_TRACER_CAPTURE_RESPONSE` | `true`  |
+| **Exception Capture** | Captures Lambda or method exception as metadata. | `POWERTOOLS_TRACER_CAPTURE_ERROR`    | `true`  |
+
+Both `POWERTOOLS_TRACER_CAPTURE_RESPONSE` and `POWERTOOLS_TRACER_CAPTURE_ERROR` can be set on a per-method basis (see [Advanced](#advanced)), overriding the environment variable value.
+
 ### Install
 
 !!! info "This is not necessary if you're installing Powertools for AWS Lambda (Python) via [Lambda Layer/SAR](../index.md#lambda-layer){target="_blank"}"


### PR DESCRIPTION
**Issue number:** #2923

Clarifies Tracer's documentation page by including its related environment variables.

<!-- markdownlint-disable MD041 MD043 -->

## Summary

This PR improves [Tracer's documentation page](https://docs.powertools.aws.dev/lambda/python/latest/core/tracer/) by including its related environment variables. They were only included on the main page, though it may be useful to also mention them in their corresponding section.

### Changes

Under the _Getting started_ section, a table listing all Tracer's environment variables has been included. It also mentions the preference order (method parameter overrides environment variable).

### User experience

When navigating through documentation, developers will now find the environment variables for Tracer on its page. It is useful as it allows us to quickly understand the behaviour of these environment variables by <kbd>Ctrl</kbd>+<kbd>F</kbd>'ing them.

This comes from personal experience, as I found out about these environment variables by checking the parameters of Tracer decorators' source code. But when going to Tracer's documentation page, I couldn't find these environment variables, until I realized they were only in the main page.

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] [Meet tenets criteria](https://docs.powertools.aws.dev/lambda/python/#tenets)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented
* [x] PR title follows [conventional commit semantics](https://github.com/aws-powertools/powertools-lambda-python/blob/develop/.github/semantic.yml)

<details>
<summary>Is this a breaking change?</summary>

No

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
