### PR TITLE
fix(event_handler): escape OpenAPI schema on Swagger UI

### DIFF
--- a/aws_lambda_powertools/event_handler/api_gateway.py
+++ b/aws_lambda_powertools/event_handler/api_gateway.py
@@ -1627,7 +1627,7 @@ class ApiGatewayResolver(BaseRouter):
 
             openapi_servers = servers or [Server(url=(base_path or "/"))]
 
-            spec = self.get_openapi_json_schema(
+            spec = self.get_openapi_schema(
                 title=title,
                 version=version,
                 openapi_version=openapi_version,

--- a/aws_lambda_powertools/event_handler/openapi/swagger_ui/html.py
+++ b/aws_lambda_powertools/event_handler/openapi/swagger_ui/html.py
@@ -1,24 +1,34 @@
-import json
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from aws_lambda_powertools.event_handler.openapi.models import OpenAPI
 
 
-def generate_swagger_html(spec: str, js_url: str, css_url: str) -> str:
+def generate_swagger_html(spec: "OpenAPI", js_url: str, css_url: str) -> str:
     """
     Generate Swagger UI HTML page
 
     Parameters
     ----------
-    spec: str
-        The OpenAPI spec in the JSON format
+    spec: OpenAPI
+        The OpenAPI spec
     js_url: str
         The URL to the Swagger UI JavaScript file
     css_url: str
         The URL to the Swagger UI CSS file
     """
 
+    from aws_lambda_powertools.event_handler.openapi.compat import model_json
+
     # The .replace('</', '<\\/') part is necessary to prevent a potential issue where the JSON string contains
     # </script> or similar tags. Escaping the forward slash in </ as <\/ ensures that the JSON does not inadvertently
     # close the script tag, and the JSON remains a valid string within the JavaScript code.
-    escaped_spec = json.dumps(json.loads(spec)).replace("</", "<\\/")
+    escaped_spec = model_json(
+        spec,
+        by_alias=True,
+        exclude_none=True,
+        indent=2,
+    ).replace("</", "<\\/")
 
     return f"""
 <!DOCTYPE html>

--- a/aws_lambda_powertools/event_handler/openapi/swagger_ui/html.py
+++ b/aws_lambda_powertools/event_handler/openapi/swagger_ui/html.py
@@ -1,3 +1,6 @@
+import json
+
+
 def generate_swagger_html(spec: str, js_url: str, css_url: str) -> str:
     """
     Generate Swagger UI HTML page
@@ -11,6 +14,12 @@ def generate_swagger_html(spec: str, js_url: str, css_url: str) -> str:
     css_url: str
         The URL to the Swagger UI CSS file
     """
+
+    # The .replace('</', '<\\/') part is necessary to prevent a potential issue where the JSON string contains
+    # </script> or similar tags. Escaping the forward slash in </ as <\/ ensures that the JSON does not inadvertently
+    # close the script tag, and the JSON remains a valid string within the JavaScript code.
+    escaped_spec = json.dumps(json.loads(spec)).replace("</", "<\\/")
+
     return f"""
 <!DOCTYPE html>
 <html>
@@ -41,9 +50,7 @@ def generate_swagger_html(spec: str, js_url: str, css_url: str) -> str:
     layout: "BaseLayout",
     showExtensions: true,
     showCommonExtensions: true,
-    spec: JSON.parse(`
-        {spec}
-    `.trim()),
+    spec: {escaped_spec},
     presets: [
       SwaggerUIBundle.presets.apis,
       SwaggerUIBundle.SwaggerUIStandalonePreset


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->

**Issue number:** #3599

## Summary

### Changes

> Please provide a summary of what's being changed

Certain characters in the OpenAPI schema where breaking the Swagger UI.

Example:

```python
@app.get("/todos/{todo_id}", description="Gets a Todo by `todo_id`")
def todo(todo_id: int):
  ...
```

### User experience

> Please share what the user experience looks like before and after this change

After this change, we escape the JSON generated before injecting it into the page.

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

- [x] [Meet tenets criteria](https://docs.powertools.aws.dev/lambda/python/#tenets)
- [x] I have performed a self-review of this change
- [x] Changes have been tested
- [ ] Changes are documented
- [x] PR title follows [conventional commit semantics](https://github.com/aws-powertools/powertools-lambda-python/blob/develop/.github/semantic.yml)

<details>
<summary>Is this a breaking change?</summary>

**RFC issue number**:

Checklist:

- [ ] Migration process documented
- [ ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
