### PR TITLE
fix(event_handler): fix format for OpenAPI path templating

### DIFF
--- a/aws_lambda_powertools/event_handler/openapi/dependant.py
+++ b/aws_lambda_powertools/event_handler/openapi/dependant.py
@@ -124,7 +124,7 @@ def get_typed_signature(call: Callable[..., Any]) -> inspect.Signature:
 
 def get_path_param_names(path: str) -> Set[str]:
     """
-    Returns the path parameter names from a path template. Those are the strings between < and >.
+    Returns the path parameter names from a path template. Those are the strings between { and }.
 
     Parameters
     ----------
@@ -137,7 +137,7 @@ def get_path_param_names(path: str) -> Set[str]:
         The path parameter names
 
     """
-    return set(re.findall("<(.*?)>", path))
+    return set(re.findall("{(.*?)}", path))
 
 
 def get_dependant(

--- a/tests/functional/event_handler/test_openapi_params.py
+++ b/tests/functional/event_handler/test_openapi_params.py
@@ -70,13 +70,13 @@ def test_openapi_with_scalar_params():
     assert schema.info.version == "0.2.2"
 
     assert len(schema.paths.keys()) == 1
-    assert "/users/<user_id>" in schema.paths
+    assert "/users/{user_id}" in schema.paths
 
-    path = schema.paths["/users/<user_id>"]
+    path = schema.paths["/users/{user_id}"]
     assert path.get
 
     get = path.get
-    assert get.summary == "GET /users/<user_id>"
+    assert get.summary == "GET /users/{user_id}"
     assert get.operationId == "handler_users__user_id__get"
     assert len(get.parameters) == 2
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->

**Issue number:** #3398

## Summary

### Changes

> Please provide a summary of what's being changed

This PR makes the OpenAPI generation return the proper [path templating](https://swagger.io/specification/#path-templating) format expected by consumers.

### User experience

> Please share what the user experience looks like before and after this change

After this change, standard tooling (e.g: Swagger UI) will be able to understand path parameters.

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

- [x] [Meet tenets criteria](https://docs.powertools.aws.dev/lambda/python/#tenets)
- [x] I have performed a self-review of this change
- [x] Changes have been tested
- [x] Changes are documented
- [x] PR title follows [conventional commit semantics](https://github.com/aws-powertools/powertools-lambda-python/blob/develop/.github/semantic.yml)

<details>
<summary>Is this a breaking change?</summary>

**RFC issue number**:

Checklist:

- [ ] Migration process documented
- [ ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
