### PR TITLE
fix(event-handler): strip whitespace from Content-Type headers during OpenAPI schema validation

### DIFF
--- a/aws_lambda_powertools/event_handler/middlewares/openapi_validation.py
+++ b/aws_lambda_powertools/event_handler/middlewares/openapi_validation.py
@@ -212,7 +212,7 @@ class OpenAPIValidationMiddleware(BaseMiddlewareHandler):
         """
 
         content_type_value = app.current_event.get_header_value("content-type")
-        if not content_type_value or content_type_value.startswith("application/json"):
+        if not content_type_value or content_type_value.strip().startswith("application/json"):
             try:
                 return app.current_event.json_body
             except json.JSONDecodeError as e:

--- a/tests/functional/event_handler/test_openapi_validation_middleware.py
+++ b/tests/functional/event_handler/test_openapi_validation_middleware.py
@@ -289,6 +289,32 @@ def test_validate_body_param():
     assert json.loads(result["body"]) == {"name": "John", "age": 30}
 
 
+def test_validate_body_param_with_stripped_headers():
+    # GIVEN an APIGatewayRestResolver with validation enabled
+    app = APIGatewayRestResolver(enable_validation=True)
+
+    class Model(BaseModel):
+        name: str
+        age: int
+
+    # WHEN a handler is defined with a body parameter
+    # WHEN headers has spaces
+    @app.post("/")
+    def handler(user: Model) -> Model:
+        return user
+
+    LOAD_GW_EVENT["httpMethod"] = "POST"
+    LOAD_GW_EVENT["headers"] = {"Content-type": " application/json "}
+    LOAD_GW_EVENT["path"] = "/"
+    LOAD_GW_EVENT["body"] = json.dumps({"name": "John", "age": 30})
+
+    # THEN the handler should be invoked and return 200
+    # THEN the body must be a JSON object
+    result = app(LOAD_GW_EVENT, {})
+    assert result["statusCode"] == 200
+    assert json.loads(result["body"]) == {"name": "John", "age": 30}
+
+
 def test_validate_body_param_with_invalid_date():
     # GIVEN an APIGatewayRestResolver with validation enabled
     app = APIGatewayRestResolver(enable_validation=True)


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
**Issue number:** #3672 

## Summary

### Changes

In this pull request, we have resolved an issue related to the handling of `Content-type` headers within the OpenAPI schema validation process in the event handler. The problem was associated with extra spaces preceding the `Content-type` value, which could lead to compatibility issues.

### User experience

> Please share what the user experience looks like before and after this change

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] [Meet tenets criteria](https://docs.powertools.aws.dev/lambda/python/#tenets)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [ ] Changes are documented
* [x] PR title follows [conventional commit semantics](https://github.com/aws-powertools/powertools-lambda-python/blob/develop/.github/semantic.yml)

<details>
<summary>Is this a breaking change?</summary>

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
