### PR TITLE
fix(event_handler): make decoded_body field optional in ApiGateway resolver

### DIFF
--- a/aws_lambda_powertools/utilities/data_classes/common.py
+++ b/aws_lambda_powertools/utilities/data_classes/common.py
@@ -150,13 +150,16 @@ class BaseProxyEvent(DictWrapper):
     @cached_property
     def json_body(self) -> Any:
         """Parses the submitted body as json"""
-        return self._json_deserializer(self.decoded_body)
+        if self.decoded_body:
+            return self._json_deserializer(self.decoded_body)
+
+        return None
 
     @cached_property
-    def decoded_body(self) -> str:
-        """Dynamically base64 decode body as a str"""
-        body: str = self["body"]
-        if self.is_base64_encoded:
+    def decoded_body(self) -> Optional[str]:
+        """Decode the body from base64 if encoded, otherwise return it as is."""
+        body: Optional[str] = self.body
+        if self.is_base64_encoded and body:
             return base64.b64decode(body.encode()).decode()
         return body
 

--- a/tests/unit/test_data_classes.py
+++ b/tests/unit/test_data_classes.py
@@ -324,25 +324,11 @@ def test_base_proxy_event_get_header_value_case_insensitive():
     assert value is None
 
 
-def test_base_proxy_event_json_body_key_error():
-    event = BaseProxyEvent({})
-    with pytest.raises(KeyError) as ke:
-        assert not event.json_body
-    assert str(ke.value) == "'body'"
-
-
 def test_base_proxy_event_json_body():
     data = {"message": "Foo"}
     event = BaseProxyEvent({"body": json.dumps(data)})
     assert event.json_body == data
     assert event.json_body["message"] == "Foo"
-
-
-def test_base_proxy_event_decode_body_key_error():
-    event = BaseProxyEvent({})
-    with pytest.raises(KeyError) as ke:
-        assert not event.decoded_body
-    assert str(ke.value) == "'body'"
 
 
 def test_base_proxy_event_decode_body_encoded_false():


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
**Issue number:** #3706  

## Summary

### Changes

This pull request resolves an issue within the event handler, specifically on the ApiGateway resolver. The `decoded_body` field is now optional, ensuring compatibility with diverse payloads, including local tests. Given that the field `body` is already optional, this change ensures consistency by making `decoded_body` Optional as well.

### User experience

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] [Meet tenets criteria](https://docs.powertools.aws.dev/lambda/python/#tenets)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented
* [x] PR title follows [conventional commit semantics](https://github.com/aws-powertools/powertools-lambda-python/blob/develop/.github/semantic.yml)

<details>
<summary>Is this a breaking change?</summary>

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
