### PR TITLE
feat(event-source): add function to get multi-value query string params by name

### DIFF
--- a/aws_lambda_powertools/utilities/data_classes/alb_event.py
+++ b/aws_lambda_powertools/utilities/data_classes/alb_event.py
@@ -32,8 +32,8 @@ class ALBEvent(BaseProxyEvent):
         return ALBEventRequestContext(self._data)
 
     @property
-    def multi_value_query_string_parameters(self) -> Optional[Dict[str, List[str]]]:
-        return self.get("multiValueQueryStringParameters")
+    def multi_value_query_string_parameters(self) -> Dict[str, List[str]]:
+        return self.get("multiValueQueryStringParameters") or {}
 
     @property
     def resolved_query_string_parameters(self) -> Dict[str, List[str]]:

--- a/aws_lambda_powertools/utilities/data_classes/common.py
+++ b/aws_lambda_powertools/utilities/data_classes/common.py
@@ -105,8 +105,8 @@ class BaseProxyEvent(DictWrapper):
         return self.get("queryStringParameters")
 
     @property
-    def multi_value_query_string_parameters(self) -> Optional[Dict[str, List[str]]]:
-        return self.get("multiValueQueryStringParameters")
+    def multi_value_query_string_parameters(self) -> Dict[str, List[str]]:
+        return self.get("multiValueQueryStringParameters") or {}
 
     @property
     def resolved_query_string_parameters(self) -> Dict[str, List[str]]:

--- a/aws_lambda_powertools/utilities/data_classes/common.py
+++ b/aws_lambda_powertools/utilities/data_classes/common.py
@@ -193,7 +193,7 @@ class BaseProxyEvent(DictWrapper):
         self,
         name: str,
         default_values: Optional[List[str]] = None,
-    ) -> Optional[List[str]]:
+    ) ->List[str]:
         """Get multi-value query string parameter values by name
 
         Parameters

--- a/aws_lambda_powertools/utilities/data_classes/common.py
+++ b/aws_lambda_powertools/utilities/data_classes/common.py
@@ -7,6 +7,7 @@ from typing import Any, Callable, Dict, Iterator, List, Optional, overload
 from aws_lambda_powertools.shared.headers_serializer import BaseHeadersSerializer
 from aws_lambda_powertools.utilities.data_classes.shared_functions import (
     get_header_value,
+    get_multi_value_query_string_values,
     get_query_string_value,
 )
 
@@ -104,6 +105,10 @@ class BaseProxyEvent(DictWrapper):
         return self.get("queryStringParameters")
 
     @property
+    def multi_value_query_string_parameters(self) -> Optional[Dict[str, List[str]]]:
+        return self.get("multiValueQueryStringParameters")
+
+    @property
     def resolved_query_string_parameters(self) -> Dict[str, List[str]]:
         """
         This property determines the appropriate query string parameter to be used
@@ -182,6 +187,31 @@ class BaseProxyEvent(DictWrapper):
             query_string_parameters=self.query_string_parameters,
             name=name,
             default_value=default_value,
+        )
+
+    def get_multi_value_query_string_values(
+        self,
+        name: str,
+        default_values: Optional[List[str]] = None,
+    ) -> Optional[List[str]]:
+        """Get multi-value query string parameter values by name
+
+        Parameters
+        ----------
+        name: str
+            Multi-Value query string parameter name
+        default_values: List[str], optional
+            Default values is no values are found by name
+        Returns
+        -------
+        List[str], optional
+            List of query string values
+
+        """
+        return get_multi_value_query_string_values(
+            multi_value_query_string_parameters=self.multi_value_query_string_parameters,
+            name=name,
+            default_values=default_values,
         )
 
     @overload

--- a/aws_lambda_powertools/utilities/data_classes/shared_functions.py
+++ b/aws_lambda_powertools/utilities/data_classes/shared_functions.py
@@ -90,7 +90,7 @@ def get_multi_value_query_string_values(
     multi_value_query_string_parameters: Dict[str, list[str]] | None,
     name: str,
     default_values: list[str] | None = None,
-) -> list[str] | None:
+) -> list[str]:
     """
     Retrieves the values of a multi-value string parameters specified by the given name.
 
@@ -107,5 +107,7 @@ def get_multi_value_query_string_values(
         The values of the query string parameter if found, or the default values if not found.
     """
 
-    params = multi_value_query_string_parameters
-    return default_values if not params else params.get(name, default_values)
+    default = default_values or []
+    params = multi_value_query_string_parameters or {}
+
+    return params.get(name) or default

--- a/aws_lambda_powertools/utilities/data_classes/shared_functions.py
+++ b/aws_lambda_powertools/utilities/data_classes/shared_functions.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import base64
-from typing import Any
+from typing import Any, Dict
 
 
 def base64_decode(value: str) -> str:
