### PR TITLE
fix(event_handler): expanding safe URI characters to include +$&

### DIFF
--- a/aws_lambda_powertools/event_handler/api_gateway.py
+++ b/aws_lambda_powertools/event_handler/api_gateway.py
@@ -41,7 +41,7 @@ from aws_lambda_powertools.utilities.typing import LambdaContext
 logger = logging.getLogger(__name__)
 
 _DYNAMIC_ROUTE_PATTERN = r"(<\w+>)"
-_SAFE_URI = "-._~()'!*:@,;="  # https://www.ietf.org/rfc/rfc3986.txt
+_SAFE_URI = "-._~()'!*:@,;=+&$"  # https://www.ietf.org/rfc/rfc3986.txt
 # API GW/ALB decode non-safe URI chars; we must support them too
 _UNSAFE_URI = r"%<> \[\]{}|^"
 _NAMED_GROUP_BOUNDARY_PATTERN = rf"(?P\1[{_SAFE_URI}{_UNSAFE_URI}\\w]+)"

--- a/tests/functional/event_handler/test_api_gateway.py
+++ b/tests/functional/event_handler/test_api_gateway.py
@@ -989,7 +989,7 @@ def test_similar_dynamic_routes_with_whitespaces():
     [
         pytest.param(123456789, id="num"),
         pytest.param("user@example.com", id="email"),
-        pytest.param("-._~'!*:@,;()=", id="safe-rfc3986"),
+        pytest.param("-._~'!*:@,;()=+&$", id="safe-rfc3986"),
         pytest.param("%<>[]{}|^", id="unsafe-rfc3986"),
     ],
 )


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
**Issue number:** #3006

## Summary
Added `+$&` as safe characters to be captured by dynamic path in API Gateway resolver.

### Changes

- Updated `_SAFE_URI` in `api_gateway.pyL46` to include characters `+`, `$` and `&`
- Updated existing test in `test_api_gateway.pyL992` to test capturing with above characters

### User experience

```python
app = APIGatewayRestResolver()

@app.get("/dummy/<value>")
def handler(value: str):
	return {}

response = app.resolve(
	{
		"path": "/dummy/a+b",
		"httpMethod": "GET",
		"requestContext": {"requestId": "227b78aa-779d-47d4-a48e-ce62120393b8"}
	},
	lambda_context
)

# This invokes above handler instead of returning 404
assert response["statusCode"] == 200
```

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] [Meet tenets criteria](https://docs.powertools.aws.dev/lambda/python/#tenets)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [ ] Changes are documented
* [x] PR title follows [conventional commit semantics](https://github.com/aws-powertools/powertools-lambda-python/blob/develop/.github/semantic.yml)

<details>
<summary>Is this a breaking change?</summary>
Not a breaking change

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
