### PR TITLE
feat(layers): add new comercial region Canada - ca-west-1

### DIFF
--- a/.github/workflows/reusable_deploy_v2_layer_stack.yml
+++ b/.github/workflows/reusable_deploy_v2_layer_stack.yml
@@ -104,6 +104,8 @@ jobs:
             has_arm64_support: "true"
           - region: "ca-central-1"
             has_arm64_support: "true"
+          - region: "ca-west-1"
+            has_arm64_support: "false"
           - region: "eu-central-1"
             has_arm64_support: "true"
           - region: "eu-central-2"

--- a/docs/index.md
+++ b/docs/index.md
@@ -92,6 +92,7 @@ You can include Powertools for AWS Lambda (Python) Lambda Layer using [AWS Lambd
         | `ap-southeast-3` | [arn:aws:lambda:ap-southeast-3:017000801446:layer:AWSLambdaPowertoolsPythonV2:58](#){: .copyMe}:clipboard: |
         | `ap-southeast-4` | [arn:aws:lambda:ap-southeast-4:017000801446:layer:AWSLambdaPowertoolsPythonV2:58](#){: .copyMe}:clipboard: |
         | `ca-central-1`   | [arn:aws:lambda:ca-central-1:017000801446:layer:AWSLambdaPowertoolsPythonV2:58](#){: .copyMe}:clipboard:   |
+        | `ca-west-1`      | [arn:aws:lambda:ca-west-1:017000801446:layer:AWSLambdaPowertoolsPythonV2:58](#){: .copyMe}:clipboard:      |
         | `eu-central-1`   | [arn:aws:lambda:eu-central-1:017000801446:layer:AWSLambdaPowertoolsPythonV2:58](#){: .copyMe}:clipboard:   |
         | `eu-central-2`   | [arn:aws:lambda:eu-central-2:017000801446:layer:AWSLambdaPowertoolsPythonV2:58](#){: .copyMe}:clipboard:   |
         | `eu-north-1`     | [arn:aws:lambda:eu-north-1:017000801446:layer:AWSLambdaPowertoolsPythonV2:58](#){: .copyMe}:clipboard:     |

--- a/layer/scripts/layer-balancer/main.go
+++ b/layer/scripts/layer-balancer/main.go
@@ -56,6 +56,7 @@ var regions = []string{
 	"ap-southeast-3",
 	"ap-southeast-4",
 	"ca-central-1",
+	"ca-west-1",
 	"eu-central-1",
 	"eu-central-2",
 	"eu-north-1",
@@ -75,7 +76,7 @@ var regions = []string{
 }
 
 // Add regions that only support x86_64
-var singleArchitectureRegions = []string{}
+var singleArchitectureRegions = []string{"ca-west-1"}
 
 // getLayerVersion returns the latest version of a layer in a region
 func getLayerVersion(ctx context.Context, layerName string, region string) (int64, error) {
@@ -149,6 +150,11 @@ func balanceRegionToVersion(ctx context.Context, region string, layer *LayerInfo
 		return fmt.Errorf("error getting layer version: %w", err)
 	}
 
+	if currentLayerVersion == 0 {
+		log.Printf("[%s] No layers found in region %s, stating with version 1", layer.Name, region)
+		currentLayerVersion = 1
+	}
+
 	cfg, err := config.LoadDefaultConfig(ctx, config.WithRegion(region))
 	if err != nil {
 		return err
@@ -172,7 +178,7 @@ func balanceRegionToVersion(ctx context.Context, region string, layer *LayerInfo
 					ZipFile: payload,
 				},
 				LayerName:          aws.String(layer.Name),
-				CompatibleRuntimes: []types.Runtime{types.RuntimePython37, types.RuntimePython38, types.RuntimePython39, types.RuntimePython310, types.RuntimePython311},
+				CompatibleRuntimes: []types.Runtime{types.RuntimePython37, types.RuntimePython38, types.RuntimePython39, types.RuntimePython310, types.RuntimePython311, types.RuntimePython312},
 				Description:        aws.String(layer.Description),
 				LicenseInfo:        aws.String("MIT-0"),
 			})
@@ -183,7 +189,7 @@ func balanceRegionToVersion(ctx context.Context, region string, layer *LayerInfo
 				},
 				LayerName:               aws.String(layer.Name),
 				CompatibleArchitectures: []types.Architecture{layer.Architecture},
-				CompatibleRuntimes:      []types.Runtime{types.RuntimePython37, types.RuntimePython38, types.RuntimePython39, types.RuntimePython310, types.RuntimePython311},
+				CompatibleRuntimes:      []types.Runtime{types.RuntimePython37, types.RuntimePython38, types.RuntimePython39, types.RuntimePython310, types.RuntimePython311, types.RuntimePython312},
 				Description:             aws.String(layer.Description),
 				LicenseInfo:             aws.String("MIT-0"),
 			})


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->

**Issue number:** #3545

## Summary

### Changes

> Please provide a summary of what's being changed

This PR adds support for the new `ca-west-1` commercial region.

Note: the region currently doesn't support `arm64` builds.

### User experience

> Please share what the user experience looks like before and after this change

After this PR, customers can now use the latest Powertools Layer with the `ca-west-1` region.

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

- [x] [Meet tenets criteria](https://docs.powertools.aws.dev/lambda/python/#tenets)
- [x] I have performed a self-review of this change
- [x] Changes have been tested
- [ ] Changes are documented
- [x] PR title follows [conventional commit semantics](https://github.com/aws-powertools/powertools-lambda-python/blob/develop/.github/semantic.yml)

<details>
<summary>Is this a breaking change?</summary>

**RFC issue number**:

Checklist:

- [ ] Migration process documented
- [ ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