@@ -63,7 +63,7 @@ def get_header_value(
 
 
 def get_query_string_value(
-    query_string_parameters: dict[str, str] | None,
+    query_string_parameters: Dict[str, str] | None,
     name: str,
     default_value: str | None = None,
 ) -> str | None:
@@ -84,3 +84,28 @@ def get_query_string_value(
     """
     params = query_string_parameters
     return default_value if params is None else params.get(name, default_value)
+
+
+def get_multi_value_query_string_values(
+    multi_value_query_string_parameters: Dict[str, list[str]] | None,
+    name: str,
+    default_values: list[str] | None = None,
+) -> list[str] | None:
+    """
+    Retrieves the values of a multi-value string parameters specified by the given name.
+
+    Parameters
+    ----------
+    name: str
+        The name of the query string parameter to retrieve.
+    default_value: list[str], optional
+        The default value to return if the parameter is not found. Defaults to None.
+
+    Returns
+    -------
+    List[str]. optional
+        The values of the query string parameter if found, or the default values if not found.
+    """
+
+    params = multi_value_query_string_parameters
+    return default_values if not params else params.get(name, default_values)

--- a/examples/event_handler_rest/src/accessing_request_details.py
+++ b/examples/event_handler_rest/src/accessing_request_details.py
@@ -1,4 +1,4 @@
-from typing import Optional
+from typing import List, Optional
 
 import requests
 from requests import Response
@@ -19,6 +19,9 @@ def get_todos():
     todo_id: str = app.current_event.get_query_string_value(name="id", default_value="")
     # alternatively
     _: Optional[str] = app.current_event.query_string_parameters.get("id")
+
+    # or multi-value query string parameters; ?category="red"&?category="blue"
+    _: List[str] = app.current_event.get_multi_value_query_string_values(name="category")
 
     # Payload
     _: Optional[str] = app.current_event.body  # raw str | None

--- a/tests/unit/data_classes/test_alb_event.py
+++ b/tests/unit/data_classes/test_alb_event.py
@@ -11,7 +11,9 @@ def test_alb_event():
     assert parsed_event.path == raw_event["path"]
     assert parsed_event.query_string_parameters == raw_event["queryStringParameters"]
     assert parsed_event.headers == raw_event["headers"]
-    assert parsed_event.multi_value_query_string_parameters == raw_event.get("multiValueQueryStringParameters")
+
+    assert parsed_event.multi_value_query_string_parameters == raw_event.get("multiValueQueryStringParameters", {})
+
     assert parsed_event.multi_value_headers == raw_event.get("multiValueHeaders")
     assert parsed_event.body == raw_event["body"]
     assert parsed_event.is_base64_encoded == raw_event["isBase64Encoded"]

--- a/tests/unit/test_data_classes.py
+++ b/tests/unit/test_data_classes.py
@@ -259,6 +259,25 @@ def test_base_proxy_event_get_query_string_value():
     assert value is None
 
 
+def test_base_proxy_event_get_multi_value_query_string_values():
+    default_values = ["default_1", "default_2"]
+    set_values = ["value_1", "value_2"]
+
+    event = BaseProxyEvent({})
+    values = event.get_multi_value_query_string_values("test", default_values)
+    assert values == default_values
+
+    event._data["multiValueQueryStringParameters"] = {"test": set_values}
+    values = event.get_multi_value_query_string_values("test", default_values)
+    assert values == set_values
+
+    values = event.get_multi_value_query_string_values("unknown", default_values)
+    assert values == default_values
+
+    values = event.get_multi_value_query_string_values("unknown")
+    assert values is None
+
+
 def test_base_proxy_event_get_header_value():
     default_value = "default"
     set_value = "value"

--- a/tests/unit/test_data_classes.py
+++ b/tests/unit/test_data_classes.py
@@ -275,7 +275,7 @@ def test_base_proxy_event_get_multi_value_query_string_values():
     assert values == default_values
 
     values = event.get_multi_value_query_string_values("unknown")
-    assert values is None
+    assert values == []
 
 
 def test_base_proxy_event_get_header_value():


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
**Issue number:** #3845

## Summary

### Changes

This adds a helper function to retrieve a list of multi-value query string params similar to the `get_query_string_value` function.


### User experience

Rather than getting the entire dictionary of multi-value parameters (`multi_value_query_string_parameters`), users
can get a single list of parameters by the name of the parameter.

`event.get_multi_value_query_string_values(name='param', default_values=['value_1']`

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] [Meet tenets criteria](https://docs.powertools.aws.dev/lambda/python/#tenets)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [ ] Changes are documented
* [x] PR title follows [conventional commit semantics](https://github.com/aws-powertools/powertools-lambda-python/blob/develop/.github/semantic.yml)

<details>
<summary>Is this a breaking change?</summary>

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
