### PR TITLE
chore(ci): Disable Redis e2e until we drop Python 3.7

### DIFF
--- a/tests/e2e/idempotency_redis/conftest.py
+++ b/tests/e2e/idempotency_redis/conftest.py
@@ -1,7 +1,5 @@
 import pytest
 
-from tests.e2e.idempotency_redis.infrastructure import IdempotencyRedisServerlessStack
-
 
 @pytest.fixture(autouse=True, scope="package")
 def infrastructure():
@@ -12,8 +10,14 @@ def infrastructure():
     Dict[str, str]
         CloudFormation Outputs from deployed infrastructure
     """
+
+    return None
+
+    # MAINTENANCE: Uncomment the code below to enable Redis e2e tests when dropping Python 3.7
+    """
     stack = IdempotencyRedisServerlessStack()
     try:
         yield stack.deploy()
     finally:
         stack.delete()
+    """

--- a/tests/e2e/idempotency_redis/conftest.py
+++ b/tests/e2e/idempotency_redis/conftest.py
@@ -11,13 +11,5 @@ def infrastructure():
         CloudFormation Outputs from deployed infrastructure
     """
 
+    # MAINTENANCE: Add the Stack constructor when Python 3.7 is dropped
     return None
-
-    # MAINTENANCE: Uncomment the code below to enable Redis e2e tests when dropping Python 3.7
-    """
-    stack = IdempotencyRedisServerlessStack()
-    try:
-        yield stack.deploy()
-    finally:
-        stack.delete()
-    """


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
**Issue number:** #3651 

## Summary

### Changes

Disabling Redis e2e tests.

### User experience

> Please share what the user experience looks like before and after this change

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] [Meet tenets criteria](https://docs.powertools.aws.dev/lambda/python/#tenets)
* [x] I have performed a self-review of this change
* [ ] Changes have been tested
* [ ] Changes are documented
* [ ] PR title follows [conventional commit semantics](https://github.com/aws-powertools/powertools-lambda-python/blob/develop/.github/semantic.yml)

<details>
<summary>Is this a breaking change?</summary>

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
