### PR TITLE
chore(ci): Remove dev dependencies locked to Pydantic v1 within the Pydantic v2 workflow.

### DIFF
--- a/.github/workflows/quality_check_pydanticv2.yml
+++ b/.github/workflows/quality_check_pydanticv2.yml
@@ -14,7 +14,6 @@ name: Code quality - Pydanticv2
 #
 # Always triggered on new PRs, PR changes and PR merge.
 
-
 on:
   pull_request:
     paths:
@@ -48,9 +47,9 @@ jobs:
     env:
       PYTHON: "${{ matrix.python-version }}"
     permissions:
-      contents: read  # checkout code only
+      contents: read # checkout code only
     steps:
-      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11  # v4.1.1
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       - name: Install poetry
         run: pipx install poetry
       - name: Set up Python ${{ matrix.python-version }}
@@ -58,8 +57,6 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
           cache: "poetry"
-      - name: Removing dev dependencies locked to Pydantic v1
-        run: poetry remove cfn-lint
       - name: Replacing Pydantic v1 with v2 > 2.0.3
         run: poetry add "pydantic=^2.0.3"
       - name: Install dependencies


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
**Issue number:** #3581 

## Summary

### Changes

Update CI configuration to remove dev dependencies tied to Pydantic v1 and ensure compatibility with the Pydantic v2 workflow.

### User experience

No changes

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] [Meet tenets criteria](https://docs.powertools.aws.dev/lambda/python/#tenets)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [ ] Changes are documented
* [x] PR title follows [conventional commit semantics](https://github.com/aws-powertools/powertools-lambda-python/blob/develop/.github/semantic.yml)

<details>
<summary>Is this a breaking change?</summary>

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
