### PR TITLE
fix(metrics): support additional arguments in functions wrapped with log_metrics decorator

### DIFF
--- a/aws_lambda_powertools/metrics/base.py
+++ b/aws_lambda_powertools/metrics/base.py
@@ -378,11 +378,11 @@ class MetricManager:
             )
 
         @functools.wraps(lambda_handler)
-        def decorate(event, context):
+        def decorate(event, context, *args, **kwargs):
             try:
                 if default_dimensions:
                     self.set_default_dimensions(**default_dimensions)
-                response = lambda_handler(event, context)
+                response = lambda_handler(event, context, *args, **kwargs)
                 if capture_cold_start_metric:
                     self._add_cold_start_metric(context=context)
             finally:

--- a/aws_lambda_powertools/metrics/provider/base.py
+++ b/aws_lambda_powertools/metrics/provider/base.py
@@ -199,9 +199,9 @@ class BaseProvider(ABC):
             )
 
         @functools.wraps(lambda_handler)
-        def decorate(event, context):
+        def decorate(event, context, *args, **kwargs):
             try:
-                response = lambda_handler(event, context)
+                response = lambda_handler(event, context, *args, **kwargs)
                 if capture_cold_start_metric:
                     self._add_cold_start_metric(context=context)
             finally:

--- a/tests/functional/metrics/test_metrics_cloudwatch_emf.py
+++ b/tests/functional/metrics/test_metrics_cloudwatch_emf.py
@@ -355,6 +355,22 @@ def test_log_metrics_decorator_call_decorated_function(metric, namespace, servic
     assert lambda_handler({}, {}) is True
 
 
+def test_log_metrics_decorator_with_additional_handler_args(namespace, service):
+    # GIVEN Metrics is initialized
+    my_metrics = Metrics(service=service, namespace=namespace)
+
+    # WHEN log_metrics is used to serialize metrics
+    # AND the wrapped function uses additional parameters
+    @my_metrics.log_metrics
+    def lambda_handler(evt, context, additional_arg, additional_kw_arg="default_value"):
+        return additional_arg, additional_kw_arg
+
+    # THEN the decorator should not raise any errors when
+    # the wrapped function is passed additional arguments
+    assert lambda_handler({}, {}, "arg_value", additional_kw_arg="kw_arg_value") == ("arg_value", "kw_arg_value")
+    assert lambda_handler({}, {}, "arg_value") == ("arg_value", "default_value")
+
+
 def test_schema_validation_incorrect_metric_resolution(metric, dimension):
     # GIVEN we pass a metric resolution that is not supported by CloudWatch
     metric["resolution"] = 10  # metric resolution must be 1 (High) or 60 (Standard)

--- a/tests/functional/metrics/test_metrics_datadog.py
+++ b/tests/functional/metrics/test_metrics_datadog.py
@@ -136,6 +136,22 @@ def test_metrics_decorator_with_metrics_warning():
         )
 
 
+def test_datadog_log_metrics_decorator_with_additional_handler_args():
+    # GIVEN DatadogMetrics is initialized
+    my_metrics = DatadogMetrics(flush_to_log=True)
+
+    # WHEN log_metrics is used to serialize metrics
+    # AND the wrapped function uses additional parameters
+    @my_metrics.log_metrics
+    def lambda_handler(evt, context, additional_arg, additional_kw_arg="default_value"):
+        return additional_arg, additional_kw_arg
+
+    # THEN the decorator should not raise any errors when
+    # the wrapped function is passed additional arguments
+    assert lambda_handler({}, {}, "arg_value", additional_kw_arg="kw_arg_value") == ("arg_value", "kw_arg_value")
+    assert lambda_handler({}, {}, "arg_value") == ("arg_value", "default_value")
+
+
 def test_metrics_with_default_namespace(capsys, namespace):
     # GIVEN DatadogMetrics is initialized with default namespace
     metrics = DatadogMetrics(flush_to_log=True)

--- a/tests/functional/metrics/test_metrics_provider.py
+++ b/tests/functional/metrics/test_metrics_provider.py
@@ -60,3 +60,19 @@ def test_metrics_provider_class_decorate():
     # THEN log_metrics should invoke the function it decorates
     # and return no error if we have a namespace and dimension
     assert lambda_handler({}, {}) is True
+
+
+def test_metrics_provider_class_decorator_with_additional_handler_args():
+    # GIVEN Metrics is initialized
+    my_metrics = Metrics()
+
+    # WHEN log_metrics is used to serialize metrics
+    # AND the wrapped function uses additional parameters
+    @my_metrics.log_metrics
+    def lambda_handler(evt, context, additional_arg, additional_kw_arg="default_value"):
+        return additional_arg, additional_kw_arg
+
+    # THEN the decorator should not raise any errors when
+    # the wrapped function is passed additional arguments
+    assert lambda_handler({}, {}, "arg_value", additional_kw_arg="kw_arg_value") == ("arg_value", "kw_arg_value")
+    assert lambda_handler({}, {}, "arg_value") == ("arg_value", "default_value")


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
**Issue number: #3119**

## Summary

### Changes

> Please provide a summary of what's being changed

Allow a function wrapped by the `@metrics.log_metrics` decorator to accept arguments besides the event and lambda context. The `decorate()` function now takes in `*args` and `**kwargs` as arguments and then passes them to the `lambda_handler()` call.

### User experience

> Please share what the user experience looks like before and after this change

Previously, the user would experience a "wrong number of positional arguments" or "unexpected keyword argument" TypeError when attempting to call a function wrapped by the decorator (e.g. lambda handler) with additional arguments.

After this change, the user is able to successfully pass additional arguments, positional or keyword, to the wrapped function without raising any errors.

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] [Meet tenets criteria](https://docs.powertools.aws.dev/lambda/python/#tenets)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [ ] Changes are documented
* [x] PR title follows [conventional commit semantics](https://github.com/aws-powertools/powertools-lambda-python/blob/develop/.github/semantic.yml)

<details>
<summary>Is this a breaking change?</summary>

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

</details>

No, this is not a breaking change.

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
