### PR TITLE
fix(event_handler): hide error details by default

### DIFF
--- a/aws_lambda_powertools/event_handler/api_gateway.py
+++ b/aws_lambda_powertools/event_handler/api_gateway.py
@@ -1979,11 +1979,14 @@ class ApiGatewayResolver(BaseRouter):
                 exp = service_error
 
         if isinstance(exp, RequestValidationError):
+            # For security reasons, we hide msg details (don't leak Python, Pydantic or file names)
+            errors = [{"loc": e["loc"], "type": e["type"]} for e in exp.errors()]
+
             return self._response_builder_class(
                 response=Response(
                     status_code=HTTPStatus.UNPROCESSABLE_ENTITY,
                     content_type=content_types.APPLICATION_JSON,
-                    body={"statusCode": HTTPStatus.UNPROCESSABLE_ENTITY, "message": exp.errors()},
+                    body={"statusCode": HTTPStatus.UNPROCESSABLE_ENTITY, "detail": errors},
                 ),
                 serializer=self._serializer,
                 route=route,

--- a/tests/functional/event_handler/test_bedrock_agent.py
+++ b/tests/functional/event_handler/test_bedrock_agent.py
@@ -121,11 +121,11 @@ def test_bedrock_agent_event_with_validation_error():
     assert result["response"]["httpMethod"] == "GET"
     assert result["response"]["httpStatusCode"] == 422
 
-    body = result["response"]["responseBody"]["application/json"]["body"]
+    body = json.loads(result["response"]["responseBody"]["application/json"]["body"])
     if PYDANTIC_V2:
-        assert "should be a valid dictionary" in body
+        assert body["detail"][0]["type"] == "dict_type"
     else:
-        assert "value is not a valid dict" in body
+        assert body["detail"][0]["type"] == "type_error.dict"
 
 
 def test_bedrock_agent_event_with_exception():


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->

**Issue number:** #3405

## Summary

### Changes

> Please provide a summary of what's being changed

This PR simplifies the default format for data validation errors, exposing just the location (field name) and the type of error.

### User experience

> Please share what the user experience looks like before and after this change

This code:

```python
@app.get("/claims")
def claims() -> Dict[str, Any]:
    return "oh no, this is not a dict"  # type: ignore
```
Now returns the following payload:

```json
{
	"statusCode": 422,
	"detail": [{"loc": ["response"], "type": "dict_type"}]
}
```

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

- [x] [Meet tenets criteria](https://docs.powertools.aws.dev/lambda/python/#tenets)
- [x] I have performed a self-review of this change
- [x] Changes have been tested
- [x] Changes are documented
- [x] PR title follows [conventional commit semantics](https://github.com/aws-powertools/powertools-lambda-python/blob/develop/.github/semantic.yml)

<details>
<summary>Is this a breaking change?</summary>

**RFC issue number**:

Checklist:

- [ ] Migration process documented
- [ ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
