### PR TITLE
fix(parameters): Respect POWERTOOLS_PARAMETERS_SSM_DECRYPT environment variable when getting multiple ssm parameters.

### DIFF
--- a/aws_lambda_powertools/utilities/parameters/ssm.py
+++ b/aws_lambda_powertools/utilities/parameters/ssm.py
@@ -188,7 +188,7 @@ class SSMProvider(BaseProvider):
 
         return self.client.get_parameter(**sdk_options)["Parameter"]["Value"]
 
-    def _get_multiple(self, path: str, decrypt: bool = False, recursive: bool = False, **sdk_options) -> Dict[str, str]:
+    def _get_multiple(self, path: str, decrypt: Optional[bool] = None, recursive: bool = False, **sdk_options) -> Dict[str, str]:
         """
         Retrieve multiple parameter values from AWS Systems Manager Parameter Store
 
@@ -203,6 +203,12 @@ class SSMProvider(BaseProvider):
         sdk_options: dict, optional
             Dictionary of options that will be passed to the Parameter Store get_parameters_by_path API call
         """
+
+        # If decrypt is not set, resolve it from the environment variable, defaulting to False
+        decrypt = resolve_truthy_env_var_choice(
+            env=os.getenv(constants.PARAMETERS_SSM_DECRYPT_ENV, "false"),
+            choice=decrypt,
+        )
 
         # Explicit arguments will take precedence over keyword arguments
         sdk_options["Path"] = path

--- a/tests/functional/test_utilities_parameters.py
+++ b/tests/functional/test_utilities_parameters.py
@@ -960,6 +960,53 @@ def test_ssm_provider_get_sdk_options_overwrite(mock_name, mock_value, mock_vers
         stubber.deactivate()
 
 
+def test_ssm_provider_get_multiple_with_decrypt_environment_variable(monkeypatch, mock_name, mock_value, mock_version, config):
+    """
+    Test SSMProvider.get_multiple() with decrypt value replaced by environment variable
+    """
+
+    # Setting environment variable to override the default value
+    monkeypatch.setenv("POWERTOOLS_PARAMETERS_SSM_DECRYPT", "true")
+
+    mock_param_names = ["A", "B", "C"]
+
+    # Create a new provider
+    provider = parameters.SSMProvider(config=config)
+
+    # Stub the boto3 client
+    stubber = stub.Stubber(provider.client)
+    response = {
+        "Parameters": [
+            {
+                "Name": f"{mock_name}/{name}",
+                "Type": "String",
+                "Value": f"{mock_value}/{name}",
+                "Version": mock_version,
+                "Selector": f"{mock_name}/{name}:{mock_version}",
+                "SourceResult": "string",
+                "LastModifiedDate": datetime(2015, 1, 1),
+                "ARN": f"arn:aws:ssm:us-east-2:111122223333:parameter/{mock_name}/{name}",
+            }
+            for name in mock_param_names
+        ],
+    }
+    expected_params = {"Path": mock_name, "Recursive": False, "WithDecryption": True}
+    stubber.add_response("get_parameters_by_path", response, expected_params)
+    stubber.activate()
+
+    try:
+        values = provider.get_multiple(mock_name)
+
+        stubber.assert_no_pending_responses()
+
+        assert len(values) == len(mock_param_names)
+        for name in mock_param_names:
+            assert name in values
+            assert values[name] == f"{mock_value}/{name}"
+    finally:
+        stubber.deactivate()
+
+
 def test_ssm_provider_get_multiple(mock_name, mock_value, mock_version, config):
     """
     Test SSMProvider.get_multiple() with a non-cached path


### PR DESCRIPTION
When getting multiple ssm parameters by path, the `POWERTOOLS_PARAMETERS_SSM_DECRYPT` environment variable should be respected as to whether to automatically decrypt the values, as is with the single `get`.

<!-- markdownlint-disable MD041 MD043 -->
**Issue number: 3240**

## Summary

Check the value of the `POWERTOOLS_PARAMETERS_SSM_DECRYPT` and respect that when deciding
whether to decrypt multiple parameters that were loaded.

### Changes

> The `get_multiple` method of the ssm provider will check the value of the environment variable, when deciding
whether to decrypt. The default remains false for the case where none exists, or no explicit parameter is passed.

### User experience

> The user can get multiple parameters, decrypted, by setting the environment variable.

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] [Meet tenets criteria](https://docs.powertools.aws.dev/lambda/python/#tenets)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [ ] Changes are documented
* [x] PR title follows [conventional commit semantics](https://github.com/aws-powertools/powertools-lambda-python/blob/develop/.github/semantic.yml)

<details>
<summary>Is this a breaking change?</summary>

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
