### PR TITLE
fix(event-handler): operation tags are now string to correct schema generation

### DIFF
--- a/aws_lambda_powertools/event_handler/api_gateway.py
+++ b/aws_lambda_powertools/event_handler/api_gateway.py
@@ -559,7 +559,7 @@ class Route:
 
         # Ensure tags is added to the operation
         if self.tags:
-            operation["tags"] = [{"name": tag for tag in self.tags}]
+            operation["tags"] = self.tags
 
         # Ensure summary is added to the operation
         operation["summary"] = self._openapi_operation_summary()

--- a/aws_lambda_powertools/event_handler/openapi/models.py
+++ b/aws_lambda_powertools/event_handler/openapi/models.py
@@ -380,7 +380,7 @@ class Tag(BaseModel):
 
 # https://swagger.io/specification/#operation-object
 class Operation(BaseModel):
-    tags: Optional[List[Tag]] = None
+    tags: Optional[List[str]] = None
     summary: Optional[str] = None
     description: Optional[str] = None
     externalDocs: Optional[ExternalDocumentation] = None

--- a/tests/functional/event_handler/test_openapi_params.py
+++ b/tests/functional/event_handler/test_openapi_params.py
@@ -10,7 +10,6 @@ from aws_lambda_powertools.event_handler.openapi.models import (
     Parameter,
     ParameterInType,
     Schema,
-    Tag,
 )
 from aws_lambda_powertools.event_handler.openapi.params import (
     Body,
@@ -119,7 +118,7 @@ def test_openapi_with_custom_params():
     assert get.summary == "Get Users"
     assert get.operationId == "GetUsers"
     assert get.description == "Get paginated users"
-    assert get.tags == [Tag(name="Users")]
+    assert get.tags == ["Users"]
 
     parameter = get.parameters[0]
     assert parameter.required is False
@@ -378,7 +377,7 @@ def test_openapi_operation_with_tags():
     assert len(get.tags) == 1
 
     tag = get.tags[0]
-    assert tag.name == "Users"
+    assert tag == "Users"
 
 
 def test_openapi_with_excluded_operations():
@@ -421,7 +420,7 @@ def test_openapi_with_router_tags():
     schema = app.get_openapi_schema()
     tags = schema.paths["/example-resource"].put.tags
     assert len(tags) == 1
-    assert tags[0].name == "Example"
+    assert tags[0] == "Example"
 
 
 def test_create_header():


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->

**Issue number:** #3520

## Summary

### Changes

> Please provide a summary of what's being changed

This PR fixes an issue with spec compliance when generating operation tags.

### User experience

> Please share what the user experience looks like before and after this change

Before this PR, our OpenAPI generation was generating opeation tags as dictionaries, similar to the [Tag Object](https://swagger.io/specification/v3/#tag-object). However, in the context of an Operation, this is wrong, as [tags should just be a list of strings](https://swagger.io/specification/v3/#operation-object).

<img width="859" alt="image" src="https://github.com/aws-powertools/powertools-lambda-python/assets/10713/68e066d4-8aa3-4188-aba4-b76b4577e649">

This was causing any OpenAPI schema validation to fail. This PR fixes this.

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

- [x] [Meet tenets criteria](https://docs.powertools.aws.dev/lambda/python/#tenets)
- [x] I have performed a self-review of this change
- [x] Changes have been tested
- [ ] Changes are documented
- [x] PR title follows [conventional commit semantics](https://github.com/aws-powertools/powertools-lambda-python/blob/develop/.github/semantic.yml)

<details>
<summary>Is this a breaking change?</summary>

**RFC issue number**:

Checklist:

- [ ] Migration process documented
- [ ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
