### PR TITLE
fix(typing): make Response headers covariant

### DIFF
--- a/aws_lambda_powertools/event_handler/api_gateway.py
+++ b/aws_lambda_powertools/event_handler/api_gateway.py
@@ -17,6 +17,7 @@ from typing import (
     Dict,
     Generic,
     List,
+    Mapping,
     Match,
     Optional,
     Pattern,
@@ -200,7 +201,7 @@ class CORSConfig:
             return {}
 
         # The origin matched an allowed origin, so return the CORS headers
-        headers: Dict[str, str] = {
+        headers = {
             "Access-Control-Allow-Origin": origin,
             "Access-Control-Allow-Headers": ",".join(sorted(self.allow_headers)),
         }
@@ -222,7 +223,7 @@ class Response(Generic[ResponseT]):
         status_code: int,
         content_type: Optional[str] = None,
         body: Optional[ResponseT] = None,
-        headers: Optional[Dict[str, Union[str, List[str]]]] = None,
+        headers: Optional[Mapping[str, Union[str, List[str]]]] = None,
         cookies: Optional[List[Cookie]] = None,
         compress: Optional[bool] = None,
     ):
@@ -237,7 +238,7 @@ class Response(Generic[ResponseT]):
             provided http headers
         body: Union[str, bytes, None]
             Optionally set the response body. Note: bytes body will be automatically base64 encoded
-        headers: dict[str, Union[str, List[str]]]
+        headers: Mapping[str, Union[str, List[str]]]
             Optionally set specific http headers. Setting "Content-Type" here would override the `content_type` value.
         cookies: list[Cookie]
             Optionally set cookies.
@@ -245,7 +246,7 @@ class Response(Generic[ResponseT]):
         self.status_code = status_code
         self.body = body
         self.base64_encoded = False
-        self.headers: Dict[str, Union[str, List[str]]] = headers if headers else {}
+        self.headers: Dict[str, Union[str, List[str]]] = dict(headers) if headers else {}
         self.cookies = cookies or []
         self.compress = compress
         self.content_type = content_type
@@ -1940,7 +1941,7 @@ class ApiGatewayResolver(BaseRouter):
 
     def _not_found(self, method: str) -> ResponseBuilder:
         """Called when no matching route was found and includes support for the cors preflight response"""
-        headers: Dict[str, Union[str, List[str]]] = {}
+        headers = {}
         if self._cors:
             logger.debug("CORS is enabled, updating headers.")
             headers.update(self._cors.to_dict(self.current_event.get_header_value("Origin")))


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
**Issue number:** https://github.com/aws-powertools/powertools-lambda-python/issues/3743

## Summary

### Changes

Change typing for `headers` in `Response` constructor.

### User experience

Able to use covariant of dicts, e.g.
```python
headers_with_str = {"str": "str"}
Response(200, headers=headers_with_str)

headers_with_list = {"str": "str", "list": ["1"]}
Response(200, headers=headers_with_list)
```

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] [Meet tenets criteria](https://docs.powertools.aws.dev/lambda/python/#tenets)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [ ] Changes are documented
* [x] PR title follows [conventional commit semantics](https://github.com/aws-powertools/powertools-lambda-python/blob/develop/.github/semantic.yml)

<details>
<summary>Is this a breaking change?</summary>

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
