### PR TITLE
feat(event_handler): support richer top level Tags

### DIFF
--- a/aws_lambda_powertools/event_handler/api_gateway.py
+++ b/aws_lambda_powertools/event_handler/api_gateway.py
@@ -80,6 +80,7 @@ if TYPE_CHECKING:
         License,
         OpenAPI,
         Server,
+        Tag,
     )
     from aws_lambda_powertools.event_handler.openapi.params import Dependant
     from aws_lambda_powertools.event_handler.openapi.types import (
@@ -1360,7 +1361,7 @@ class ApiGatewayResolver(BaseRouter):
         openapi_version: str = DEFAULT_OPENAPI_VERSION,
         summary: Optional[str] = None,
         description: Optional[str] = None,
-        tags: Optional[List[str]] = None,
+        tags: Optional[List[Union["Tag", str]]] = None,
         servers: Optional[List["Server"]] = None,
         terms_of_service: Optional[str] = None,
         contact: Optional["Contact"] = None,
@@ -1381,7 +1382,7 @@ class ApiGatewayResolver(BaseRouter):
             A short summary of what the application does.
         description: str, optional
             A verbose explanation of the application behavior.
-        tags: List[str], optional
+        tags: List[Tag | str], optional
             A list of tags used by the specification with additional metadata.
         servers: List[Server], optional
             An array of Server Objects, which provide connectivity information to a target server.
@@ -1403,7 +1404,7 @@ class ApiGatewayResolver(BaseRouter):
             get_compat_model_name_map,
             get_definitions,
         )
-        from aws_lambda_powertools.event_handler.openapi.models import OpenAPI, PathItem, Server
+        from aws_lambda_powertools.event_handler.openapi.models import OpenAPI, PathItem, Server, Tag
         from aws_lambda_powertools.event_handler.openapi.types import (
             COMPONENT_REF_TEMPLATE,
         )
@@ -1468,7 +1469,7 @@ class ApiGatewayResolver(BaseRouter):
         if components:
             output["components"] = components
         if tags:
-            output["tags"] = [{"name": tag} for tag in tags]
+            output["tags"] = [Tag(name=tag) if isinstance(tag, str) else tag for tag in tags]
 
         output["paths"] = {k: PathItem(**v) for k, v in paths.items()}
 
@@ -1482,7 +1483,7 @@ class ApiGatewayResolver(BaseRouter):
         openapi_version: str = DEFAULT_OPENAPI_VERSION,
         summary: Optional[str] = None,
         description: Optional[str] = None,
-        tags: Optional[List[str]] = None,
+        tags: Optional[List[Union["Tag", str]]] = None,
         servers: Optional[List["Server"]] = None,
         terms_of_service: Optional[str] = None,
         contact: Optional["Contact"] = None,
@@ -1503,7 +1504,7 @@ class ApiGatewayResolver(BaseRouter):
             A short summary of what the application does.
         description: str, optional
             A verbose explanation of the application behavior.
-        tags: List[str], optional
+        tags: List[Tag, str], optional
             A list of tags used by the specification with additional metadata.
         servers: List[Server], optional
             An array of Server Objects, which provide connectivity information to a target server.
@@ -1548,7 +1549,7 @@ class ApiGatewayResolver(BaseRouter):
         openapi_version: str = DEFAULT_OPENAPI_VERSION,
         summary: Optional[str] = None,
         description: Optional[str] = None,
-        tags: Optional[List[str]] = None,
+        tags: Optional[List[Union["Tag", str]]] = None,
         servers: Optional[List["Server"]] = None,
         terms_of_service: Optional[str] = None,
         contact: Optional["Contact"] = None,
@@ -1573,7 +1574,7 @@ class ApiGatewayResolver(BaseRouter):
             A short summary of what the application does.
         description: str, optional
             A verbose explanation of the application behavior.
-        tags: List[str], optional
+        tags: List[Tag, str], optional
             A list of tags used by the specification with additional metadata.
         servers: List[Server], optional
             An array of Server Objects, which provide connectivity information to a target server.

--- a/tests/functional/event_handler/test_openapi_params.py
+++ b/tests/functional/event_handler/test_openapi_params.py
@@ -349,37 +349,6 @@ def test_openapi_with_embed_body_param():
     assert body_post_handler_schema.properties["user"].ref == "#/components/schemas/User"
 
 
