### PR TITLE
refactor(parameters): BaseProvider._get to also support Dict

### DIFF
--- a/aws_lambda_powertools/utilities/parameters/base.py
+++ b/aws_lambda_powertools/utilities/parameters/base.py
@@ -147,7 +147,7 @@ class BaseProvider(ABC):
         return value
 
     @abstractmethod
-    def _get(self, name: str, **sdk_options) -> Union[str, bytes]:
+    def _get(self, name: str, **sdk_options) -> Union[str, bytes, Dict[str, Any]]:
         """
         Retrieve parameter value from the underlying parameter store
         """

--- a/examples/parameters/src/custom_provider_vault.py
+++ b/examples/parameters/src/custom_provider_vault.py
@@ -1,5 +1,4 @@
-import json
-from typing import Dict
+from typing import Any, Dict
 
 from hvac import Client
 
@@ -8,21 +7,18 @@ from aws_lambda_powertools.utilities.parameters import BaseProvider
 
 class VaultProvider(BaseProvider):
     def __init__(self, vault_url: str, vault_token: str) -> None:
-
         super().__init__()
 
         self.vault_client = Client(url=vault_url, verify=False, timeout=10)
         self.vault_client.token = vault_token
 
-    def _get(self, name: str, **sdk_options) -> str:
-
+    def _get(self, name: str, **sdk_options) -> Dict[str, Any]:
         # for example proposal, the mountpoint is always /secret
         kv_configuration = self.vault_client.secrets.kv.v2.read_secret(path=name)
 
-        return json.dumps(kv_configuration["data"]["data"])
+        return kv_configuration["data"]["data"]
 
     def _get_multiple(self, path: str, **sdk_options) -> Dict[str, str]:
-
         list_secrets = {}
         all_secrets = self.vault_client.secrets.kv.v2.list_secrets(path=path)
 

--- a/examples/parameters/src/working_with_own_provider_vault.py
+++ b/examples/parameters/src/working_with_own_provider_vault.py
@@ -14,10 +14,9 @@ vault_provider = VaultProvider(vault_url="http://192.168.68.105:8200/", vault_to
 
 
 def lambda_handler(event: dict, context: LambdaContext):
-
     try:
         # Retrieve a single parameter
-        endpoint_comments: Any = vault_provider.get("comments_endpoint", transform="json")
+        endpoint_comments: Any = vault_provider.get("comments_endpoint")
 
         # you can get all parameters using get_multiple and specifying vault mount point
         # # for testing purposes we will not use it


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
**Issue number:** #2250 

## Summary

### Changes

This pull request extends the functionality of the `_get` method by adding support for an additional return type, `Dict[str, Any]`. Previously, the method returned either a `str` or `bytes`, limiting its usability with providers that return secrets as dictionary, like [Vault by HashiCorp](https://www.vaultproject.io/).

### User experience

> Please share what the user experience looks like before and after this change

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] [Meet tenets criteria](https://docs.powertools.aws.dev/lambda/python/#tenets)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented
* [x] PR title follows [conventional commit semantics](https://github.com/aws-powertools/powertools-lambda-python/blob/develop/.github/semantic.yml)

<details>
<summary>Is this a breaking change?</summary>

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
