### PR TITLE
feat(event_handler): add support for multiValueQueryStringParameters in OpenAPI schema

### DIFF
--- a/aws_lambda_powertools/event_handler/middlewares/openapi_validation.py
+++ b/aws_lambda_powertools/event_handler/middlewares/openapi_validation.py
@@ -353,7 +353,7 @@ def _get_embed_body(
     return received_body, field_alias_omitted
 
 
-def _normalize_multi_query_string_with_param(query_string, params: Sequence[ModelField]):
+def _normalize_multi_query_string_with_param(query_string: Dict[str, Any], params: Sequence[ModelField]):
     """
     Extract and normalize resolved_query_string_parameters
 
@@ -367,30 +367,11 @@ def _normalize_multi_query_string_with_param(query_string, params: Sequence[Mode
     Returns
     -------
     A dictionary containing the processed multi_query_string_parameters.
-
-    Comments
-    --------
-    - These comments are to explain the decision to create this method
-
-    - In the case of using LambdaFunctionUrlResolver or APIGatewayHttpResolver, multi-query strings consistently
-      reside in the same field, separated by commas.
-
-    - When using a VPCLatticeV2Resolver, the Payload consistently sends query strings as arrays. To enhance
-      compatibility, we attempt to identify scalar types within the arrays and convert them to single elements.
-
-    - In the case of using APIGatewayRestResolver or ALBResolver, the payload may includes both query string and
-      multi-query string fields. We apply a similar logic as used in VPCLatticeV2Resolver
-      to handle these query strings effectively.
-
-    - VPCLatticeResolver (v1) and BedrockAgentResolver doesn't support multi-query strings
-      and we retain original query
     """
     for param in filter(is_scalar_field, params):
         try:
-            # If the field is a scalar, it implies it's not a multi-query string.
-            # And we keep the first value for this field
-
-            # We Attempt to retain only the first element if the parameter is a scalar field
+            # if the target parameter is a scalar, we keep the first value of the query string
+            # regardless if there are more in the payload
             query_string[param.name] = query_string[param.name][0]
         except KeyError:
             pass

--- a/aws_lambda_powertools/event_handler/middlewares/openapi_validation.py
+++ b/aws_lambda_powertools/event_handler/middlewares/openapi_validation.py
@@ -353,7 +353,7 @@ def _get_embed_body(
     return received_body, field_alias_omitted
 
 
-def _normalize_multi_query_string_with_param(query_string: Dict[str, Any], params: Sequence[ModelField]):
+def _normalize_multi_query_string_with_param(query_string: Optional[Dict[str, str]], params: Sequence[ModelField]):
     """
     Extract and normalize resolved_query_string_parameters
 
@@ -368,11 +368,12 @@ def _normalize_multi_query_string_with_param(query_string: Dict[str, Any], param
     -------
     A dictionary containing the processed multi_query_string_parameters.
     """
-    for param in filter(is_scalar_field, params):
-        try:
-            # if the target parameter is a scalar, we keep the first value of the query string
-            # regardless if there are more in the payload
-            query_string[param.name] = query_string[param.name][0]
-        except KeyError:
-            pass
+    if query_string:
+        for param in filter(is_scalar_field, params):
+            try:
+                # if the target parameter is a scalar, we keep the first value of the query string
+                # regardless if there are more in the payload
+                query_string[param.name] = query_string[param.name][0]
+            except KeyError:
+                pass
     return query_string

--- a/aws_lambda_powertools/event_handler/middlewares/openapi_validation.py
+++ b/aws_lambda_powertools/event_handler/middlewares/openapi_validation.py
@@ -6,7 +6,14 @@ from typing import Any, Dict, List, Mapping, Optional, Sequence, Tuple
 
 from pydantic import BaseModel
 
-from aws_lambda_powertools.event_handler import Response
+from aws_lambda_powertools.event_handler import (
+    ALBResolver,
+    APIGatewayHttpResolver,
+    APIGatewayRestResolver,
+    LambdaFunctionUrlResolver,
+    Response,
+    VPCLatticeV2Resolver,
+)
 from aws_lambda_powertools.event_handler.api_gateway import Route
 from aws_lambda_powertools.event_handler.middlewares import BaseMiddlewareHandler, NextMiddleware
 from aws_lambda_powertools.event_handler.openapi.compat import (
@@ -16,6 +23,7 @@ from aws_lambda_powertools.event_handler.openapi.compat import (
     _regenerate_error_with_loc,
     get_missing_field_error,
 )
+from aws_lambda_powertools.event_handler.openapi.dependant import is_scalar_field
 from aws_lambda_powertools.event_handler.openapi.encoders import jsonable_encoder
 from aws_lambda_powertools.event_handler.openapi.exceptions import RequestValidationError
 from aws_lambda_powertools.event_handler.openapi.params import Param
@@ -54,6 +62,98 @@ class OpenAPIValidationMiddleware(BaseMiddlewareHandler):
     ```
     """
 
+    def _extract_multi_query_string_with_param(self, query_string, params: Sequence[ModelField]):
+        """
+        Extract and process multi_query_string_parameters for VPCLatticeV2Resolver and APIGatewayRestResolver.
+
+        Parameters
+        ----------
+        query_string: Dict
+            A dictionary containing the initial query string parameters.
+        params: Sequence[ModelField]
+            A sequence of ModelField objects representing parameters.
+
+        Returns
+        -------
+        A dictionary containing the processed multi_query_string_parameters.
+
+        Comments
+        --------
+        - This method is specifically designed for VPCLatticeV2Resolver and APIGatewayRestResolver.
+        - It processes multi_query_string_parameters based on the given params.
+        """
+        for param in filter(is_scalar_field, params):
+            try:
+                # If the field is a scalar, it implies it's not a multi-query string.
+                # And we keep the first value for this field
+
+                # We Attempt to retain only the first element if the parameter is a scalar field
+                query_string[param.name] = query_string[param.name][0]
+            except KeyError:
+                pass
+        return query_string
+
+    def _extract_query_string(self, app: EventHandlerInstance, params: Sequence[ModelField]):
+        """
+        Extract and process query string parameters based on the resolver type.
+        Payloads are different and we need to identify when it is using multiValueQueryStringParameters.
+
+        References
+        https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api-develop-integrations-lambda.html#http-api-develop-integrations-lambda.proxy-format
+        https://docs.aws.amazon.com/elasticloadbalancing/latest/application/lambda-functions.html#multi-value-headers
+        https://docs.aws.amazon.com/vpc-lattice/latest/ug/lambda-functions.html#multi-value-headers
+        https://docs.aws.amazon.com/lambda/latest/dg/urls-invocation.html#urls-payloads
+
+        Parameters
+        ----------
+        app: EventHandlerInstance.
+            Instance of a Resolver
+        params: Sequence[ModelField]
+            A sequence of ModelField objects representing parameters.
+
+        Returns
+        -------
+            A dictionary containing the processed query string parameters.
+
+        Comments
+        --------
+        - The initial query is obtained from app.current_event.query_string_parameters.
+
+        - In the case of using ALBResolver, we attempt to retrieve multi_value_query_string_parameters; otherwise,
+          we retain the original query.
+
+        - In the case of using LambdaFunctionUrlResolver or APIGatewayHttpResolver, multi-query strings consistently
+          reside in the same field, separated by commas. Consequently, we split these strings into lists.
+
+        - When using a VPCLatticeV2Resolver, the Payload consistently sends query strings as arrays. To enhance
+          compatibility, we attempt to identify scalar types within the arrays and convert them to single elements.
+
+        - In the case of using APIGatewayRestResolver, the payload includes both query string and multi-query string
+          fields. We apply a similar logic as used in VPCLatticeV2Resolver to handle these query strings effectively.
+
+        - VPCLatticeResolver (v1) and BedrockAgentResolver doesn't support multi-query strings
+          and we retain original query
+        """
+
+        query = app.current_event.query_string_parameters or {}
+
+        if isinstance(app, ALBResolver):
+            query = app.current_event.multi_value_query_string_parameters or query
+
+        if isinstance(app, (LambdaFunctionUrlResolver, APIGatewayHttpResolver)):
+            query = {key: value.split(",") if "," in value else value for key, value in query.items()}
+
+        if isinstance(app, VPCLatticeV2Resolver):
+            query = self._extract_multi_query_string_with_param(query, params)
+
+        if isinstance(app, APIGatewayRestResolver) and app.current_event.multi_value_query_string_parameters:
+            query = self._extract_multi_query_string_with_param(
+                app.current_event.multi_value_query_string_parameters,
+                params,
+            )
+
+        return query
+
     def handler(self, app: EventHandlerInstance, next_middleware: NextMiddleware) -> Response:
         logger.debug("OpenAPIValidationMiddleware handler")
 
@@ -68,10 +168,12 @@ class OpenAPIValidationMiddleware(BaseMiddlewareHandler):
             app.context["_route_args"],
         )
 
+        query_string = self._extract_query_string(app, route.dependant.query_params)
+
         # Process query values
         query_values, query_errors = _request_params_to_args(
             route.dependant.query_params,
-            app.current_event.query_string_parameters or {},
+            query_string,
         )
 
         values.update(path_values)

--- a/aws_lambda_powertools/event_handler/middlewares/openapi_validation.py
+++ b/aws_lambda_powertools/event_handler/middlewares/openapi_validation.py
@@ -130,27 +130,27 @@ class OpenAPIValidationMiddleware(BaseMiddlewareHandler):
           to handle these query strings effectively.
 
         - VPCLatticeResolver (v1) and BedrockAgentResolver doesn't support multi-query strings
-          and we retain original query
+          and we retain original query_string field
         """
 
-        query = app.current_event.query_string_parameters or {}
+        query_string = app.current_event.query_string_parameters or {}
 
         if isinstance(app, (LambdaFunctionUrlResolver, APIGatewayHttpResolver)):
-            query = {key: value.split(",") if "," in value else value for key, value in query.items()}
+            query_string = {key: value.split(",") if "," in value else value for key, value in query_string.items()}
 
         if isinstance(app, VPCLatticeV2Resolver):
-            query = self._extract_multi_query_string_with_param(query, params)
+            query_string = self._extract_multi_query_string_with_param(query_string, params)
 
         if (
             isinstance(app, (ALBResolver, APIGatewayRestResolver))
             and app.current_event.multi_value_query_string_parameters
         ):
-            query = self._extract_multi_query_string_with_param(
+            query_string = self._extract_multi_query_string_with_param(
                 app.current_event.multi_value_query_string_parameters,
                 params,
             )
 
-        return query
+        return query_string
 
     def handler(self, app: EventHandlerInstance, next_middleware: NextMiddleware) -> Response:
         logger.debug("OpenAPIValidationMiddleware handler")

--- a/aws_lambda_powertools/utilities/data_classes/alb_event.py
+++ b/aws_lambda_powertools/utilities/data_classes/alb_event.py
@@ -1,4 +1,4 @@
-from typing import Dict, List, Optional
+from typing import Any, Dict, List, Optional
 
 from aws_lambda_powertools.shared.headers_serializer import (
     BaseHeadersSerializer,
@@ -34,6 +34,17 @@ class ALBEvent(BaseProxyEvent):
     @property
     def multi_value_query_string_parameters(self) -> Optional[Dict[str, List[str]]]:
         return self.get("multiValueQueryStringParameters")
+
+    @property
+    def resolved_query_string_parameters(self) -> Optional[Dict[str, Any]]:
+        """
+        This property determines the appropriate query string parameter to be used
+        as a trusted source for validating OpenAPI.
+        """
+        if self.multi_value_query_string_parameters:
+            return self.multi_value_query_string_parameters
+
+        return self.query_string_parameters
 
     @property
     def multi_value_headers(self) -> Optional[Dict[str, List[str]]]:

--- a/aws_lambda_powertools/utilities/data_classes/alb_event.py
+++ b/aws_lambda_powertools/utilities/data_classes/alb_event.py
@@ -37,10 +37,6 @@ class ALBEvent(BaseProxyEvent):
 
     @property
     def resolved_query_string_parameters(self) -> Optional[Dict[str, Any]]:
-        """
-        This property determines the appropriate query string parameter to be used
-        as a trusted source for validating OpenAPI.
-        """
         if self.multi_value_query_string_parameters:
             return self.multi_value_query_string_parameters
 

--- a/aws_lambda_powertools/utilities/data_classes/api_gateway_proxy_event.py
+++ b/aws_lambda_powertools/utilities/data_classes/api_gateway_proxy_event.py
@@ -119,6 +119,17 @@ class APIGatewayProxyEvent(BaseProxyEvent):
         return self.get("multiValueQueryStringParameters")
 
     @property
+    def resolved_query_string_parameters(self) -> Optional[Dict[str, Any]]:
+        """
+        This property determines the appropriate query string parameter to be used
+        as a trusted source for validating OpenAPI.
+        """
+        if self.multi_value_query_string_parameters:
+            return self.multi_value_query_string_parameters
+
+        return self.query_string_parameters
+
+    @property
     def request_context(self) -> APIGatewayEventRequestContext:
         return APIGatewayEventRequestContext(self._data)
 
@@ -299,3 +310,17 @@ class APIGatewayProxyEventV2(BaseProxyEvent):
 
     def header_serializer(self):
         return HttpApiHeadersSerializer()
+
+    @property
+    def resolved_query_string_parameters(self) -> Optional[Dict[str, Any]]:
+        """
+        This property determines the appropriate query string parameter to be used
+        as a trusted source for validating OpenAPI.
+        """
+        if self.query_string_parameters is not None:
+            query_string = {
+                key: value.split(",") if "," in value else value for key, value in self.query_string_parameters.items()
+            }
+            return query_string
+
+        return {}

--- a/aws_lambda_powertools/utilities/data_classes/api_gateway_proxy_event.py
+++ b/aws_lambda_powertools/utilities/data_classes/api_gateway_proxy_event.py
@@ -120,10 +120,6 @@ class APIGatewayProxyEvent(BaseProxyEvent):
 
     @property
     def resolved_query_string_parameters(self) -> Optional[Dict[str, Any]]:
-        """
-        This property determines the appropriate query string parameter to be used
-        as a trusted source for validating OpenAPI.
-        """
         if self.multi_value_query_string_parameters:
             return self.multi_value_query_string_parameters
 
@@ -313,10 +309,6 @@ class APIGatewayProxyEventV2(BaseProxyEvent):
 
     @property
     def resolved_query_string_parameters(self) -> Optional[Dict[str, Any]]:
-        """
-        This property determines the appropriate query string parameter to be used
-        as a trusted source for validating OpenAPI.
-        """
         if self.query_string_parameters is not None:
             query_string = {
                 key: value.split(",") if "," in value else value for key, value in self.query_string_parameters.items()

--- a/aws_lambda_powertools/utilities/data_classes/bedrock_agent_event.py
+++ b/aws_lambda_powertools/utilities/data_classes/bedrock_agent_event.py
@@ -108,3 +108,11 @@ class BedrockAgentEvent(BaseProxyEvent):
         # In Bedrock Agent events, query string parameters are passed as undifferentiated parameters,
         # together with the other parameters. So we just return all parameters here.
         return {x["name"]: x["value"] for x in self["parameters"]} if self.get("parameters") else None
+
+    @property
+    def resolved_query_string_parameters(self) -> Optional[Dict[str, str]]:
+        """
+        This property determines the appropriate query string parameter to be used
+        as a trusted source for validating OpenAPI.
+        """
+        return self.query_string_parameters

--- a/aws_lambda_powertools/utilities/data_classes/bedrock_agent_event.py
+++ b/aws_lambda_powertools/utilities/data_classes/bedrock_agent_event.py
@@ -111,8 +111,4 @@ class BedrockAgentEvent(BaseProxyEvent):
 
     @property
     def resolved_query_string_parameters(self) -> Optional[Dict[str, str]]:
-        """
-        This property determines the appropriate query string parameter to be used
-        as a trusted source for validating OpenAPI.
-        """
         return self.query_string_parameters

--- a/aws_lambda_powertools/utilities/data_classes/common.py
+++ b/aws_lambda_powertools/utilities/data_classes/common.py
@@ -109,7 +109,8 @@ class BaseProxyEvent(DictWrapper):
         This property determines the appropriate query string parameter to be used
         as a trusted source for validating OpenAPI.
 
-        This is necessary because different resolvers use different formats to encode multi query string parameters.
+        This is necessary because different resolvers use different formats to encode
+        multi query string parameters.
         """
         return self.query_string_parameters
 

--- a/aws_lambda_powertools/utilities/data_classes/common.py
+++ b/aws_lambda_powertools/utilities/data_classes/common.py
@@ -108,6 +108,8 @@ class BaseProxyEvent(DictWrapper):
         """
         This property determines the appropriate query string parameter to be used
         as a trusted source for validating OpenAPI.
+
+        This is necessary because different resolvers use different formats to encode multi query string parameters.
         """
         return self.query_string_parameters
 

--- a/aws_lambda_powertools/utilities/data_classes/common.py
+++ b/aws_lambda_powertools/utilities/data_classes/common.py
@@ -104,6 +104,14 @@ class BaseProxyEvent(DictWrapper):
         return self.get("queryStringParameters")
 
     @property
+    def resolved_query_string_parameters(self) -> Optional[Dict[str, str]]:
+        """
+        This property determines the appropriate query string parameter to be used
+        as a trusted source for validating OpenAPI.
+        """
+        return self.query_string_parameters
+
+    @property
     def is_base64_encoded(self) -> Optional[bool]:
         return self.get("isBase64Encoded")
 

--- a/aws_lambda_powertools/utilities/data_classes/vpc_lattice.py
+++ b/aws_lambda_powertools/utilities/data_classes/vpc_lattice.py
@@ -141,6 +141,14 @@ class VPCLatticeEvent(VPCLatticeEventBase):
         """The request query string parameters."""
         return self["query_string_parameters"]
 
+    @property
+    def resolved_query_string_parameters(self) -> Optional[Dict[str, str]]:
+        """
+        This property determines the appropriate query string parameter to be used
+        as a trusted source for validating OpenAPI.
+        """
+        return self.query_string_parameters
+
 
 class vpcLatticeEventV2Identity(DictWrapper):
     @property
@@ -251,3 +259,11 @@ class VPCLatticeEventV2(VPCLatticeEventBase):
     def query_string_parameters(self) -> Optional[Dict[str, str]]:
         """The request query string parameters."""
         return self.get("queryStringParameters")
+
+    @property
+    def resolved_query_string_parameters(self) -> Optional[Dict[str, str]]:
+        """
+        This property determines the appropriate query string parameter to be used
+        as a trusted source for validating OpenAPI.
+        """
+        return self.query_string_parameters

--- a/aws_lambda_powertools/utilities/data_classes/vpc_lattice.py
+++ b/aws_lambda_powertools/utilities/data_classes/vpc_lattice.py
@@ -143,10 +143,6 @@ class VPCLatticeEvent(VPCLatticeEventBase):
 
     @property
     def resolved_query_string_parameters(self) -> Optional[Dict[str, str]]:
-        """
-        This property determines the appropriate query string parameter to be used
-        as a trusted source for validating OpenAPI.
-        """
         return self.query_string_parameters
 
 
@@ -262,8 +258,4 @@ class VPCLatticeEventV2(VPCLatticeEventBase):
 
     @property
     def resolved_query_string_parameters(self) -> Optional[Dict[str, str]]:
-        """
-        This property determines the appropriate query string parameter to be used
-        as a trusted source for validating OpenAPI.
-        """
         return self.query_string_parameters

--- a/docs/core/event_handler/api_gateway.md
+++ b/docs/core/event_handler/api_gateway.md
@@ -400,6 +400,16 @@ In the following example, we use a new `Query` OpenAPI type to add [one out of m
 
     1. `completed` is still the same query string as before, except we simply state it's an string. No `Query` or `Annotated` to validate it.
 
+=== "working_with_multi_query_values.py"
+
+    If you need to handle multi-value query parameters, you can create a list of the desired type.
+
+    ```python hl_lines="23"
+    --8<-- "examples/event_handler_rest/src/working_with_multi_query_values.py"
+    ```
+
+    1. `example_multi_value_param` is a list containing values from the `ExampleEnum` enumeration.
+
 <!-- markdownlint-enable MD013 -->
 
 #### Validating path parameters

--- a/examples/event_handler_rest/src/working_with_multi_query_values.py
+++ b/examples/event_handler_rest/src/working_with_multi_query_values.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+from enum import Enum
+
+from aws_lambda_powertools.event_handler import APIGatewayRestResolver
+from aws_lambda_powertools.event_handler.openapi.params import Query
+from aws_lambda_powertools.shared.types import Annotated
+from aws_lambda_powertools.utilities.typing import LambdaContext
+
+app = APIGatewayRestResolver(enable_validation=True)
+
+
+class ExampleEnum(Enum):
+    """Example of an Enum class."""
+
+    ONE = "value_one"
+    TWO = "value_two"
+    THREE = "value_three"
+
+
+@app.get("/todos")
+def get(
+    example_multi_value_param: Annotated[
+        list[ExampleEnum],  # (1)!
+        Query(
+            description="This is multi value query parameter.",
+        ),
+    ],
+):
+    """Return validated multi-value param values."""
+    return example_multi_value_param
+
+
+def lambda_handler(event: dict, context: LambdaContext) -> dict:
+    return app.resolve(event, context)

--- a/examples/event_handler_rest/src/working_with_multi_query_values.py
+++ b/examples/event_handler_rest/src/working_with_multi_query_values.py
@@ -1,6 +1,5 @@
-from __future__ import annotations
-
 from enum import Enum
+from typing import List
 
 from aws_lambda_powertools.event_handler import APIGatewayRestResolver
 from aws_lambda_powertools.event_handler.openapi.params import Query
@@ -21,7 +20,7 @@ class ExampleEnum(Enum):
 @app.get("/todos")
 def get(
     example_multi_value_param: Annotated[
-        list[ExampleEnum],  # (1)!
+        List[ExampleEnum],  # (1)!
         Query(
             description="This is multi value query parameter.",
         ),

--- a/tests/events/albMultiValueQueryStringEvent.json
+++ b/tests/events/albMultiValueQueryStringEvent.json
@@ -1,0 +1,38 @@
+{
+  "requestContext": {
+    "elb": {
+      "targetGroupArn": "arn:aws:elasticloadbalancing:eu-central-1:1234567890:targetgroup/alb-c-Targe-11GDXTPQ7663S/804a67588bfdc10f"
+    }
+  },
+  "httpMethod": "GET",
+  "path": "/todos",
+  "multiValueQueryStringParameters": {
+    "parameter1": ["value1","value2"],
+    "parameter2": ["value"]
+  },
+  "multiValueHeaders": {
+    "accept": [
+      "*/*"
+    ],
+    "host": [
+      "alb-c-LoadB-14POFKYCLBNSF-1815800096.eu-central-1.elb.amazonaws.com"
+    ],
+    "user-agent": [
+      "curl/7.79.1"
+    ],
+    "x-amzn-trace-id": [
+      "Root=1-62fa9327-21cdd4da4c6db451490a5fb7"
+    ],
+    "x-forwarded-for": [
+      "123.123.123.123"
+    ],
+    "x-forwarded-port": [
+      "80"
+    ],
+    "x-forwarded-proto": [
+      "http"
+    ]
+  },
+  "body": "",
+  "isBase64Encoded": false
+}

--- a/tests/events/lambdaFunctionUrlEventWithHeaders.json
+++ b/tests/events/lambdaFunctionUrlEventWithHeaders.json
@@ -1,0 +1,51 @@
+{
+   "version":"2.0",
+   "routeKey":"$default",
+   "rawPath":"/",
+   "rawQueryString":"",
+   "headers":{
+      "sec-fetch-mode":"navigate",
+      "x-amzn-tls-version":"TLSv1.2",
+      "sec-fetch-site":"cross-site",
+      "accept-language":"pt-BR,pt;q=0.9",
+      "x-forwarded-proto":"https",
+      "x-forwarded-port":"443",
+      "x-forwarded-for":"123.123.123.123",
+      "sec-fetch-user":"?1",
+      "accept":"text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.9",
+      "x-amzn-tls-cipher-suite":"ECDHE-RSA-AES128-GCM-SHA256",
+      "sec-ch-ua":"\" Not A;Brand\";v=\"99\", \"Chromium\";v=\"102\", \"Google Chrome\";v=\"102\"",
+      "sec-ch-ua-mobile":"?0",
+      "x-amzn-trace-id":"Root=1-62ecd163-5f302e550dcde3b12402207d",
+      "sec-ch-ua-platform":"\"Linux\"",
+      "host":"<url-id>.lambda-url.us-east-1.on.aws",
+      "upgrade-insecure-requests":"1",
+      "cache-control":"max-age=0",
+      "accept-encoding":"gzip, deflate, br",
+      "sec-fetch-dest":"document",
+      "user-agent":"Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/102.0.0.0 Safari/537.36"
+   },
+   "queryStringParameters": {
+      "parameter1": "value1,value2",
+      "parameter2": "value"
+    },
+   "requestContext":{
+      "accountId":"anonymous",
+      "apiId":"<url-id>",
+      "domainName":"<url-id>.lambda-url.us-east-1.on.aws",
+      "domainPrefix":"<url-id>",
+      "http":{
+         "method":"GET",
+         "path":"/",
+         "protocol":"HTTP/1.1",
+         "sourceIp":"123.123.123.123",
+         "userAgent":"agent"
+      },
+      "requestId":"id",
+      "routeKey":"$default",
+      "stage":"$default",
+      "time":"05/Aug/2022:08:14:39 +0000",
+      "timeEpoch":1659687279885
+   },
+   "isBase64Encoded":false
+}

--- a/tests/events/vpcLatticeV2EventWithHeaders.json
+++ b/tests/events/vpcLatticeV2EventWithHeaders.json
@@ -1,0 +1,36 @@
+{
+    "version": "2.0",
+    "path": "/newpath",
+    "method": "GET",
+    "headers": {
+      "user_agent": "curl/7.64.1",
+      "x-forwarded-for": "10.213.229.10",
+      "host": "test-lambda-service-3908sdf9u3u.dkfjd93.vpc-lattice-svcs.us-east-2.on.aws",
+      "accept": "*/*"
+    },
+    "queryStringParameters": {
+      "parameter1": [
+        "value1",
+        "value2"
+      ],
+      "parameter2": [
+        "value"
+      ]
+    },
+    "body": "{\"message\": \"Hello from Lambda!\"}",
+    "isBase64Encoded": false,
+    "requestContext": {
+        "serviceNetworkArn": "arn:aws:vpc-lattice:us-east-2:123456789012:servicenetwork/sn-0bf3f2882e9cc805a",
+        "serviceArn": "arn:aws:vpc-lattice:us-east-2:123456789012:service/svc-0a40eebed65f8d69c",
+        "targetGroupArn": "arn:aws:vpc-lattice:us-east-2:123456789012:targetgroup/tg-6d0ecf831eec9f09",
+        "identity": {
+          "sourceVpcArn": "arn:aws:ec2:region:123456789012:vpc/vpc-0b8276c84697e7339",
+          "type" : "AWS_IAM",
+          "principal": "arn:aws:sts::123456789012:assumed-role/example-role/057d00f8b51257ba3c853a0f248943cf",
+          "sessionName": "057d00f8b51257ba3c853a0f248943cf",
+          "x509SanDns": "example.com"
+        },
+        "region": "us-east-2",
+        "timeEpoch": "1696331543569073"
+    }
+}

--- a/tests/functional/event_handler/test_openapi_params.py
+++ b/tests/functional/event_handler/test_openapi_params.py
@@ -184,6 +184,20 @@ def test_openapi_with_omitted_param():
     assert get.parameters is None
 
 
+def test_openapi_with_list_param():
+    app = APIGatewayRestResolver()
+
+    @app.get("/")
+    def handler(page: Annotated[List[str], Query()]):
+        return page
+
+    schema = app.get_openapi_schema()
+    assert len(schema.paths.keys()) == 1
+
+    get = schema.paths["/"].get
+    assert get.parameters[0].schema_.type == "array"
+
+
 def test_openapi_with_description():
     app = APIGatewayRestResolver()
 

--- a/tests/functional/event_handler/test_openapi_validation_middleware.py
+++ b/tests/functional/event_handler/test_openapi_validation_middleware.py
@@ -423,7 +423,7 @@ def test_validate_rest_api_resolver_with_multi_query_params_fail():
     # THEN the handler should be invoked and return 422
     result = app(LOAD_GW_EVENT, {})
     assert result["statusCode"] == 422
-    assert any(text in result["body"] for text in ["type_error.integer"])
+    assert any(text in result["body"] for text in ["type_error.integer", "int_parsing"])
 
 
 def test_validate_rest_api_resolver_without_query_params():
@@ -479,7 +479,7 @@ def test_validate_http_resolver_with_multi_query_values_fail():
     # THEN the handler should be invoked and return 422
     result = app(LOAD_GW_EVENT_HTTP, {})
     assert result["statusCode"] == 422
-    assert any(text in result["body"] for text in ["type_error.integer"])
+    assert any(text in result["body"] for text in ["type_error.integer", "int_parsing"])
 
 
 def test_validate_http_resolver_without_query_params():
@@ -531,7 +531,7 @@ def test_validate_alb_resolver_with_multi_query_values_fail():
     # THEN the handler should be invoked and return 422
     result = app(LOAD_GW_EVENT_ALB, {})
     assert result["statusCode"] == 422
-    assert any(text in result["body"] for text in ["type_error.integer"])
+    assert any(text in result["body"] for text in ["type_error.integer", "int_parsing"])
 
 
 def test_validate_alb_resolver_without_query_params():
@@ -585,7 +585,7 @@ def test_validate_lambda_url_resolver_with_multi_query_params_fail():
     # THEN the handler should be invoked and return 422
     result = app(LOAD_GW_EVENT_LAMBDA_URL, {})
     assert result["statusCode"] == 422
-    assert any(text in result["body"] for text in ["type_error.integer"])
+    assert any(text in result["body"] for text in ["type_error.integer", "int_parsing"])
 
 
 def test_validate_lambda_url_resolver_without_query_params():
@@ -637,7 +637,7 @@ def test_validate_vpc_lattice_resolver_with_multi_query_params_fail():
     # THEN the handler should be invoked and return 422
     result = app(LOAD_GW_EVENT_VPC_LATTICE, {})
     assert result["statusCode"] == 422
-    assert any(text in result["body"] for text in ["type_error.integer"])
+    assert any(text in result["body"] for text in ["type_error.integer", "int_parsing"])
 
 
 def test_validate_vpc_lattice_resolver_without_query_params():

--- a/tests/functional/event_handler/test_openapi_validation_middleware.py
+++ b/tests/functional/event_handler/test_openapi_validation_middleware.py
@@ -391,7 +391,7 @@ def test_validate_response_invalid_return():
     assert "missing" in result["body"]
 
 
-def test_validate_rest_api_resolver_with_multi_query_values():
+def test_validate_rest_api_resolver_with_multi_query_params():
     # GIVEN an APIGatewayRestResolver with validation enabled
     app = APIGatewayRestResolver(enable_validation=True)
 
@@ -408,7 +408,7 @@ def test_validate_rest_api_resolver_with_multi_query_values():
     assert result["statusCode"] == 200
 
 
-def test_validate_rest_api_resolver_with_multi_query_values_fail():
+def test_validate_rest_api_resolver_with_multi_query_params_fail():
     # GIVEN an APIGatewayRestResolver with validation enabled
     app = APIGatewayRestResolver(enable_validation=True)
 
@@ -426,7 +426,26 @@ def test_validate_rest_api_resolver_with_multi_query_values_fail():
     assert any(text in result["body"] for text in ["type_error.integer"])
 
 
-def test_validate_http_resolver_with_multi_query_values():
+def test_validate_rest_api_resolver_without_query_params():
+    # GIVEN an APIGatewayRestResolver with validation enabled
+    app = APIGatewayRestResolver(enable_validation=True)
+
+    # WHEN a handler is defined with a default scalar parameter and a list with wrong type
+    @app.get("/users")
+    def handler():
+        return None
+
+    LOAD_GW_EVENT["httpMethod"] = "GET"
+    LOAD_GW_EVENT["path"] = "/users"
+    LOAD_GW_EVENT["queryStringParameters"] = None
+    LOAD_GW_EVENT["multiValueQueryStringParameters"] = None
+
+    # THEN the handler should be invoked and return 422
+    result = app(LOAD_GW_EVENT, {})
+    assert result["statusCode"] == 200
+
+
+def test_validate_http_resolver_with_multi_query_params():
     # GIVEN an APIGatewayHttpResolver with validation enabled
     app = APIGatewayHttpResolver(enable_validation=True)
 
@@ -463,6 +482,25 @@ def test_validate_http_resolver_with_multi_query_values_fail():
     assert any(text in result["body"] for text in ["type_error.integer"])
 
 
+def test_validate_http_resolver_without_query_params():
+    # GIVEN an APIGatewayHttpResolver with validation enabled
+    app = APIGatewayHttpResolver(enable_validation=True)
+
+    # WHEN a handler is defined without any query params
+    @app.get("/users")
+    def handler():
+        return None
+
+    LOAD_GW_EVENT_HTTP["rawPath"] = "/users"
+    LOAD_GW_EVENT_HTTP["requestContext"]["http"]["method"] = "GET"
+    LOAD_GW_EVENT_HTTP["requestContext"]["http"]["path"] = "/users"
+    LOAD_GW_EVENT_HTTP["queryStringParameters"] = None
+
+    # THEN the handler should be invoked and return 200
+    result = app(LOAD_GW_EVENT_HTTP, {})
+    assert result["statusCode"] == 200
+
+
 def test_validate_alb_resolver_with_multi_query_values():
     # GIVEN an ALBResolver with validation enabled
     app = ALBResolver(enable_validation=True)
@@ -496,7 +534,24 @@ def test_validate_alb_resolver_with_multi_query_values_fail():
     assert any(text in result["body"] for text in ["type_error.integer"])
 
 
-def test_validate_lambda_url_resolver_with_multi_query_values():
+def test_validate_alb_resolver_without_query_params():
+    # GIVEN an ALBResolver with validation enabled
+    app = ALBResolver(enable_validation=True)
+
+    # WHEN a handler is defined without any query params
+    @app.get("/users")
+    def handler(parameter1: Annotated[List[str], Query()], parameter2: str):
+        print(parameter2)
+
+    LOAD_GW_EVENT_ALB["path"] = "/users"
+    LOAD_GW_EVENT_HTTP["multiValueQueryStringParameters"] = None
+
+    # THEN the handler should be invoked and return 200
+    result = app(LOAD_GW_EVENT_ALB, {})
+    assert result["statusCode"] == 200
+
+
+def test_validate_lambda_url_resolver_with_multi_query_params():
     # GIVEN an LambdaFunctionUrlResolver with validation enabled
     app = LambdaFunctionUrlResolver(enable_validation=True)
 
@@ -514,7 +569,7 @@ def test_validate_lambda_url_resolver_with_multi_query_values():
     assert result["statusCode"] == 200
 
 
-def test_validate__lambda_url_resolver_with_multi_query_values_fail():
+def test_validate_lambda_url_resolver_with_multi_query_params_fail():
     # GIVEN an LambdaFunctionUrlResolver with validation enabled
     app = LambdaFunctionUrlResolver(enable_validation=True)
 
@@ -533,7 +588,26 @@ def test_validate__lambda_url_resolver_with_multi_query_values_fail():
     assert any(text in result["body"] for text in ["type_error.integer"])
 
 
-def test_validate_vpc_lattice_resolver_with_multi_query_values():
+def test_validate_lambda_url_resolver_without_query_params():
+    # GIVEN an LambdaFunctionUrlResolver with validation enabled
+    app = LambdaFunctionUrlResolver(enable_validation=True)
+
+    # WHEN a handler is defined  without any query params
+    @app.get("/users")
+    def handler():
+        return None
+
+    LOAD_GW_EVENT_LAMBDA_URL["rawPath"] = "/users"
+    LOAD_GW_EVENT_LAMBDA_URL["requestContext"]["http"]["method"] = "GET"
+    LOAD_GW_EVENT_LAMBDA_URL["requestContext"]["http"]["path"] = "/users"
+    LOAD_GW_EVENT_LAMBDA_URL["queryStringParameters"] = None
+
+    # THEN the handler should be invoked and return 200
+    result = app(LOAD_GW_EVENT_LAMBDA_URL, {})
+    assert result["statusCode"] == 200
+
+
+def test_validate_vpc_lattice_resolver_with_multi_params_values():
     # GIVEN an VPCLatticeV2Resolver with validation enabled
     app = VPCLatticeV2Resolver(enable_validation=True)
 
@@ -549,7 +623,7 @@ def test_validate_vpc_lattice_resolver_with_multi_query_values():
     assert result["statusCode"] == 200
 
 
-def test_validate_vpc_lattice_resolver_with_multi_query_values_fail():
+def test_validate_vpc_lattice_resolver_with_multi_query_params_fail():
     # GIVEN an VPCLatticeV2Resolver with validation enabled
     app = VPCLatticeV2Resolver(enable_validation=True)
 
@@ -564,3 +638,20 @@ def test_validate_vpc_lattice_resolver_with_multi_query_values_fail():
     result = app(LOAD_GW_EVENT_VPC_LATTICE, {})
     assert result["statusCode"] == 422
     assert any(text in result["body"] for text in ["type_error.integer"])
+
+
+def test_validate_vpc_lattice_resolver_without_query_params():
+    # GIVEN an VPCLatticeV2Resolver with validation enabled
+    app = VPCLatticeV2Resolver(enable_validation=True)
+
+    # WHEN a handler is defined without any query params
+    @app.get("/users")
+    def handler():
+        return None
+
+    LOAD_GW_EVENT_VPC_LATTICE["path"] = "/users"
+    LOAD_GW_EVENT_VPC_LATTICE["queryStringParameters"] = None
+
+    # THEN the handler should be invoked and return 200
+    result = app(LOAD_GW_EVENT_VPC_LATTICE, {})
+    assert result["statusCode"] == 200


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
**Issue number:** #3622 

## Summary

### Changes

This pull request enhances the OpenAPI utility by introducing support for `multiValueQueryStringParameters` in the OpenAPI schema. Previously, our utility encountered issues parsing multi-value query fields, leading to errors for customers attempting to utilize such fields. Work did:

- Added support for multiValueQueryStringParameters in the OpenAPI schema.
- Resolved parsing issues previously encountered when dealing with multi-value fields in different Resolvers.
- Added new tests


### User experience

Using the code below now we can validate multi value param.

```python
from enum import Enum
from http import HTTPStatus

from aws_lambda_powertools.event_handler import APIGatewayRestResolver
from aws_lambda_powertools.event_handler.openapi.params import Query
from aws_lambda_powertools.shared.types import Annotated
from aws_lambda_powertools.utilities.typing import LambdaContext

app = APIGatewayRestResolver(enable_validation=True)


class ExampleEnum(Enum):
    """Example of an Enum class."""

    ONE = "value_one"
    TWO = "value_two"
    THREE = "value_three"


@app.get("/example-resource")
def get(
    example_multi_value_param: Annotated[
        ExampleEnum,
        Query(
            description="This should be a multi value query parameter."
        ),  # TODO: How should this represent multi-value query string parameters?
    ]
):
    """Return validated multi-value param values."""
    return example_multi_value_param


def lambda_handler(event: dict, context: LambdaContext):
    """Handler to route API Gateway events."""
    return app.resolve(event, context)
```

![image](https://github.com/aws-powertools/powertools-lambda-python/assets/4295173/85501237-0598-421e-8fd2-6c64636b374f)


## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] [Meet tenets criteria](https://docs.powertools.aws.dev/lambda/python/#tenets)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented
* [x] PR title follows [conventional commit semantics](https://github.com/aws-powertools/powertools-lambda-python/blob/develop/.github/semantic.yml)

<details>
<summary>Is this a breaking change?</summary>

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
