### PR TITLE
fix(parser): change ApproximateCreationDateTime field to datetime in DynamoDBStreamChangedRecordModel

### DIFF
--- a/aws_lambda_powertools/utilities/parser/models/dynamodb.py
+++ b/aws_lambda_powertools/utilities/parser/models/dynamodb.py
@@ -1,4 +1,4 @@
-from datetime import date
+from datetime import datetime
 from typing import Any, Dict, List, Optional, Type, Union
 
 from pydantic import BaseModel
@@ -7,7 +7,7 @@ from aws_lambda_powertools.utilities.parser.types import Literal
 
 
 class DynamoDBStreamChangedRecordModel(BaseModel):
-    ApproximateCreationDateTime: Optional[date] = None
+    ApproximateCreationDateTime: Optional[datetime] = None
     Keys: Dict[str, Dict[str, Any]]
     NewImage: Optional[Union[Dict[str, Any], Type[BaseModel], BaseModel]] = None
     OldImage: Optional[Union[Dict[str, Any], Type[BaseModel], BaseModel]] = None

--- a/tests/events/dynamoStreamEvent.json
+++ b/tests/events/dynamoStreamEvent.json
@@ -4,6 +4,7 @@
       "eventID": "1",
       "eventVersion": "1.0",
       "dynamodb": {
+        "ApproximateCreationDateTime": 1693997155.0,
         "Keys": {
           "Id": {
             "N": "101"

--- a/tests/unit/data_classes/test_dynamo_db_stream_event.py
+++ b/tests/unit/data_classes/test_dynamo_db_stream_event.py
@@ -33,7 +33,7 @@ def test_dynamodb_stream_trigger_event():
     assert record.user_identity is None
     dynamodb = record.dynamodb
     assert dynamodb is not None
-    assert dynamodb.approximate_creation_date_time is None
+    assert dynamodb.approximate_creation_date_time == record_raw["dynamodb"]["ApproximateCreationDateTime"]
     keys = dynamodb.keys
     assert keys is not None
     assert keys["Id"] == decimal_context.create_decimal(101)

--- a/tests/unit/parser/test_dynamodb.py
+++ b/tests/unit/parser/test_dynamodb.py
@@ -55,7 +55,8 @@ def test_dynamo_db_stream_trigger_event_no_envelope():
     dynamodb = record.dynamodb
     raw_dynamodb = raw_record["dynamodb"]
     assert dynamodb is not None
-    assert dynamodb.ApproximateCreationDateTime is None
+    assert dynamodb.ApproximateCreationDateTime is not None
+    assert dynamodb.ApproximateCreationDateTime.timestamp() == raw_dynamodb["ApproximateCreationDateTime"]
     assert dynamodb.OldImage is None
     assert dynamodb.SequenceNumber == raw_dynamodb["SequenceNumber"]
     assert dynamodb.SizeBytes == raw_dynamodb["SizeBytes"]


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
**Issue number: #3048**

## Summary

This promotes `ApproximateCreationDateTime` to a `datetime` object (instead of `date`) so that pydantic v2 will correctly deserialize it when parsing DynamoDB stream events.

### Changes

Only the type of `ApproximateCreationDateTime` has changed.

### User experience

If users would like to rely on a proper `date` object after the change, they need to use `datetime`'s `date` method. Here's how that may look like.

#### Before the change
```python
from aws_lambda_powertools.utilities.parser.models import DynamoDBStreamChangedRecordModel

changed_record = {
    "ApproximateCreationDateTime": 1479499740,
    "Keys": {
        "Timestamp": {"S": "2016-11-18:12:09:36"},
        "Username": {"S": "John Doe"},
    },
    "NewImage": {
        "Timestamp": {"S": "2016-11-18:12:09:36"},
        "Message": {"S": "This is a bark from the Woofer social network"},
        "Username": {"S": "John Doe"},
    },
    "SequenceNumber": "13021600000000001596893679",
    "SizeBytes": 112,
    "StreamViewType": "NEW_IMAGE",
}
model = DynamoDBStreamChangedRecordModel.model_validate(changed_record)
creation_date = model.ApproximateCreationDateTime
# Carry on with evaluating the date...
```
#### After the change
```python
# Parse the model just like before...
creation_date = model.ApproximateCreationDateTime.date()
# Carry on with evaluating the date...
```

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] [Meet tenets criteria](https://docs.powertools.aws.dev/lambda/python/#tenets)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [ ] Changes are documented
* [x] PR title follows [conventional commit semantics](https://github.com/aws-powertools/powertools-lambda-python/blob/develop/.github/semantic.yml)

<details>
<summary>Is this a breaking change?</summary>
Yes, this could break existing code using Pydantic V1 that examines `ApproximateCreationDateTime` and relies on it being a proper date object.

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
