### PR TITLE
docs(feature_flags): fix incorrect line markers and envelope name

### DIFF
--- a/docs/utilities/feature_flags.md
+++ b/docs/utilities/feature_flags.md
@@ -178,7 +178,7 @@ You can use `get_enabled_features` method for scenarios where you need a list of
 
 === "getting_all_enabled_features.py"
 
-    ```python hl_lines="2 9 26"
+    ```python hl_lines="4 9 11 28"
     --8<-- "examples/feature_flags/src/getting_all_enabled_features.py"
     ```
 
@@ -472,7 +472,7 @@ For this to work, you need to use a JMESPath expression via the `envelope` param
 
 === "extracting_envelope.py"
 
-    ```python hl_lines="7"
+    ```python hl_lines="10"
     --8<-- "examples/feature_flags/src/extracting_envelope.py"
     ```
 

--- a/examples/feature_flags/src/extracting_envelope.py
+++ b/examples/feature_flags/src/extracting_envelope.py
@@ -6,8 +6,8 @@ from aws_lambda_powertools.utilities.typing import LambdaContext
 app_config = AppConfigStore(
     environment="dev",
     application="product-catalogue",
-    name="features",
-    envelope="feature_flags",
+    name="feature_flags",
+    envelope="features",
 )
 
 feature_flags = FeatureFlags(store=app_config)


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
**Issue number:** #3791

## Summary
Fix line markers & envelope example to the correct sub dict in the json configuration.

### Changes

> Please provide a summary of what's being changed

### User experience

> Please share what the user experience looks like before and after this change

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [ ] [Meet tenets criteria](https://docs.powertools.aws.dev/lambda/python/#tenets)
* [ ] I have performed a self-review of this change
* [ ] Changes have been tested
* [ ] Changes are documented
* [ ] PR title follows [conventional commit semantics](https://github.com/aws-powertools/powertools-lambda-python/blob/develop/.github/semantic.yml)

<details>
<summary>Is this a breaking change?</summary>

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
