### PR TITLE
fix(event-handler): swagger schema respects api stage

### DIFF
--- a/aws_lambda_powertools/event_handler/api_gateway.py
+++ b/aws_lambda_powertools/event_handler/api_gateway.py
@@ -1692,7 +1692,13 @@ class ApiGatewayResolver(BaseRouter):
                     body=escaped_spec,
                 )
 
-            body = generate_swagger_html(escaped_spec, path, swagger_js, swagger_css, swagger_base_url)
+            body = generate_swagger_html(
+                escaped_spec,
+                f"{base_path}{path}",
+                swagger_js,
+                swagger_css,
+                swagger_base_url,
+            )
 
             return Response(
                 status_code=200,

--- a/tests/functional/event_handler/test_openapi_swagger.py
+++ b/tests/functional/event_handler/test_openapi_swagger.py
@@ -1,5 +1,4 @@
 import json
-from copy import deepcopy
 from typing import Dict
 
 from aws_lambda_powertools.event_handler import APIGatewayRestResolver
@@ -80,7 +79,7 @@ def test_openapi_swagger_with_rest_api_default_stage():
     app = APIGatewayRestResolver(enable_validation=True)
     app.enable_swagger()
 
-    event = deepcopy(LOAD_GW_EVENT)
+    event = load_event("apiGatewayProxyEvent.json")
     event["path"] = "/swagger"
     event["requestContext"]["stage"] = "$default"
 
@@ -93,7 +92,7 @@ def test_openapi_swagger_with_rest_api_stage():
     app = APIGatewayRestResolver(enable_validation=True)
     app.enable_swagger()
 
-    event = deepcopy(LOAD_GW_EVENT)
+    event = load_event("apiGatewayProxyEvent.json")
     event["path"] = "/swagger"
     event["requestContext"]["stage"] = "prod"
     event["requestContext"]["path"] = "/prod/swagger"


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
**Issue number:** #3793

## Summary

### Changes

> Please provide a summary of what's being changed

This PR fixes the path to the downloadable OpenAPI schema inside Swagger by taking into account the current API stage (if present).

### User experience

> Please share what the user experience looks like before and after this change

Users should be able to download the OpenAPI swagger when using API REST Gateway.

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] [Meet tenets criteria](https://docs.powertools.aws.dev/lambda/python/#tenets)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [X] Changes are documented
* [X] PR title follows [conventional commit semantics](https://github.com/aws-powertools/powertools-lambda-python/blob/develop/.github/semantic.yml)

<details>
<summary>Is this a breaking change?</summary>

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
