### PR TITLE
fix(event_handler): make invalid chars a raw str to fix invalid escape sequence

### DIFF
--- a/aws_lambda_powertools/event_handler/api_gateway.py
+++ b/aws_lambda_powertools/event_handler/api_gateway.py
@@ -43,7 +43,7 @@ logger = logging.getLogger(__name__)
 _DYNAMIC_ROUTE_PATTERN = r"(<\w+>)"
 _SAFE_URI = "-._~()'!*:@,;="  # https://www.ietf.org/rfc/rfc3986.txt
 # API GW/ALB decode non-safe URI chars; we must support them too
-_UNSAFE_URI = "%<> \[\]{}|^"  # noqa: W605
+_UNSAFE_URI = r"%<> \[\]{}|^"
 _NAMED_GROUP_BOUNDARY_PATTERN = rf"(?P\1[{_SAFE_URI}{_UNSAFE_URI}\\w]+)"
 _ROUTE_REGEX = "^{}$"
 

--- a/tests/unit/data_classes/test_api_gateway_authorizer.py
+++ b/tests/unit/data_classes/test_api_gateway_authorizer.py
@@ -31,7 +31,7 @@ def test_authorizer_response_invalid_verb(builder: APIGatewayAuthorizerResponse)
 
 
 def test_authorizer_response_invalid_resource(builder: APIGatewayAuthorizerResponse):
-    with pytest.raises(ValueError, match="Invalid resource path: \$."):  # noqa: W605
+    with pytest.raises(ValueError, match=r"Invalid resource path: \$."):
         # GIVEN an invalid resource path "$"
         # WHEN calling deny_method
         builder.deny_route(http_method=HttpVerb.GET.value, resource="$")


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->

**Issue number:** #2980

## Summary

This PR fixes a syntax error on the API Gateway project.

### Changes

> Please provide a summary of what's being changed

Removes the `noqa: W605` and make the string a raw string.

### User experience

> Please share what the user experience looks like before and after this change

After this PR, the code should not print a warning when importing the APIGateway resolver.

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

- [x] [Meet tenets criteria](https://docs.powertools.aws.dev/lambda/python/#tenets)
- [x] I have performed a self-review of this change
- [x] Changes have been tested
- [x] Changes are documented
- [ ] PR title follows [conventional commit semantics](https://github.com/aws-powertools/powertools-lambda-python/blob/develop/.github/semantic.yml)

<details>
<summary>Is this a breaking change?</summary>

**RFC issue number**:

Checklist:

- [ ] Migration process documented
- [ ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
