### PR TITLE
chore(automation): remove previous labels when PR is updated

### DIFF
--- a/.github/scripts/save_pr_details.js
+++ b/.github/scripts/save_pr_details.js
@@ -1,9 +1,19 @@
-module.exports = async ({context, core}) => {
+module.exports = async ({github, context, core}) => {
     const fs = require('fs');
     const filename = "pr.txt";
 
+    const labelsData = await github.rest.issues.listLabelsOnIssue({
+        owner: context.repo.owner,
+        repo: context.repo.repo,
+        issue_number: (context.payload.issue || context.payload.pull_request || context.payload).number,
+    });
+
+    const labels = labelsData.data.map((label) => {
+    	return label['name'];
+    });
+
     try {
-        fs.writeFileSync(`./${filename}`, JSON.stringify(context.payload));
+        fs.writeFileSync(`./${filename}`, JSON.stringify({...context.payload, ...{labels:labels.join(",")}}));
 
         return `PR successfully saved ${filename}`
     } catch (err) {

--- a/.github/workflows/reusable_export_pr_details.yml
+++ b/.github/workflows/reusable_export_pr_details.yml
@@ -49,6 +49,9 @@ on:
       prIsMerged:
         description: "Whether PR is merged"
         value: ${{ jobs.export_pr_details.outputs.prIsMerged }}
+      prLabels:
+        description: "PR Labels"
+        value: ${{ jobs.export_pr_details.outputs.prLabels }}
 
 permissions:
   contents: read
@@ -70,6 +73,7 @@ jobs:
       prAuthor: ${{ steps.prAuthor.outputs.prAuthor }}
       prAction: ${{ steps.prAction.outputs.prAction }}
       prIsMerged: ${{ steps.prIsMerged.outputs.prIsMerged }}
+      prLabels: ${{ steps.prLabels.outputs.prLabels }}
     steps:
       - name: Checkout repository # in case caller workflow doesn't checkout thus failing with file not found
         uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac  # v4.0.0
@@ -106,3 +110,6 @@ jobs:
       - name: "Export Pull Request Merged status"
         id: prIsMerged
         run: echo prIsMerged="$(jq -c '.pull_request.merged' "${FILENAME}")" >> "$GITHUB_OUTPUT"
+      - name: "Export Pull Request labels"
+        id: prLabels
+        run: echo prLabels="$(jq -c '.labels' "${FILENAME}")" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
**Issue number:** #1335 

## Summary

### Changes

> Please provide a summary of what's being changed

- save_pr_details.js: saves labels as a part of the PR artifact object
- label_pr_based_on_title.js: removes old labels as they're found based on the list within the same file
- reusable_export_pr_details.yml: adds PR labels as an output.

### User experience

> Please share what the user experience looks like before and after this change

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [X] [Meet tenets criteria](https://docs.powertools.aws.dev/lambda/python/#tenets)
* [X] I have performed a self-review of this change
* [X] Changes have been tested
* [X] Changes are documented
* [X] PR title follows [conventional commit semantics](https://github.com/aws-powertools/powertools-lambda-python/blob/develop/.github/semantic.yml)

<details>
<summary>Is this a breaking change?</summary>

**RFC issue number**:

Checklist:

* [X] Migration process documented
* [X] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
