### PR TITLE
fix(event_source): fix typo in physicalname attribute for AmazonMQ events

### DIFF
--- a/aws_lambda_powertools/utilities/data_classes/active_mq_event.py
+++ b/aws_lambda_powertools/utilities/data_classes/active_mq_event.py
@@ -59,7 +59,7 @@ class ActiveMQMessage(DictWrapper):
 
     @property
     def destination_physicalname(self) -> str:
-        return self["destination"]["physicalname"]
+        return self["destination"]["physicalName"]
 
     @property
     def delivery_mode(self) -> Optional[int]:

--- a/tests/events/activeMQEvent.json
+++ b/tests/events/activeMQEvent.json
@@ -9,7 +9,7 @@
       "connectionId": "myJMSCoID",
       "redelivered": false,
       "destination": {
-        "physicalname": "testQueue"
+        "physicalName": "testQueue"
       },
       "timestamp": 1598827811958,
       "brokerInTime": 1598827811958,
@@ -25,7 +25,7 @@
       "connectionId": "myJMSCoID2",
       "redelivered": false,
       "destination": {
-        "physicalname": "testQueue"
+        "physicalName": "testQueue"
       },
       "timestamp": 1598827811958,
       "brokerInTime": 1598827811958,
@@ -42,7 +42,7 @@
       "connectionId": "myJMSCoID1",
       "persistent": false,
       "destination": {
-        "physicalname": "testQueue"
+        "physicalName": "testQueue"
       },
       "timestamp": 1598827811958,
       "brokerInTime": 1598827811958,

--- a/tests/unit/data_classes/test_active_mq_event.py
+++ b/tests/unit/data_classes/test_active_mq_event.py
@@ -27,7 +27,7 @@ def test_active_mq_event():
     assert message.broker_in_time == raw_event["messages"][0]["brokerInTime"]
     assert message.broker_out_time == raw_event["messages"][0]["brokerOutTime"]
     assert message.properties.get("testKey") == raw_event["messages"][0]["properties"]["testKey"]
-    assert message.destination_physicalname == raw_event["messages"][0]["destination"]["physicalname"]
+    assert message.destination_physicalname == raw_event["messages"][0]["destination"]["physicalName"]
     assert message.delivery_mode is None
     assert message.correlation_id is None
     assert message.reply_to is None


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
**Issue number:** #4051 

## Summary
Fixed a typo in attribute name of ActiveMQ event of AmazonMQ event integration

### Changes

Fixed typo in attribute name

### User experience

> Please share what the user experience looks like before and after this change

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] [Meet tenets criteria](https://docs.powertools.aws.dev/lambda/python/#tenets)
* [x] I have performed a self-review of this change
* [ ] Changes have been tested
* [ ] Changes are documented
* [x] PR title follows [conventional commit semantics](https://github.com/aws-powertools/powertools-lambda-python/blob/develop/.github/semantic.yml)

<details>
<summary>Is this a breaking change?</summary>

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
