### PR TITLE
refactor(parameters): add overload signatures for get_parameter and get_parameters

### DIFF
--- a/aws_lambda_powertools/utilities/parameters/ssm.py
+++ b/aws_lambda_powertools/utilities/parameters/ssm.py
@@ -577,13 +577,25 @@ def get_parameter(
     force_fetch: bool = False,
     max_age: Optional[int] = None,
     **sdk_options,
+) -> Union[str, dict, bytes]:
+    ...
+
+
+@overload
+def get_parameter(
+    name: str,
+    transform: Literal["auto"],
+    decrypt: Optional[bool] = None,
+    force_fetch: bool = False,
+    max_age: Optional[int] = None,
+    **sdk_options,
 ) -> bytes:
     ...
 
 
 def get_parameter(
     name: str,
-    transform: Optional[Literal["json", "binary"]] = None,
+    transform: Optional[Literal["json", "binary", "auto"]] = None,
     decrypt: Optional[bool] = None,
     force_fetch: bool = False,
     max_age: Optional[int] = None,
@@ -703,9 +715,23 @@ def get_parameters(
     ...
 
 
+@overload
 def get_parameters(
     path: str,
-    transform: Optional[Literal["json", "binary"]] = None,
+    transform: Literal["auto"],
+    recursive: bool = True,
+    decrypt: Optional[bool] = None,
+    force_fetch: bool = False,
+    max_age: Optional[int] = None,
+    raise_on_transform_error: bool = False,
+    **sdk_options,
+) -> Union[Dict[str, bytes], Dict[str, dict], Dict[str, str]]:
+    ...
+
+
+def get_parameters(
+    path: str,
+    transform: Optional[Literal["json", "binary", "auto"]] = None,
     recursive: bool = True,
     decrypt: Optional[bool] = None,
     force_fetch: bool = False,

--- a/aws_lambda_powertools/utilities/parameters/ssm.py
+++ b/aws_lambda_powertools/utilities/parameters/ssm.py
@@ -595,7 +595,7 @@ def get_parameter(
 
 def get_parameter(
     name: str,
-    transform: Optional[Literal["json", "binary", "auto"]] = None,
+    transform: TransformOptions = None,
     decrypt: Optional[bool] = None,
     force_fetch: bool = False,
     max_age: Optional[int] = None,
@@ -731,7 +731,7 @@ def get_parameters(
 
 def get_parameters(
     path: str,
-    transform: Optional[Literal["json", "binary", "auto"]] = None,
+    transform: TransformOptions = None,
     recursive: bool = True,
     decrypt: Optional[bool] = None,
     force_fetch: bool = False,

--- a/aws_lambda_powertools/utilities/parameters/ssm.py
+++ b/aws_lambda_powertools/utilities/parameters/ssm.py
@@ -545,9 +545,45 @@ class SSMProvider(BaseProvider):
             )
 
 
+@overload
 def get_parameter(
     name: str,
-    transform: Optional[str] = None,
+    transform: None = None,
+    decrypt: Optional[bool] = None,
+    force_fetch: bool = False,
+    max_age: Optional[int] = None,
+    **sdk_options,
+) -> str:
+    ...
+
+
+@overload
+def get_parameter(
+    name: str,
+    transform: Literal["json"],
+    decrypt: Optional[bool] = None,
+    force_fetch: bool = False,
+    max_age: Optional[int] = None,
+    **sdk_options,
+) -> dict:
+    ...
+
+
+@overload
+def get_parameter(
+    name: str,
+    transform: Literal["binary"],
+    decrypt: Optional[bool] = None,
+    force_fetch: bool = False,
+    max_age: Optional[int] = None,
+    **sdk_options,
+) -> bytes:
+    ...
+
+
+def get_parameter(
+    name: str,
+    transform: Optional[Literal["json", "binary"]] = None,
     decrypt: Optional[bool] = None,
     force_fetch: bool = False,
     max_age: Optional[int] = None,

--- a/aws_lambda_powertools/utilities/parameters/ssm.py
+++ b/aws_lambda_powertools/utilities/parameters/ssm.py
@@ -661,6 +661,48 @@ def get_parameter(
     )
 
 
+@overload
+def get_parameters(
+    path: str,
+    transform: None = None,
+    recursive: bool = True,
+    decrypt: Optional[bool] = None,
+    force_fetch: bool = False,
+    max_age: Optional[int] = None,
+    raise_on_transform_error: bool = False,
+    **sdk_options,
+) -> Dict[str, str]:
+    ...
+
+
+@overload
+def get_parameters(
+    path: str,
+    transform: Literal["json"],
+    recursive: bool = True,
+    decrypt: Optional[bool] = None,
+    force_fetch: bool = False,
+    max_age: Optional[int] = None,
+    raise_on_transform_error: bool = False,
+    **sdk_options,
+) -> Dict[str, dict]:
+    ...
+
+
+@overload
+def get_parameters(
+    path: str,
+    transform: Literal["binary"],
+    recursive: bool = True,
+    decrypt: Optional[bool] = None,
+    force_fetch: bool = False,
+    max_age: Optional[int] = None,
+    raise_on_transform_error: bool = False,
+    **sdk_options,
+) -> Dict[str, bytes]:
+    ...
+
+
 def get_parameters(
     path: str,
     transform: Optional[str] = None,

--- a/aws_lambda_powertools/utilities/parameters/ssm.py
+++ b/aws_lambda_powertools/utilities/parameters/ssm.py
@@ -705,7 +705,7 @@ def get_parameters(
 
 def get_parameters(
     path: str,
-    transform: Optional[str] = None,
+    transform: Optional[Literal["json", "binary"]] = None,
     recursive: bool = True,
     decrypt: Optional[bool] = None,
     force_fetch: bool = False,

--- a/examples/parameters/src/getting_started_single_ssm_parameter.py
+++ b/examples/parameters/src/getting_started_single_ssm_parameter.py
@@ -7,7 +7,7 @@ from aws_lambda_powertools.utilities.typing import LambdaContext
 def lambda_handler(event: dict, context: LambdaContext) -> dict:
     try:
         # Retrieve a single parameter
-        endpoint_comments: str = parameters.get_parameter("/lambda-powertools/endpoint_comments")  # type: ignore[assignment] # noqa: E501
+        endpoint_comments = parameters.get_parameter("/lambda-powertools/endpoint_comments")
 
         # the value of this parameter is https://jsonplaceholder.typicode.com/comments/
         comments: requests.Response = requests.get(endpoint_comments)


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
**Issue number: #3507**

## Summary

### Changes

Adds overload signatures for the `get_parameter` and `get_parameters` functions depending on the arguments present. Also defines the literals that are available in the `transform` argument.

### User experience

Type checkers should return the expected type based on the value in the `transform` argument.

* If `None`, return type should be `str`
* If `"json"`, return type should be `dict`
* If `"binary"`, return type should be `bytes`

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] [Meet tenets criteria](https://docs.powertools.aws.dev/lambda/python/#tenets)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented
* [x] PR title follows [conventional commit semantics](https://github.com/aws-powertools/powertools-lambda-python/blob/develop/.github/semantic.yml)

<details>
<summary>Is this a breaking change?</summary>
No
</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
