### PR TITLE
docs(homepage): add banner about Python 3.7 deprecation

### DIFF
--- a/docs/overrides/main.html
+++ b/docs/overrides/main.html
@@ -1,5 +1,10 @@
 {% extends "base.html" %}
 
+{% block announce %}
+<p>🚨 As of February 8, 2024, AWS Lambda will no longer allow Python 3.7 functions to be updated. Inline with this, Powertools releases will stop supporting it.</p>
+<p>Please ensure you update your functions to Python 3.8 or later to continue to use the latest version of Powertools for AWS Lambda (Python).</p>
+{% endblock %}
+
 {% block outdated %}
   You're not viewing the latest version.
   <a href="{{ '../' ~ base_url }}">

--- a/tests/e2e/idempotency_redis/test_idempotency_redis.py
+++ b/tests/e2e/idempotency_redis/test_idempotency_redis.py
@@ -6,6 +6,8 @@ import pytest
 from tests.e2e.utils import data_fetcher
 from tests.e2e.utils.data_fetcher.common import GetLambdaResponseOptions, get_lambda_response_in_parallel
 
+pytest.skip(reason="Redis tests disabled until we deprecate Python 3.7.", allow_module_level=True)
+
 
 @pytest.fixture
 def ttl_cache_expiration_handler_fn_arn(infrastructure: dict) -> str:


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
**Issue number:** #3617 

## Summary

### Changes

![image](https://github.com/aws-powertools/powertools-lambda-python/assets/4295173/f28500bc-a115-475d-9446-353892202424)

### User experience

No changes in the user experience

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] [Meet tenets criteria](https://docs.powertools.aws.dev/lambda/python/#tenets)
* [x] I have performed a self-review of this change
* [ ] Changes have been tested
* [ ] Changes are documented
* [x] PR title follows [conventional commit semantics](https://github.com/aws-powertools/powertools-lambda-python/blob/develop/.github/semantic.yml)

<details>
<summary>Is this a breaking change?</summary>

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
