### PR TITLE
refactor(logger): add type annotation for append_keys method

### DIFF
--- a/aws_lambda_powertools/logging/logger.py
+++ b/aws_lambda_powertools/logging/logger.py
@@ -580,7 +580,7 @@ class Logger:
             extra=extra,
         )
 
-    def append_keys(self, **additional_keys) -> None:
+    def append_keys(self, **additional_keys: object) -> None:
         self.registered_formatter.append_keys(**additional_keys)
 
     def remove_keys(self, keys: Iterable[str]) -> None:


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
**Issue number:** #3989 

## Summary

Add type annotation for additional_keys parameter in append_keys function in the logger.py file.

Type `: object` as suggested by @leandrodamascena in the comment https://github.com/aws-powertools/powertools-lambda-python/pull/3869#issuecomment-2009693934

### Changes

Type annotation added.

### User experience

Type checker like Pyright stops complaining about missing type annotation.

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] [Meet tenets criteria](https://docs.powertools.aws.dev/lambda/python/#tenets)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [ ] Changes are documented
* [x] PR title follows [conventional commit semantics](https://github.com/aws-powertools/powertools-lambda-python/blob/develop/.github/semantic.yml)

<details>
<summary>Is this a breaking change?</summary>

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
