### PR TITLE
docs(metrics): fix empty metric warning filter

### DIFF
--- a/docs/core/metrics.md
+++ b/docs/core/metrics.md
@@ -165,7 +165,7 @@ If you want to ensure at least one metric is always emitted, you can pass `raise
 ```
 
 ???+ tip "Suppressing warning messages on empty metrics"
-    If you expect your function to execute without publishing metrics every time, you can suppress the warning with **`warnings.filterwarnings("ignore", "No metrics to publish*")`**.
+    If you expect your function to execute without publishing metrics every time, you can suppress the warning with **`warnings.filterwarnings("ignore", "No application metrics to publish*")`**.
 
 ### Capturing cold start metric
 

--- a/docs/core/metrics/datadog.md
+++ b/docs/core/metrics/datadog.md
@@ -142,7 +142,7 @@ Use `raise_on_empty_metrics=True` if you want to ensure at least one metric is a
 ```
 
 ???+ tip "Suppressing warning messages on empty metrics"
-    If you expect your function to execute without publishing metrics every time, you can suppress the warning with **`warnings.filterwarnings("ignore", "No metrics to publish*")`**.
+    If you expect your function to execute without publishing metrics every time, you can suppress the warning with **`warnings.filterwarnings("ignore", "No application metrics to publish*")`**.
 
 ### Capturing cold start metric
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
**Issue number:** #3664 

## Summary

Noticed the empty metrics warning filter in the docs didn't work. Based on the warning below `application` was left out. 
https://github.com/aws-powertools/powertools-lambda-python/blob/8b5341c38af6233c2d3e019c50891b31441ddf61/aws_lambda_powertools/metrics/base.py#L317 

### Changes

> Please provide a summary of what's being changed

### User experience

> Please share what the user experience looks like before and after this change

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] [Meet tenets criteria](https://docs.powertools.aws.dev/lambda/python/#tenets)
* [ ] I have performed a self-review of this change
* [x] Changes have been tested
* [ ] Changes are documented
* [x] PR title follows [conventional commit semantics](https://github.com/aws-powertools/powertools-lambda-python/blob/develop/.github/semantic.yml)

<details>
<summary>Is this a breaking change?</summary>

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
