### PR TITLE
feat(event_handler): allow customers to catch request validation errors

### DIFF
--- a/aws_lambda_powertools/event_handler/api_gateway.py
+++ b/aws_lambda_powertools/event_handler/api_gateway.py
@@ -789,6 +789,8 @@ class ResponseBuilder(Generic[ResponseEventT]):
             logger.debug("Encoding bytes response with base64")
             self.response.base64_encoded = True
             self.response.body = base64.b64encode(self.response.body).decode()
+        elif self.response.is_json():
+            self.response.body = self.serializer(self.response.body)
 
         # We only apply the serializer when the content type is JSON and the
         # body is not a str, to avoid double encoding

--- a/aws_lambda_powertools/event_handler/api_gateway.py
+++ b/aws_lambda_powertools/event_handler/api_gateway.py
@@ -789,7 +789,10 @@ class ResponseBuilder(Generic[ResponseEventT]):
             logger.debug("Encoding bytes response with base64")
             self.response.base64_encoded = True
             self.response.body = base64.b64encode(self.response.body).decode()
-        elif self.response.is_json():
+
+        # We only apply the serializer when the content type is JSON and the
+        # body is not a str, to avoid double encoding
+        elif self.response.is_json() and not isinstance(self.response.body, str):
             self.response.body = self.serializer(self.response.body)
 
         # We only apply the serializer when the content type is JSON and the

--- a/aws_lambda_powertools/event_handler/api_gateway.py
+++ b/aws_lambda_powertools/event_handler/api_gateway.py
@@ -795,11 +795,6 @@ class ResponseBuilder(Generic[ResponseEventT]):
         elif self.response.is_json() and not isinstance(self.response.body, str):
             self.response.body = self.serializer(self.response.body)
 
