### PR TITLE
fix(parser): API Gateway V2 request context scope field should be optional

### DIFF
--- a/aws_lambda_powertools/utilities/parser/models/apigwv2.py
+++ b/aws_lambda_powertools/utilities/parser/models/apigwv2.py
@@ -25,7 +25,7 @@ class RequestContextV2AuthorizerIam(BaseModel):
 
 class RequestContextV2AuthorizerJwt(BaseModel):
     claims: Dict[str, Any]
-    scopes: List[str]
+    scopes: Optional[List[str]] = None
 
 
 class RequestContextV2Authorizer(BaseModel):

--- a/tests/unit/parser/test_apigwv2.py
+++ b/tests/unit/parser/test_apigwv2.py
@@ -63,6 +63,13 @@ def test_apigw_v2_event_jwt_authorizer():
     assert parsed_event.stageVariables == raw_event["stageVariables"]
 
 
+def test_apigw_v2_event_empty_jwt_scopes():
+    raw_event = load_event("apiGatewayProxyV2Event.json")
+    raw_event["requestContext"]["authorizer"]["jwt"]["scopes"] = None
+
+    APIGatewayProxyEventV2Model(**raw_event)
+
+
 def test_api_gateway_proxy_v2_event_lambda_authorizer():
     raw_event = load_event("apiGatewayProxyV2LambdaAuthorizerEvent.json")
     parsed_event: APIGatewayProxyEventV2Model = APIGatewayProxyEventV2Model(**raw_event)


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
**Issue number:** #2953 

## Summary

### Changes

Include the Optional type to make the "scope" field optional.

### User experience

> Please share what the user experience looks like before and after this change

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] [Meet tenets criteria](https://docs.powertools.aws.dev/lambda/python/#tenets)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented
* [x] PR title follows [conventional commit semantics](https://github.com/aws-powertools/powertools-lambda-python/blob/develop/.github/semantic.yml)

<details>
<summary>Is this a breaking change?</summary>

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
