### PR TITLE
fix(event_handler): apply serialization as the last operation for middlewares

### DIFF
--- a/aws_lambda_powertools/event_handler/api_gateway.py
+++ b/aws_lambda_powertools/event_handler/api_gateway.py
@@ -783,7 +783,10 @@ class ResponseBuilder(Generic[ResponseEventT]):
             logger.debug("Encoding bytes response with base64")
             self.response.base64_encoded = True
             self.response.body = base64.b64encode(self.response.body).decode()
-        elif self.response.is_json():
+
+        # We only apply the serializer when the content type is JSON and the
+        # body is not a str, to avoid double encoding
+        elif self.response.is_json() and not isinstance(self.response.body, str):
             self.response.body = self.serializer(self.response.body)
 
         return {

--- a/aws_lambda_powertools/event_handler/api_gateway.py
+++ b/aws_lambda_powertools/event_handler/api_gateway.py
@@ -702,7 +702,7 @@ class ResponseBuilder(Generic[ResponseEventT]):
     def __init__(
         self,
         response: Response,
-        serializer: Optional[Callable[[Any], str]] = json.dumps,
+        serializer: Callable[[Any], str] = json.dumps,
         route: Optional[Route] = None,
     ):
         self.response = response

--- a/aws_lambda_powertools/event_handler/api_gateway.py
+++ b/aws_lambda_powertools/event_handler/api_gateway.py
@@ -699,7 +699,12 @@ class Route:
 class ResponseBuilder(Generic[ResponseEventT]):
     """Internally used Response builder"""
 
-    def __init__(self, response: Response, serializer: Callable[[Any], str], route: Optional[Route] = None):
+    def __init__(
+        self,
+        response: Response,
+        serializer: Optional[Callable[[Any], str]] = json.dumps,
+        route: Optional[Route] = None,
+    ):
         self.response = response
         self.serializer = serializer
         self.route = route

--- a/aws_lambda_powertools/event_handler/api_gateway.py
+++ b/aws_lambda_powertools/event_handler/api_gateway.py
@@ -699,8 +699,9 @@ class Route:
 class ResponseBuilder(Generic[ResponseEventT]):
     """Internally used Response builder"""
 
-    def __init__(self, response: Response, route: Optional[Route] = None):
+    def __init__(self, response: Response, serializer: Callable[[Any], str], route: Optional[Route] = None):
         self.response = response
+        self.serializer = serializer
         self.route = route
 
     def _add_cors(self, event: ResponseEventT, cors: CORSConfig):
@@ -782,6 +783,8 @@ class ResponseBuilder(Generic[ResponseEventT]):
             logger.debug("Encoding bytes response with base64")
             self.response.base64_encoded = True
             self.response.body = base64.b64encode(self.response.body).decode()
+        elif self.response.is_json():
+            self.response.body = self.serializer(self.response.body)
 
         return {
             "statusCode": self.response.status_code,
@@ -1332,14 +1335,6 @@ class ApiGatewayResolver(BaseRouter):
 
             self.use([OpenAPIValidationMiddleware()])
 
-            # When using validation, we need to skip the serializer, as the middleware is doing it automatically.
-            # However, if the user is using a custom serializer, we need to abort.
-            if serializer:
-                raise ValueError("Cannot use a custom serializer when using validation")
-
-            # Install a dummy serializer
-            self._serializer = lambda args: args  # type: ignore
-
     def get_openapi_schema(
         self,
         *,
@@ -1717,7 +1712,7 @@ class ApiGatewayResolver(BaseRouter):
             event = event.raw_event
 
         if self._debug:
-            print(self._json_dump(event))
+            print(self._serializer(event))
 
         # Populate router(s) dependencies without keeping a reference to each registered router
         BaseRouter.current_event = self._to_proxy_event(event)
@@ -1881,19 +1876,23 @@ class ApiGatewayResolver(BaseRouter):
             if method == "OPTIONS":
                 logger.debug("Pre-flight request detected. Returning CORS with null response")
                 headers["Access-Control-Allow-Methods"] = ",".join(sorted(self._cors_methods))
-                return ResponseBuilder(Response(status_code=204, content_type=None, headers=headers, body=""))
+                return ResponseBuilder(
+                    response=Response(status_code=204, content_type=None, headers=headers, body=""),
+                    serializer=self._serializer,
+                )
 
         handler = self._lookup_exception_handler(NotFoundError)
         if handler:
-            return self._response_builder_class(handler(NotFoundError()))
+            return self._response_builder_class(response=handler(NotFoundError()), serializer=self._serializer)
 
         return self._response_builder_class(
-            Response(
+            response=Response(
                 status_code=HTTPStatus.NOT_FOUND.value,
                 content_type=content_types.APPLICATION_JSON,
                 headers=headers,
-                body=self._json_dump({"statusCode": HTTPStatus.NOT_FOUND.value, "message": "Not found"}),
+                body={"statusCode": HTTPStatus.NOT_FOUND.value, "message": "Not found"},
             ),
+            serializer=self._serializer,
         )
 
     def _call_route(self, route: Route, route_arguments: Dict[str, str]) -> ResponseBuilder:
@@ -1903,10 +1902,11 @@ class ApiGatewayResolver(BaseRouter):
             self._reset_processed_stack()
 
             return self._response_builder_class(
-                self._to_response(
+                response=self._to_response(
                     route(router_middlewares=self._router_middlewares, app=self, route_arguments=route_arguments),
                 ),
-                route,
+                serializer=self._serializer,
+                route=route,
             )
         except Exception as exc:
             # If exception is handled then return the response builder to reduce noise
@@ -1920,12 +1920,13 @@ class ApiGatewayResolver(BaseRouter):
                 # we'll let the original exception propagate, so
                 # they get more information about what went wrong.
                 return self._response_builder_class(
-                    Response(
+                    response=Response(
                         status_code=500,
                         content_type=content_types.TEXT_PLAIN,
                         body="".join(traceback.format_exc()),
                     ),
-                    route,
+                    serializer=self._serializer,
+                    route=route,
                 )
 
             raise
@@ -1958,18 +1959,19 @@ class ApiGatewayResolver(BaseRouter):
         handler = self._lookup_exception_handler(type(exp))
         if handler:
             try:
-                return self._response_builder_class(handler(exp), route)
+                return self._response_builder_class(response=handler(exp), serializer=self._serializer, route=route)
             except ServiceError as service_error:
                 exp = service_error
 
         if isinstance(exp, ServiceError):
             return self._response_builder_class(
-                Response(
+                response=Response(
                     status_code=exp.status_code,
                     content_type=content_types.APPLICATION_JSON,
-                    body=self._json_dump({"statusCode": exp.status_code, "message": exp.msg}),
+                    body={"statusCode": exp.status_code, "message": exp.msg},
                 ),
-                route,
+                serializer=self._serializer,
+                route=route,
             )
 
         return None
@@ -1995,11 +1997,8 @@ class ApiGatewayResolver(BaseRouter):
         return Response(
             status_code=status_code,
             content_type=content_types.APPLICATION_JSON,
-            body=self._json_dump(result),
+            body=result,
         )
-
-    def _json_dump(self, obj: Any) -> str:
-        return self._serializer(obj)
 
     def include_router(self, router: "Router", prefix: Optional[str] = None) -> None:
         """Adds all routes and context defined in a router

--- a/aws_lambda_powertools/event_handler/bedrock_agent.py
+++ b/aws_lambda_powertools/event_handler/bedrock_agent.py
@@ -24,7 +24,7 @@ class BedrockResponseBuilder(ResponseBuilder):
         self._route(event, None)
 
         body = self.response.body
-        if self.response.is_json():
+        if self.response.is_json() and not isinstance(self.response.body, str):
             body = self.serializer(self.response.body)
 
         return {

--- a/aws_lambda_powertools/event_handler/bedrock_agent.py
+++ b/aws_lambda_powertools/event_handler/bedrock_agent.py
@@ -23,6 +23,10 @@ class BedrockResponseBuilder(ResponseBuilder):
         """Build the full response dict to be returned by the lambda"""
         self._route(event, None)
 
+        body = self.response.body
+        if self.response.is_json():
+            body = self.serializer(self.response.body)
+
         return {
             "messageVersion": "1.0",
             "response": {
@@ -32,7 +36,7 @@ class BedrockResponseBuilder(ResponseBuilder):
                 "httpStatusCode": self.response.status_code,
                 "responseBody": {
                     self.response.content_type: {
-                        "body": self.response.body,
+                        "body": body,
                     },
                 },
             },

--- a/aws_lambda_powertools/event_handler/middlewares/openapi_validation.py
+++ b/aws_lambda_powertools/event_handler/middlewares/openapi_validation.py
@@ -112,9 +112,9 @@ class OpenAPIValidationMiddleware(BaseMiddlewareHandler):
         if response.body:
             # Validate and serialize the response, if it's JSON
             if response.is_json():
-                response.body = json.dumps(
-                    self._serialize_response(field=route.dependant.return_param, response_content=response.body),
-                    sort_keys=True,
+                response.body = self._serialize_response(
+                    field=route.dependant.return_param,
+                    response_content=response.body,
                 )
 
         return response

--- a/tests/functional/event_handler/test_api_gateway.py
+++ b/tests/functional/event_handler/test_api_gateway.py
@@ -367,7 +367,7 @@ def test_override_route_compress_parameter():
     # AND the Response object with compress=False
     app = ApiGatewayResolver()
     mock_event = {"path": "/my/request", "httpMethod": "GET", "headers": {"Accept-Encoding": "deflate, gzip"}}
-    expected_value = '{"test": "value"}'
+    expected_value = {"test": "value"}
 
     @app.get("/my/request", compress=True)
     def with_compression() -> Response:
@@ -379,9 +379,9 @@ def test_override_route_compress_parameter():
     # WHEN calling the event handler
     result = handler(mock_event, None)
 
-    # THEN then the response is not compressed
+    # THEN the response is not compressed
     assert result["isBase64Encoded"] is False
-    assert result["body"] == expected_value
+    assert json.loads(result["body"]) == expected_value
     assert result["multiValueHeaders"].get("Content-Encoding") is None
 
 
@@ -681,7 +681,7 @@ def test_custom_cors_config():
 def test_no_content_response():
     # GIVEN a response with no content-type or body
     response = Response(status_code=204, content_type=None, body=None, headers=None)
-    response_builder = ResponseBuilder(response)
+    response_builder = ResponseBuilder(response, serializer=json.dumps)
 
     # WHEN calling to_dict
     result = response_builder.build(APIGatewayProxyEvent(LOAD_GW_EVENT))
@@ -1482,7 +1482,7 @@ def test_exception_handler_service_error():
     # THEN call the exception_handler
     assert result["statusCode"] == 500
     assert result["multiValueHeaders"]["Content-Type"] == [content_types.APPLICATION_JSON]
-    assert result["body"] == "CUSTOM ERROR FORMAT"
+    assert result["body"] == '"CUSTOM ERROR FORMAT"'
 
 
 def test_exception_handler_not_found():
@@ -1778,11 +1778,11 @@ def test_route_match_prioritize_full_match():
 
     @router.get("/my/{path}")
     def dynamic_handler() -> Response:
-        return Response(200, content_types.APPLICATION_JSON, json.dumps({"hello": "dynamic"}))
+        return Response(200, content_types.APPLICATION_JSON, {"hello": "dynamic"})
 
     @router.get("/my/path")
     def static_handler() -> Response:
-        return Response(200, content_types.APPLICATION_JSON, json.dumps({"hello": "static"}))
+        return Response(200, content_types.APPLICATION_JSON, {"hello": "static"})
 
     app.include_router(router)
 

--- a/tests/functional/event_handler/test_api_gateway.py
+++ b/tests/functional/event_handler/test_api_gateway.py
@@ -681,7 +681,7 @@ def test_custom_cors_config():
 def test_no_content_response():
     # GIVEN a response with no content-type or body
     response = Response(status_code=204, content_type=None, body=None, headers=None)
-    response_builder = ResponseBuilder(response, serializer=json.dumps)
+    response_builder = ResponseBuilder(response)
 
     # WHEN calling to_dict
     result = response_builder.build(APIGatewayProxyEvent(LOAD_GW_EVENT))

--- a/tests/functional/event_handler/test_api_gateway.py
+++ b/tests/functional/event_handler/test_api_gateway.py
@@ -1482,7 +1482,7 @@ def test_exception_handler_service_error():
     # THEN call the exception_handler
     assert result["statusCode"] == 500
     assert result["multiValueHeaders"]["Content-Type"] == [content_types.APPLICATION_JSON]
-    assert result["body"] == '"CUSTOM ERROR FORMAT"'
+    assert result["body"] == "CUSTOM ERROR FORMAT"
 
 
 def test_exception_handler_not_found():

--- a/tests/functional/event_handler/test_api_gateway.py
+++ b/tests/functional/event_handler/test_api_gateway.py
@@ -367,7 +367,7 @@ def test_override_route_compress_parameter():
     # AND the Response object with compress=False
     app = ApiGatewayResolver()
     mock_event = {"path": "/my/request", "httpMethod": "GET", "headers": {"Accept-Encoding": "deflate, gzip"}}
-    expected_value = {"test": "value"}
+    expected_value = '{"test": "value"}'
 
     @app.get("/my/request", compress=True)
     def with_compression() -> Response:
@@ -381,7 +381,7 @@ def test_override_route_compress_parameter():
 
     # THEN the response is not compressed
     assert result["isBase64Encoded"] is False
-    assert json.loads(result["body"]) == expected_value
+    assert result["body"] == expected_value
     assert result["multiValueHeaders"].get("Content-Encoding") is None
 
 
@@ -1778,11 +1778,11 @@ def test_route_match_prioritize_full_match():
 
     @router.get("/my/{path}")
     def dynamic_handler() -> Response:
-        return Response(200, content_types.APPLICATION_JSON, {"hello": "dynamic"})
+        return Response(200, content_types.APPLICATION_JSON, json.dumps({"hello": "dynamic"}))
 
     @router.get("/my/path")
     def static_handler() -> Response:
-        return Response(200, content_types.APPLICATION_JSON, {"hello": "static"})
+        return Response(200, content_types.APPLICATION_JSON, json.dumps({"hello": "static"}))
 
     app.include_router(router)
 

--- a/tests/functional/event_handler/test_base_path.py
+++ b/tests/functional/event_handler/test_base_path.py
@@ -21,7 +21,7 @@ def test_base_path_api_gateway_rest():
 
     result = app(event, {})
     assert result["statusCode"] == 200
-    assert result["body"] == ""
+    assert result["body"] == '""'
 
 
 def test_base_path_api_gateway_http():
@@ -38,7 +38,7 @@ def test_base_path_api_gateway_http():
 
     result = app(event, {})
     assert result["statusCode"] == 200
-    assert result["body"] == ""
+    assert result["body"] == '""'
 
 
 def test_base_path_alb():
@@ -53,7 +53,7 @@ def test_base_path_alb():
 
     result = app(event, {})
     assert result["statusCode"] == 200
-    assert result["body"] == ""
+    assert result["body"] == '""'
 
 
 def test_base_path_lambda_function_url():
@@ -70,7 +70,7 @@ def test_base_path_lambda_function_url():
 
     result = app(event, {})
     assert result["statusCode"] == 200
-    assert result["body"] == ""
+    assert result["body"] == '""'
 
 
 def test_vpc_lattice():
@@ -85,7 +85,7 @@ def test_vpc_lattice():
 
     result = app(event, {})
     assert result["statusCode"] == 200
-    assert result["body"] == ""
+    assert result["body"] == '""'
 
 
 def test_vpc_latticev2():
@@ -100,4 +100,4 @@ def test_vpc_latticev2():
 
     result = app(event, {})
     assert result["statusCode"] == 200
-    assert result["body"] == ""
+    assert result["body"] == '""'

--- a/tests/functional/event_handler/test_base_path.py
+++ b/tests/functional/event_handler/test_base_path.py
@@ -21,7 +21,7 @@ def test_base_path_api_gateway_rest():
 
     result = app(event, {})
     assert result["statusCode"] == 200
-    assert result["body"] == '""'
+    assert result["body"] == ""
 
 
 def test_base_path_api_gateway_http():
@@ -38,7 +38,7 @@ def test_base_path_api_gateway_http():
 
     result = app(event, {})
     assert result["statusCode"] == 200
-    assert result["body"] == '""'
+    assert result["body"] == ""
 
 
 def test_base_path_alb():
@@ -53,7 +53,7 @@ def test_base_path_alb():
 
     result = app(event, {})
     assert result["statusCode"] == 200
-    assert result["body"] == '""'
+    assert result["body"] == ""
 
 
 def test_base_path_lambda_function_url():
@@ -70,7 +70,7 @@ def test_base_path_lambda_function_url():
 
     result = app(event, {})
     assert result["statusCode"] == 200
-    assert result["body"] == '""'
+    assert result["body"] == ""
 
 
 def test_vpc_lattice():
@@ -85,7 +85,7 @@ def test_vpc_lattice():
 
     result = app(event, {})
     assert result["statusCode"] == 200
-    assert result["body"] == '""'
+    assert result["body"] == ""
 
 
 def test_vpc_latticev2():
@@ -100,4 +100,4 @@ def test_vpc_latticev2():
 
     result = app(event, {})
     assert result["statusCode"] == 200
-    assert result["body"] == '""'
+    assert result["body"] == ""

--- a/tests/functional/event_handler/test_bedrock_agent.py
+++ b/tests/functional/event_handler/test_bedrock_agent.py
@@ -31,7 +31,7 @@ def test_bedrock_agent_event():
     assert result["response"]["httpStatusCode"] == 200
 
     body = result["response"]["responseBody"]["application/json"]["body"]
-    assert body == json.dumps({"output": claims_response})
+    assert json.loads(body) == {"output": claims_response}
 
 
 def test_bedrock_agent_with_path_params():
@@ -79,7 +79,7 @@ def test_bedrock_agent_event_with_response():
     assert result["response"]["httpStatusCode"] == 200
 
     body = result["response"]["responseBody"]["application/json"]["body"]
-    assert body == json.dumps(output)
+    assert json.loads(body) == output
 
 
 def test_bedrock_agent_event_with_no_matches():

--- a/tests/functional/event_handler/test_openapi_validation_middleware.py
+++ b/tests/functional/event_handler/test_openapi_validation_middleware.py
@@ -4,7 +4,6 @@ from enum import Enum
 from pathlib import PurePath
 from typing import List, Tuple
 
-import pytest
 from pydantic import BaseModel
 
 from aws_lambda_powertools.event_handler import APIGatewayRestResolver
@@ -13,11 +12,6 @@ from aws_lambda_powertools.shared.types import Annotated
 from tests.functional.utils import load_event
 
 LOAD_GW_EVENT = load_event("apiGatewayProxyEvent.json")
-
-
-def test_validate_with_customn_serializer():
-    with pytest.raises(ValueError):
-        APIGatewayRestResolver(enable_validation=True, serializer=json.dumps)
 
 
 def test_validate_scalars():
@@ -128,7 +122,7 @@ def test_validate_return_list():
     # THEN the body must be [123, 234]
     result = app(LOAD_GW_EVENT, {})
     assert result["statusCode"] == 200
-    assert result["body"] == "[123, 234]"
+    assert json.loads(result["body"]) == [123, 234]
 
 
 def test_validate_return_tuple():
@@ -148,7 +142,7 @@ def test_validate_return_tuple():
     # THEN the body must be a tuple
     result = app(LOAD_GW_EVENT, {})
     assert result["statusCode"] == 200
-    assert result["body"] == "[1, 2, 3]"
+    assert json.loads(result["body"]) == [1, 2, 3]
 
 
 def test_validate_return_purepath():

--- a/tests/functional/event_handler/test_openapi_validation_middleware.py
+++ b/tests/functional/event_handler/test_openapi_validation_middleware.py
@@ -163,7 +163,7 @@ def test_validate_return_purepath():
     # THEN the body must be a string
     result = app(LOAD_GW_EVENT, {})
     assert result["statusCode"] == 200
-    assert result["body"] == json.dumps(sample_path.as_posix())
+    assert result["body"] == sample_path.as_posix()
 
 
 def test_validate_return_enum():
@@ -184,7 +184,7 @@ def test_validate_return_enum():
     # THEN the body must be a string
     result = app(LOAD_GW_EVENT, {})
     assert result["statusCode"] == 200
-    assert result["body"] == '"powertools"'
+    assert result["body"] == "powertools"
 
 
 def test_validate_return_dataclass():


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->

**Issue number:** #3391

## Summary

### Changes

> Please provide a summary of what's being changed

This PR moves the serialization on event handler to the very last step before returning to the client. This allows all middlewares to see the original returns from the handler.

The serialization is also only applied if the content type of the response is JSON. This means we don't try to apply the serialization to HTML or PLAIN responses.

### User experience

> Please share what the user experience looks like before and after this change

After this PR, a user can again use a custom serializer, even when using data validation.

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

- [x] [Meet tenets criteria](https://docs.powertools.aws.dev/lambda/python/#tenets)
- [x] I have performed a self-review of this change
- [x] Changes have been tested
- [x] Changes are documented
- [x] PR title follows [conventional commit semantics](https://github.com/aws-powertools/powertools-lambda-python/blob/develop/.github/semantic.yml)

<details>
<summary>Is this a breaking change?</summary>

**RFC issue number**:

Checklist:

- [ ] Migration process documented
- [ ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