-def test_openapi_with_tags():
-    app = APIGatewayRestResolver()
-
-    @app.get("/users")
-    def handler():
-        raise NotImplementedError()
-
-    schema = app.get_openapi_schema(tags=["Orders"])
-    assert len(schema.tags) == 1
-
-    tag = schema.tags[0]
-    assert tag.name == "Orders"
-
-
-def test_openapi_operation_with_tags():
-    app = APIGatewayRestResolver()
-
-    @app.get("/users", tags=["Users"])
-    def handler():
-        raise NotImplementedError()
-
-    schema = app.get_openapi_schema()
-    assert len(schema.paths.keys()) == 1
-
-    get = schema.paths["/users"].get
-    assert len(get.tags) == 1
-
-    tag = get.tags[0]
-    assert tag == "Users"
-
-
 def test_openapi_with_excluded_operations():
     app = APIGatewayRestResolver()
 

--- a/tests/functional/event_handler/test_openapi_tags.py
+++ b/tests/functional/event_handler/test_openapi_tags.py
@@ -1,0 +1,53 @@
+from aws_lambda_powertools.event_handler import APIGatewayRestResolver
+from aws_lambda_powertools.event_handler.openapi.models import Tag
+
+
+def test_openapi_with_tags():
+    app = APIGatewayRestResolver()
+
+    @app.get("/users")
+    def handler():
+        raise NotImplementedError()
+
+    schema = app.get_openapi_schema(tags=["Orders"])
+    assert schema.tags is not None
+    assert len(schema.tags) == 1
+
+    tag = schema.tags[0]
+    assert tag.name == "Orders"
+
+
+def test_openapi_with_object_tags():
+    app = APIGatewayRestResolver()
+
+    @app.get("/users")
+    def handler():
+        raise NotImplementedError()
+
+    schema = app.get_openapi_schema(tags=[Tag(name="Orders", description="Order description tag")])
+    assert schema.tags is not None
+    assert len(schema.tags) == 1
+
+    tag = schema.tags[0]
+    assert tag.name == "Orders"
+    assert tag.description == "Order description tag"
+
+
+def test_openapi_operation_with_tags():
+    app = APIGatewayRestResolver()
+
+    @app.get("/users", tags=["Users"])
+    def handler():
+        raise NotImplementedError()
+
+    schema = app.get_openapi_schema()
+    assert schema.paths is not None
+    assert len(schema.paths.keys()) == 1
+
+    get = schema.paths["/users"].get
+    assert get is not None
+    assert get.tags is not None
+    assert len(get.tags) == 1
+
+    tag = get.tags[0]
+    assert tag == "Users"


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->

**Issue number:** #3533

## Summary

### Changes

> Please provide a summary of what's being changed

This PR adds support for richer top level Tags, acording to the OpenAPI specification.

### User experience

> Please share what the user experience looks like before and after this change

This code:

```python
from pydantic import AnyUrl

from aws_lambda_powertools.event_handler import APIGatewayRestResolver
from aws_lambda_powertools.event_handler.openapi.models import ExternalDocumentation, Tag

app = APIGatewayRestResolver(enable_validation=True)


@app.put("/example-resource")
def put():
    pass


if __name__ == "__main__":
    print(
        app.get_openapi_json_schema(
            tags=[
                Tag(
                    name="Example",
                    description="This is a description",
                    externalDocs=ExternalDocumentation(
                        url=AnyUrl("https://example.org", scheme="https"),
                        description="Example website",
                    ),
                ),
            ],
        ),
    )

```

Now produces the following OpenAPI json schema

```json
{
  ...
  "tags": [
    {
      "name": "Example",
      "description": "This is a description",
      "externalDocs": {
        "description": "Example website",
        "url": "https://example.org"
      }
    }
  ]
}

```

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

- [x] [Meet tenets criteria](https://docs.powertools.aws.dev/lambda/python/#tenets)
- [x] I have performed a self-review of this change
- [x] Changes have been tested
- [x] Changes are documented
- [x] PR title follows [conventional commit semantics](https://github.com/aws-powertools/powertools-lambda-python/blob/develop/.github/semantic.yml)

<details>
<summary>Is this a breaking change?</summary>

**RFC issue number**:

Checklist:

- [ ] Migration process documented
- [ ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
