### PR TITLE
fix(event_handler): always add 422 response to the schema

### DIFF
--- a/aws_lambda_powertools/event_handler/openapi/types.py
+++ b/aws_lambda_powertools/event_handler/openapi/types.py
@@ -28,7 +28,7 @@ validation_error_definition = {
             "type": "array",
             "items": {"anyOf": [{"type": "string"}, {"type": "integer"}]},
         },
-        "msg": {"title": "Message", "type": "string"},
+        # For security reasons, we hide **msg** details (don't leak Python, Pydantic or filenames)
         "type": {"title": "Error Type", "type": "string"},
     },
     "required": ["loc", "msg", "type"],

--- a/tests/functional/event_handler/test_openapi_params.py
+++ b/tests/functional/event_handler/test_openapi_params.py
@@ -52,7 +52,7 @@ def test_openapi_no_params():
 
     assert JSON_CONTENT_TYPE in response.content
     json_response = response.content[JSON_CONTENT_TYPE]
-    assert json_response.schema_ == Schema()
+    assert json_response.schema_ is None
     assert not json_response.examples
     assert not json_response.encoding
 

--- a/tests/functional/event_handler/test_openapi_responses.py
+++ b/tests/functional/event_handler/test_openapi_responses.py
@@ -54,6 +54,32 @@ def test_openapi_200_custom_response():
     assert 422 in responses.keys()  # 422 is always added due to potential data validation errors
 
 
+def test_openapi_422_default_response():
+    app = APIGatewayRestResolver(enable_validation=True)
+
+    @app.get("/")
+    def handler():
+        return {"message": "hello world"}
+
+    schema = app.get_openapi_schema()
+    responses = schema.paths["/"].get.responses
+    assert 422 in responses.keys()
+    assert responses[422].description == "Validation Error"
+
+
+def test_openapi_422_custom_response():
+    app = APIGatewayRestResolver(enable_validation=True)
+
+    @app.get("/", responses={422: {"description": "Custom validation response"}})
+    def handler():
+        return {"message": "hello world"}
+
+    schema = app.get_openapi_schema()
+    responses = schema.paths["/"].get.responses
+    assert 422 in responses.keys()
+    assert responses[422].description == "Custom validation response"
+
+
 def test_openapi_200_custom_schema():
     app = APIGatewayRestResolver(enable_validation=True)
 

--- a/tests/functional/event_handler/test_openapi_responses.py
+++ b/tests/functional/event_handler/test_openapi_responses.py
@@ -50,8 +50,8 @@ def test_openapi_200_custom_response():
     assert 202 in responses.keys()
     assert responses[202].description == "Custom response"
 
-    assert 200 not in responses.keys()
-    assert 422 not in responses.keys()
+    assert 200 not in responses.keys()  # 200 was not added due to custom responses
+    assert 422 in responses.keys()  # 422 is always added due to potential data validation errors
 
 
 def test_openapi_200_custom_schema():


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
**Issue number:** #3600

## Summary

### Changes

> Please provide a summary of what's being changed

This PR makes sure that the 422 error is always added to the OpenAPI schema, even when the user is customizing the response.
It also fixes the default schema of the 422 error to not have a "msg" field, for security reasons.
Also took the opportunity to simplify the code to make it easier to read.

### User experience

> Please share what the user experience looks like before and after this change

After this PR, the user can still customize the openapi responses, while maintaining the 422 error that is generated when there is a validation error.

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] [Meet tenets criteria](https://docs.powertools.aws.dev/lambda/python/#tenets)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented
* [x] PR title follows [conventional commit semantics](https://github.com/aws-powertools/powertools-lambda-python/blob/develop/.github/semantic.yml)

<details>
<summary>Is this a breaking change?</summary>

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
