### PR TITLE
docs(bedrock-agents): fix type in Bedrock operation example

### DIFF
--- a/examples/event_handler_bedrock_agents/src/customizing_bedrock_api_operations.py
+++ b/examples/event_handler_bedrock_agents/src/customizing_bedrock_api_operations.py
@@ -2,7 +2,7 @@ import requests
 from typing_extensions import Annotated
 
 from aws_lambda_powertools.event_handler import BedrockAgentResolver
-from aws_lambda_powertools.event_handler.openapi.params import Body, Query
+from aws_lambda_powertools.event_handler.openapi.params import Body, Path
 from aws_lambda_powertools.utilities.typing import LambdaContext
 
 app = BedrockAgentResolver()
@@ -22,7 +22,7 @@ app = BedrockAgentResolver()
     tags=["todos"],
 )
 def get_todo_title(
-    todo_id: Annotated[int, Query(description="The ID of the TODO item to get the title from")],
+    todo_id: Annotated[int, Path(description="The ID of the TODO item from which to retrieve the title")],
 ) -> Annotated[str, Body(description="The TODO title")]:
     todo = requests.get(f"https://jsonplaceholder.typicode.com/todos/{todo_id}")
     todo.raise_for_status()


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
**Issue number:** #3945

## Summary

### Changes

Changed the OpenAPI parameter specification from Query to Path, to correctly match the configuration of the `get` for the BedrockAgentResolver. Also reworded the Path description.  

### User experience

The example code is now accurate. 

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] [Meet tenets criteria](https://docs.powertools.aws.dev/lambda/python/#tenets)
* [x] I have performed a self-review of this change
* [ ] Changes have been tested
* [x] Changes are documented
* [x ] PR title follows [conventional commit semantics](https://github.com/aws-powertools/powertools-lambda-python/blob/develop/.github/semantic.yml)

<details>
<summary>Is this a breaking change?</summary>

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
