### PR TITLE
docs(we-made-this): fix broken Twitch video embeds

### DIFF
--- a/docs/we_made_this.md
+++ b/docs/we_made_this.md
@@ -106,7 +106,7 @@ When building applications with AWS Lambda it is critical to verify the data str
 
 In this session you will learn how to increase code quality, extensibility and testability, boost you productivity and ship rock solid apps to production.
 
-<iframe src="https://player.twitch.tv/?video=1034744364&parent=awslabs.github.io&autoplay=false" frameborder="0" allowfullscreen="true" scrolling="no" height="378" width="620"></iframe>
+<iframe src="https://player.twitch.tv/?video=1034744364&parent=docs.powertools.aws.dev&autoplay=false" frameborder="0" allowfullscreen="true" scrolling="no" height="378" width="620"></iframe>
 
 #### Talk DEV to me | Feature Flags with AWS Lambda Powertools
 
@@ -114,7 +114,7 @@ In this session you will learn how to increase code quality, extensibility and t
 
 A deep dive in the [Feature Flags](./utilities/feature_flags.md){target="_blank" rel="nofollow"} feature along with tips and tricks.
 
-<iframe src="https://player.twitch.tv/?video=1174133534&parent=awslabs.github.io&autoplay=false" frameborder="0" allowfullscreen="true" scrolling="no" height="378" width="620"></iframe>
+<iframe src="https://player.twitch.tv/?video=1174133534&parent=docs.powertools.aws.dev&autoplay=false" frameborder="0" allowfullscreen="true" scrolling="no" height="378" width="620"></iframe>
 
 #### Level Up Your CI/CD With Smart AWS Feature Flags
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
**Issue number:** #3095 

## Summary

### Changes

This pull request addresses broken Twitch video embeds caused by our recent domain migration. It updates the video URLs to point to the new domain.

Changes Made:

Updated Twitch video URLs in embeds to reflect the new domain.

### User experience

> Please share what the user experience looks like before and after this change

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] [Meet tenets criteria](https://docs.powertools.aws.dev/lambda/python/#tenets)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [ ] Changes are documented
* [x] PR title follows [conventional commit semantics](https://github.com/aws-powertools/powertools-lambda-python/blob/develop/.github/semantic.yml)

<details>
<summary>Is this a breaking change?</summary>

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