-        # We only apply the serializer when the content type is JSON and the
-        # body is not a str, to avoid double encoding
-        elif self.response.is_json() and not isinstance(self.response.body, str):
-            self.response.body = self.serializer(self.response.body)
-
         return {
             "statusCode": self.response.status_code,
             "body": self.response.body,

--- a/aws_lambda_powertools/event_handler/middlewares/openapi_validation.py
+++ b/aws_lambda_powertools/event_handler/middlewares/openapi_validation.py
@@ -62,50 +62,43 @@ class OpenAPIValidationMiddleware(BaseMiddlewareHandler):
         values: Dict[str, Any] = {}
         errors: List[Any] = []
 
-        try:
-            # Process path values, which can be found on the route_args
-            path_values, path_errors = _request_params_to_args(
-                route.dependant.path_params,
-                app.context["_route_args"],
+        # Process path values, which can be found on the route_args
+        path_values, path_errors = _request_params_to_args(
+            route.dependant.path_params,
+            app.context["_route_args"],
+        )
+
+        # Process query values
+        query_values, query_errors = _request_params_to_args(
+            route.dependant.query_params,
+            app.current_event.query_string_parameters or {},
+        )
+
+        values.update(path_values)
+        values.update(query_values)
+        errors += path_errors + query_errors
+
+        # Process the request body, if it exists
+        if route.dependant.body_params:
+            (body_values, body_errors) = _request_body_to_args(
+                required_params=route.dependant.body_params,
+                received_body=self._get_body(app),
             )
+            values.update(body_values)
+            errors.extend(body_errors)
 
-            # Process query values
-            query_values, query_errors = _request_params_to_args(
-                route.dependant.query_params,
-                app.current_event.query_string_parameters or {},
-            )
+        if errors:
+            # Raise the validation errors
+            raise RequestValidationError(_normalize_errors(errors))
+        else:
+            # Re-write the route_args with the validated values, and call the next middleware
+            app.context["_route_args"] = values
 
-            values.update(path_values)
-            values.update(query_values)
-            errors += path_errors + query_errors
+            # Call the handler by calling the next middleware
+            response = next_middleware(app)
 
-            # Process the request body, if it exists
-            if route.dependant.body_params:
-                (body_values, body_errors) = _request_body_to_args(
-                    required_params=route.dependant.body_params,
-                    received_body=self._get_body(app),
-                )
-                values.update(body_values)
-                errors.extend(body_errors)
-
-            if errors:
-                # Raise the validation errors
-                raise RequestValidationError(_normalize_errors(errors))
-            else:
-                # Re-write the route_args with the validated values, and call the next middleware
-                app.context["_route_args"] = values
-
-                # Call the handler by calling the next middleware
-                response = next_middleware(app)
-
-                # Process the response
-                return self._handle_response(route=route, response=response)
-        except RequestValidationError as e:
-            return Response(
-                status_code=422,
-                content_type="application/json",
-                body=json.dumps({"detail": e.errors()}),
-            )
+            # Process the response
+            return self._handle_response(route=route, response=response)
 
     def _handle_response(self, *, route: Route, response: Response):
         # Process the response body if it exists

--- a/tests/functional/event_handler/test_api_gateway.py
+++ b/tests/functional/event_handler/test_api_gateway.py
@@ -367,7 +367,7 @@ def test_override_route_compress_parameter():
     # AND the Response object with compress=False
     app = ApiGatewayResolver()
     mock_event = {"path": "/my/request", "httpMethod": "GET", "headers": {"Accept-Encoding": "deflate, gzip"}}
-    expected_value = '{"test": "value"}'
+    expected_value = {"test": "value"}
 
     @app.get("/my/request", compress=True)
     def with_compression() -> Response:
@@ -381,7 +381,7 @@ def test_override_route_compress_parameter():
 
     # THEN the response is not compressed
     assert result["isBase64Encoded"] is False
-    assert result["body"] == expected_value
+    assert json.loads(result["body"]) == expected_value
     assert result["multiValueHeaders"].get("Content-Encoding") is None
 
 
@@ -681,7 +681,7 @@ def test_custom_cors_config():
 def test_no_content_response():
     # GIVEN a response with no content-type or body
     response = Response(status_code=204, content_type=None, body=None, headers=None)
-    response_builder = ResponseBuilder(response)
+    response_builder = ResponseBuilder(response, serializer=json.dumps)
 
     # WHEN calling to_dict
     result = response_builder.build(APIGatewayProxyEvent(LOAD_GW_EVENT))
@@ -1482,7 +1482,7 @@ def test_exception_handler_service_error():
     # THEN call the exception_handler
     assert result["statusCode"] == 500
     assert result["multiValueHeaders"]["Content-Type"] == [content_types.APPLICATION_JSON]
-    assert result["body"] == "CUSTOM ERROR FORMAT"
+    assert result["body"] == '"CUSTOM ERROR FORMAT"'
 
 
 def test_exception_handler_not_found():
@@ -1778,11 +1778,11 @@ def test_route_match_prioritize_full_match():
 
     @router.get("/my/{path}")
     def dynamic_handler() -> Response:
-        return Response(200, content_types.APPLICATION_JSON, json.dumps({"hello": "dynamic"}))
+        return Response(200, content_types.APPLICATION_JSON, {"hello": "dynamic"})
 
     @router.get("/my/path")
     def static_handler() -> Response:
-        return Response(200, content_types.APPLICATION_JSON, json.dumps({"hello": "static"}))
+        return Response(200, content_types.APPLICATION_JSON, {"hello": "static"})
 
     app.include_router(router)
 

--- a/tests/functional/event_handler/test_api_gateway.py
+++ b/tests/functional/event_handler/test_api_gateway.py
@@ -681,7 +681,7 @@ def test_custom_cors_config():
 def test_no_content_response():
     # GIVEN a response with no content-type or body
     response = Response(status_code=204, content_type=None, body=None, headers=None)
-    response_builder = ResponseBuilder(response, serializer=json.dumps)
+    response_builder = ResponseBuilder(response)
 
     # WHEN calling to_dict
     result = response_builder.build(APIGatewayProxyEvent(LOAD_GW_EVENT))

--- a/tests/functional/event_handler/test_api_gateway.py
+++ b/tests/functional/event_handler/test_api_gateway.py
@@ -30,6 +30,7 @@ from aws_lambda_powertools.event_handler.exceptions import (
     ServiceError,
     UnauthorizedError,
 )
+from aws_lambda_powertools.event_handler.openapi.exceptions import RequestValidationError
 from aws_lambda_powertools.shared import constants
 from aws_lambda_powertools.shared.cookies import Cookie
 from aws_lambda_powertools.shared.json_encoder import Encoder
@@ -1456,6 +1457,51 @@ def test_exception_handler():
     assert result["statusCode"] == 418
     assert result["multiValueHeaders"]["Content-Type"] == [content_types.TEXT_HTML]
     assert result["body"] == "Foo!"
+
+
+def test_exception_handler_with_data_validation():
+    # GIVEN a resolver with an exception handler defined for RequestValidationError
+    app = ApiGatewayResolver(enable_validation=True)
+
+    @app.exception_handler(RequestValidationError)
+    def handle_validation_error(ex: RequestValidationError):
+        print(f"request path is '{app.current_event.path}'")
+        return Response(
+            status_code=422,
+            content_type=content_types.TEXT_PLAIN,
+            body=f"Invalid data. Number of errors: {len(ex.errors())}",
+        )
+
+    @app.get("/my/path")
+    def get_lambda(param: int):
+        ...
+
+    # WHEN calling the event handler
+    # AND a RequestValidationError is raised
+    result = app(LOAD_GW_EVENT, {})
+
+    # THEN call the exception_handler
+    assert result["statusCode"] == 422
+    assert result["multiValueHeaders"]["Content-Type"] == [content_types.TEXT_PLAIN]
+    assert result["body"] == "Invalid data. Number of errors: 1"
+
+
+def test_data_validation_error():
+    # GIVEN a resolver without an exception handler
+    app = ApiGatewayResolver(enable_validation=True)
+
+    @app.get("/my/path")
+    def get_lambda(param: int):
+        ...
+
+    # WHEN calling the event handler
+    # AND a RequestValidationError is raised
+    result = app(LOAD_GW_EVENT, {})
+
+    # THEN call the exception_handler
+    assert result["statusCode"] == 422
+    assert result["multiValueHeaders"]["Content-Type"] == [content_types.APPLICATION_JSON]
+    assert "missing" in result["body"]
 
 
 def test_exception_handler_service_error():

--- a/tests/functional/event_handler/test_api_gateway.py
+++ b/tests/functional/event_handler/test_api_gateway.py
@@ -1482,7 +1482,7 @@ def test_exception_handler_service_error():
     # THEN call the exception_handler
     assert result["statusCode"] == 500
     assert result["multiValueHeaders"]["Content-Type"] == [content_types.APPLICATION_JSON]
-    assert result["body"] == '"CUSTOM ERROR FORMAT"'
+    assert result["body"] == "CUSTOM ERROR FORMAT"
 
 
 def test_exception_handler_not_found():

--- a/tests/functional/event_handler/test_api_gateway.py
+++ b/tests/functional/event_handler/test_api_gateway.py
@@ -367,7 +367,7 @@ def test_override_route_compress_parameter():
     # AND the Response object with compress=False
     app = ApiGatewayResolver()
     mock_event = {"path": "/my/request", "httpMethod": "GET", "headers": {"Accept-Encoding": "deflate, gzip"}}
-    expected_value = {"test": "value"}
+    expected_value = '{"test": "value"}'
 
     @app.get("/my/request", compress=True)
     def with_compression() -> Response:
@@ -381,7 +381,7 @@ def test_override_route_compress_parameter():
 
     # THEN the response is not compressed
     assert result["isBase64Encoded"] is False
-    assert json.loads(result["body"]) == expected_value
+    assert result["body"] == expected_value
     assert result["multiValueHeaders"].get("Content-Encoding") is None
 
 
@@ -1778,11 +1778,11 @@ def test_route_match_prioritize_full_match():
 
     @router.get("/my/{path}")
     def dynamic_handler() -> Response:
-        return Response(200, content_types.APPLICATION_JSON, {"hello": "dynamic"})
+        return Response(200, content_types.APPLICATION_JSON, json.dumps({"hello": "dynamic"}))
 
     @router.get("/my/path")
     def static_handler() -> Response:
-        return Response(200, content_types.APPLICATION_JSON, {"hello": "static"})
+        return Response(200, content_types.APPLICATION_JSON, json.dumps({"hello": "static"}))
 
     app.include_router(router)
 

--- a/tests/functional/event_handler/test_base_path.py
+++ b/tests/functional/event_handler/test_base_path.py
@@ -21,7 +21,7 @@ def test_base_path_api_gateway_rest():
 
     result = app(event, {})
     assert result["statusCode"] == 200
-    assert result["body"] == ""
+    assert result["body"] == '""'
 
 
 def test_base_path_api_gateway_http():
@@ -38,7 +38,7 @@ def test_base_path_api_gateway_http():
 
     result = app(event, {})
     assert result["statusCode"] == 200
-    assert result["body"] == ""
+    assert result["body"] == '""'
 
 
 def test_base_path_alb():
@@ -53,7 +53,7 @@ def test_base_path_alb():
 
     result = app(event, {})
     assert result["statusCode"] == 200
-    assert result["body"] == ""
+    assert result["body"] == '""'
 
 
 def test_base_path_lambda_function_url():
@@ -70,7 +70,7 @@ def test_base_path_lambda_function_url():
 
     result = app(event, {})
     assert result["statusCode"] == 200
-    assert result["body"] == ""
+    assert result["body"] == '""'
 
 
 def test_vpc_lattice():
@@ -85,7 +85,7 @@ def test_vpc_lattice():
 
     result = app(event, {})
     assert result["statusCode"] == 200
-    assert result["body"] == ""
+    assert result["body"] == '""'
 
 
 def test_vpc_latticev2():
@@ -100,4 +100,4 @@ def test_vpc_latticev2():
 
     result = app(event, {})
     assert result["statusCode"] == 200
-    assert result["body"] == ""
+    assert result["body"] == '""'

--- a/tests/functional/event_handler/test_base_path.py
+++ b/tests/functional/event_handler/test_base_path.py
@@ -21,7 +21,7 @@ def test_base_path_api_gateway_rest():
 
     result = app(event, {})
     assert result["statusCode"] == 200
-    assert result["body"] == '""'
+    assert result["body"] == ""
 
 
 def test_base_path_api_gateway_http():
@@ -38,7 +38,7 @@ def test_base_path_api_gateway_http():
 
     result = app(event, {})
     assert result["statusCode"] == 200
-    assert result["body"] == '""'
+    assert result["body"] == ""
 
 
 def test_base_path_alb():
@@ -53,7 +53,7 @@ def test_base_path_alb():
 
     result = app(event, {})
     assert result["statusCode"] == 200
-    assert result["body"] == '""'
+    assert result["body"] == ""
 
 
 def test_base_path_lambda_function_url():
@@ -70,7 +70,7 @@ def test_base_path_lambda_function_url():
 
     result = app(event, {})
     assert result["statusCode"] == 200
-    assert result["body"] == '""'
+    assert result["body"] == ""
 
 
 def test_vpc_lattice():
@@ -85,7 +85,7 @@ def test_vpc_lattice():
 
     result = app(event, {})
     assert result["statusCode"] == 200
-    assert result["body"] == '""'
+    assert result["body"] == ""
 
 
 def test_vpc_latticev2():
@@ -100,4 +100,4 @@ def test_vpc_latticev2():
 
     result = app(event, {})
     assert result["statusCode"] == 200
-    assert result["body"] == '""'
+    assert result["body"] == ""

--- a/tests/functional/event_handler/test_openapi_validation_middleware.py
+++ b/tests/functional/event_handler/test_openapi_validation_middleware.py
@@ -343,7 +343,7 @@ def test_validate_response_return():
     # WHEN a handler is defined with a body parameter
     @app.post("/")
     def handler(user: Model) -> Response[Model]:
-        return Response(body=user, status_code=200)
+        return Response(body=user, status_code=200, content_type="application/json")
 
     LOAD_GW_EVENT["httpMethod"] = "POST"
     LOAD_GW_EVENT["path"] = "/"
@@ -353,7 +353,7 @@ def test_validate_response_return():
     # THEN the body must be a dict
     result = app(LOAD_GW_EVENT, {})
     assert result["statusCode"] == 200
-    assert result["body"] == {"name": "John", "age": 30}
+    assert json.loads(result["body"]) == {"name": "John", "age": 30}
 
 
 def test_validate_response_invalid_return():


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->

**Issue number:** #3395

## Summary

### Changes

> Please provide a summary of what's being changed

This PR allows the exception handler feature to work again when using data validation.

### User experience

> Please share what the user experience looks like before and after this change

```python
app = APIGatewayRestResolver(enable_validation=True)

@app.exception_handler(RequestValidationError)
def handle_invalid_data(ex: RequestValidationError):
    return Response(
        status_code=422,
        content_type=content_types.TEXT_PLAIN,
        body="Invalid request parameters.",
    )
```

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

- [x] [Meet tenets criteria](https://docs.powertools.aws.dev/lambda/python/#tenets)
- [x] I have performed a self-review of this change
- [x] Changes have been tested
- [x] Changes are documented
- [x] PR title follows [conventional commit semantics](https://github.com/aws-powertools/powertools-lambda-python/blob/develop/.github/semantic.yml)

<details>
<summary>Is this a breaking change?</summary>

**RFC issue number**:

Checklist:

- [ ] Migration process documented
- [ ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
