### PR TITLE
feat(event-handler): add description to request body in OpenAPI schema

### DIFF
--- a/aws_lambda_powertools/event_handler/api_gateway.py
+++ b/aws_lambda_powertools/event_handler/api_gateway.py
@@ -617,6 +617,9 @@ class Route:
         if required:
             request_body_oai["required"] = required
 
+        if field_info.description:
+            request_body_oai["description"] = field_info.description
+
         # Generate the request body media type
         request_media_content: Dict[str, Any] = {"schema": body_schema}
         request_body_oai["content"] = {request_media_type: request_media_content}

--- a/tests/functional/event_handler/test_openapi_params.py
+++ b/tests/functional/event_handler/test_openapi_params.py
@@ -349,6 +349,30 @@ def test_openapi_with_embed_body_param():
     assert body_post_handler_schema.properties["user"].ref == "#/components/schemas/User"
 
 
+def test_openapi_with_body_description():
+    app = APIGatewayRestResolver()
+
+    class User(BaseModel):
+        name: str
+
+    @app.post("/users")
+    def handler(user: Annotated[User, Body(description="This is a user")]):
+        print(user)
+
+    schema = app.get_openapi_schema()
+    assert len(schema.paths.keys()) == 1
+
+    post = schema.paths["/users"].post
+    assert post.parameters is None
+    assert post.requestBody is not None
+
+    request_body = post.requestBody
+
+    # Description should appear in two places: on the request body and on the schema
+    assert request_body.description == "This is a user"
+    assert request_body.content[JSON_CONTENT_TYPE].schema_.description == "This is a user"
+
+
 def test_openapi_with_excluded_operations():
     app = APIGatewayRestResolver()
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->

**Issue number:** #3539

## Summary

### Changes

> Please provide a summary of what's being changed

This PR adds support to expose the request body description directly on OpenAPI.

### User experience

> Please share what the user experience looks like before and after this change

Before this PR, certain API browsers like Redoc would fail to render the body description, even though it was part of the schema. After this change, we duplicate the body description on a higher level (still part of the OpenAPI specification) and that fixes the problem with Redoc.

![image](https://github.com/aws-powertools/powertools-lambda-python/assets/10713/ff6c14f4-ad18-458f-98a3-6d28957e0917)

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

- [x] [Meet tenets criteria](https://docs.powertools.aws.dev/lambda/python/#tenets)
- [x] I have performed a self-review of this change
- [x] Changes have been tested
- [x] Changes are documented
- [x] PR title follows [conventional commit semantics](https://github.com/aws-powertools/powertools-lambda-python/blob/develop/.github/semantic.yml)

<details>
<summary>Is this a breaking change?</summary>

**RFC issue number**:

Checklist:

- [ ] Migration process documented
- [ ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
