### PR TITLE
fix(ci): fail dispatch analytics job when Lambda call fails

### DIFF
--- a/.github/workflows/dispatch_analytics.yml
+++ b/.github/workflows/dispatch_analytics.yml
@@ -51,7 +51,14 @@ jobs:
       - name: Invoke Lambda function
         run: |
           payload=$(echo -n '{"githubToken": "${{ secrets.GITHUB_TOKEN }}"}' | base64)
-          aws lambda invoke \
-            --function-name ${{ secrets.AWS_ANALYTICS_DISPATCHER_ARN }} \
-            --payload "$payload" response.json
-          cat response.json
+          response=$(aws lambda invoke \
+            --function-name "${{ secrets.AWS_ANALYTICS_DISPATCHER_ARN }}" \
+            --payload "$payload" \
+            response.json \
+            --query 'FunctionError' \
+            --output text)
+
+          if [ "$response" != "None" ]; then
+            echo "Error invoking lambda function, aborting."
+            exit 1
+          fi

--- a/.github/workflows/dispatch_analytics.yml
+++ b/.github/workflows/dispatch_analytics.yml
@@ -59,6 +59,6 @@ jobs:
             --output text)
 
           if [ "$response" != "None" ]; then
-            echo "Error invoking lambda function, aborting."
+            echo "Error invoking lambda function: $response. Aborting."
             exit 1
           fi

--- a/.github/workflows/dispatch_analytics.yml
+++ b/.github/workflows/dispatch_analytics.yml
@@ -58,6 +58,8 @@ jobs:
             --query 'FunctionError' \
             --output text)
 
+          jq -C response.json
+
           if [ "$response" != "None" ]; then
             echo "Error invoking lambda function: $response. Aborting."
             exit 1

--- a/.github/workflows/dispatch_analytics.yml
+++ b/.github/workflows/dispatch_analytics.yml
@@ -58,7 +58,7 @@ jobs:
             --query 'FunctionError' \
             --output text)
 
-          jq -C response.json
+          cat response.json
 
           if [ "$response" != "None" ]; then
             echo "Error invoking lambda function: $response. Aborting."

--- a/.github/workflows/dispatch_analytics.yml
+++ b/.github/workflows/dispatch_analytics.yml
@@ -58,7 +58,7 @@ jobs:
             --query 'FunctionError' \
             --output text)
 
-          cat response.json
+          cat response.json ; echo # add newline at the end
 
           if [ "$response" != "None" ]; then
             echo "Error invoking lambda function: $response. Aborting."


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->

**Issue number:** #3578

## Summary

### Changes

> Please provide a summary of what's being changed

This PR changes the Dispatch Analytics workflow to fail the job if the Lambda invocation fails.

### User experience

> Please share what the user experience looks like before and after this change

After this PR, we should see the job failing when the Analytics Lambda function fails.

<img width="1345" alt="image" src="https://github.com/aws-powertools/powertools-lambda-python/assets/10713/66b9fb7a-735b-479a-8ba9-4dba9c8f7094">


## Checklist

If your change doesn't seem to apply, please leave them unchecked.

- [x] [Meet tenets criteria](https://docs.powertools.aws.dev/lambda/python/#tenets)
- [x] I have performed a self-review of this change
- [x] Changes have been tested
- [ ] Changes are documented
- [x] PR title follows [conventional commit semantics](https://github.com/aws-powertools/powertools-lambda-python/blob/develop/.github/semantic.yml)

<details>
<summary>Is this a breaking change?</summary>

**RFC issue number**:

Checklist:

- [ ] Migration process documented
- [ ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
