### PR TITLE
fix(typing): ensure return type is a str when default_value is set

### DIFF
--- a/aws_lambda_powertools/utilities/data_classes/api_gateway_authorizer_event.py
+++ b/aws_lambda_powertools/utilities/data_classes/api_gateway_authorizer_event.py
@@ -1,6 +1,6 @@
 import enum
 import re
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, overload
 
 from aws_lambda_powertools.utilities.data_classes.common import (
     BaseRequestContext,
@@ -161,6 +161,22 @@ class APIGatewayAuthorizerRequestEvent(DictWrapper):
     @property
     def request_context(self) -> BaseRequestContext:
         return BaseRequestContext(self._data)
+
+    @overload
+    def get_header_value(
+        self,
+        name: str,
+        default_value: str,
+        case_sensitive: Optional[bool] = False,
+    ) -> str: ...
+
+    @overload
+    def get_header_value(
+        self,
+        name: str,
+        default_value: Optional[str] = None,
+        case_sensitive: Optional[bool] = False,
+    ) -> Optional[str]: ...
 
     def get_header_value(
         self,


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
**Issue number: #3839**

## Summary

### Changes

Overload get_header_value.

### User experience

Ensure return type without casting.

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] [Meet tenets criteria](https://docs.powertools.aws.dev/lambda/python/#tenets)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [ ] Changes are documented
* [x] PR title follows [conventional commit semantics](https://github.com/aws-powertools/powertools-lambda-python/blob/develop/.github/semantic.yml)

<details>
<summary>Is this a breaking change?</summary>

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
