### PR TITLE
fix(internal): call ruff with correct args

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ format:
 	poetry run black aws_lambda_powertools tests examples
 
 lint: format
-	poetry run ruff aws_lambda_powertools tests examples
+	poetry run ruff check aws_lambda_powertools tests examples
 
 lint-docs:
 	docker run -v ${PWD}:/markdown 06kellyjac/markdownlint-cli "docs"


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
**Issue number:** #3899

## Summary

### Changes

> Please provide a summary of what's being changed

This PR removes the warning when invoking `ruff`, by adding the new required `check` parameter.

### User experience

> Please share what the user experience looks like before and after this change

The warning is no longer present.

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] [Meet tenets criteria](https://docs.powertools.aws.dev/lambda/python/#tenets)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented
* [x] PR title follows [conventional commit semantics](https://github.com/aws-powertools/powertools-lambda-python/blob/develop/.github/semantic.yml)

<details>
<summary>Is this a breaking change?</summary>

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
