### PR TITLE
feat(event_handler): add support for OpenAPI security schemes

### DIFF
--- a/aws_lambda_powertools/event_handler/api_gateway.py
+++ b/aws_lambda_powertools/event_handler/api_gateway.py
@@ -87,7 +87,6 @@ if TYPE_CHECKING:
         Server,
         Tag,
     )
-    from aws_lambda_powertools.event_handler.openapi.oauth2 import OAuth2Config
     from aws_lambda_powertools.event_handler.openapi.params import Dependant
     from aws_lambda_powertools.event_handler.openapi.types import (
         TypeModelOrEnum,
@@ -1670,7 +1669,6 @@ class ApiGatewayResolver(BaseRouter):
         contact: Optional["Contact"] = None,
         license_info: Optional["License"] = None,
         swagger_base_url: Optional[str] = None,
-        oauth2: Optional["OAuth2Config"] = None,
         middlewares: Optional[List[Callable[..., Response]]] = None,
         compress: bool = False,
     ):
@@ -1703,8 +1701,6 @@ class ApiGatewayResolver(BaseRouter):
             The license information for the exposed API.
         swagger_base_url: str, optional
             The base url for the swagger UI. If not provided, we will serve a recent version of the Swagger UI.
-        oauth2: OAuth2Config, optional
-            The OAuth2 configuration for the Swagger UI.
         middlewares: List[Callable[..., Response]], optional
             List of middlewares to be used for the swagger route.
         compress: bool, default = False
@@ -1769,7 +1765,6 @@ class ApiGatewayResolver(BaseRouter):
                 swagger_js,
                 swagger_css,
                 swagger_base_url,
-                oauth2,
             )
 
             return Response(

--- a/aws_lambda_powertools/event_handler/api_gateway.py
+++ b/aws_lambda_powertools/event_handler/api_gateway.py
@@ -1680,7 +1680,7 @@ class ApiGatewayResolver(BaseRouter):
         compress: bool = False,
         security_schemes: Optional[Dict[str, "SecurityScheme"]] = None,
         security: Optional[List[Dict[str, List[str]]]] = None,
-        oauth2Config: Optional["OAuth2Config"] = None,
+        oauth2_config: Optional["OAuth2Config"] = None,
     ):
         """
         Returns the OpenAPI schema as a JSON serializable dict
@@ -1719,7 +1719,7 @@ class ApiGatewayResolver(BaseRouter):
             A declaration of the security schemes available to be used in the specification.
         security: List[Dict[str, List[str]]], optional
             A declaration of which security mechanisms are applied globally across the API.
-        oauth2Config: OAuth2Config, optional
+        oauth2_config: OAuth2Config, optional
             The OAuth2 configuration for the Swagger UI.
         """
         from aws_lambda_powertools.event_handler.openapi.compat import model_json
@@ -1783,7 +1783,7 @@ class ApiGatewayResolver(BaseRouter):
                 swagger_js,
                 swagger_css,
                 swagger_base_url,
-                oauth2Config,
+                oauth2_config,
             )
 
             return Response(

--- a/aws_lambda_powertools/event_handler/api_gateway.py
+++ b/aws_lambda_powertools/event_handler/api_gateway.py
@@ -88,6 +88,7 @@ if TYPE_CHECKING:
         Tag,
     )
     from aws_lambda_powertools.event_handler.openapi.params import Dependant
+    from aws_lambda_powertools.event_handler.openapi.swagger_ui.oauth2 import OAuth2Config
     from aws_lambda_powertools.event_handler.openapi.types import (
         TypeModelOrEnum,
     )
@@ -1671,6 +1672,9 @@ class ApiGatewayResolver(BaseRouter):
         swagger_base_url: Optional[str] = None,
         middlewares: Optional[List[Callable[..., Response]]] = None,
         compress: bool = False,
+        security_schemes: Optional[Dict[str, "SecurityScheme"]] = None,
+        security: Optional[List[Dict[str, List[str]]]] = None,
+        oauth2Config: Optional["OAuth2Config"] = None,
     ):
         """
         Returns the OpenAPI schema as a JSON serializable dict
@@ -1705,6 +1709,12 @@ class ApiGatewayResolver(BaseRouter):
             List of middlewares to be used for the swagger route.
         compress: bool, default = False
             Whether or not to enable gzip compression swagger route.
+        security_schemes: Dict[str, "SecurityScheme"], optional
+            A declaration of the security schemes available to be used in the specification.
+        security: List[Dict[str, List[str]]], optional
+            A declaration of which security mechanisms are applied globally across the API.
+        oauth2Config: OAuth2Config, optional
+            The OAuth2 configuration for the Swagger UI.
         """
         from aws_lambda_powertools.event_handler.openapi.compat import model_json
         from aws_lambda_powertools.event_handler.openapi.models import Server
@@ -1736,6 +1746,8 @@ class ApiGatewayResolver(BaseRouter):
                 terms_of_service=terms_of_service,
                 contact=contact,
                 license_info=license_info,
+                security_schemes=security_schemes,
+                security=security,
             )
 
             # The .replace('</', '<\\/') part is necessary to prevent a potential issue where the JSON string contains
@@ -1765,6 +1777,7 @@ class ApiGatewayResolver(BaseRouter):
                 swagger_js,
                 swagger_css,
                 swagger_base_url,
+                oauth2Config,
             )
 
             return Response(

--- a/aws_lambda_powertools/event_handler/api_gateway.py
+++ b/aws_lambda_powertools/event_handler/api_gateway.py
@@ -2266,6 +2266,7 @@ class Router(BaseRouter):
         tags: Optional[List[str]] = None,
         operation_id: Optional[str] = None,
         include_in_schema: bool = True,
+        security: Optional[List[Dict[str, List[str]]]] = None,
         middlewares: Optional[List[Callable[..., Any]]] = None,
     ):
         def register_route(func: Callable):
@@ -2287,6 +2288,7 @@ class Router(BaseRouter):
                 frozen_tags,
                 operation_id,
                 include_in_schema,
+                security,
             )
 
             # Collate Middleware for routes

--- a/aws_lambda_powertools/event_handler/api_gateway.py
+++ b/aws_lambda_powertools/event_handler/api_gateway.py
@@ -1572,17 +1572,17 @@ class ApiGatewayResolver(BaseRouter):
         security: Optional[List[Dict[str, List[str]]]],
         security_schemes: Optional[Dict[str, "SecurityScheme"]],
     ) -> Optional[List[Dict[str, List[str]]]]:
-        if security:
-            if not security_schemes:
-                raise ValueError("security_schemes must be provided if security is provided")
-
-            # Check if all keys in security are present in the security_schemes
-            if not all(key in security_schemes for sec in security for key in sec):
-                raise ValueError("Some security schemes not found in security_schemes")
-
-            return security
-        else:
+        if not security:
             return None
+
+        if not security_schemes:
+            raise ValueError("security_schemes must be provided if security is provided")
+
+        # Check if all keys in security are present in the security_schemes
+        if any(key not in security_schemes for sec in security for key in sec):
+            raise ValueError("Some security schemes not found in security_schemes")
+
+        return security
 
     @staticmethod
     def _determine_openapi_version(openapi_version):

--- a/aws_lambda_powertools/event_handler/api_gateway.py
+++ b/aws_lambda_powertools/event_handler/api_gateway.py
@@ -1485,24 +1485,11 @@ class ApiGatewayResolver(BaseRouter):
             get_definitions,
         )
         from aws_lambda_powertools.event_handler.openapi.models import OpenAPI, PathItem, Server, Tag
-        from aws_lambda_powertools.event_handler.openapi.pydantic_loader import PYDANTIC_V2
         from aws_lambda_powertools.event_handler.openapi.types import (
             COMPONENT_REF_TEMPLATE,
         )
 
-        # Pydantic V2 has no support for OpenAPI schema 3.0
-        if PYDANTIC_V2 and not openapi_version.startswith("3.1"):
-            warnings.warn(
-                "You are using Pydantic v2, which is incompatible with OpenAPI schema 3.0. Forcing OpenAPI 3.1",
-                stacklevel=2,
-            )
-            openapi_version = "3.1.0"
-        elif not PYDANTIC_V2 and not openapi_version.startswith("3.0"):
-            warnings.warn(
-                "You are using Pydantic v1, which is incompatible with OpenAPI schema 3.1. Forcing OpenAPI 3.0",
-                stacklevel=2,
-            )
-            openapi_version = "3.0.3"
+        openapi_version = self._determine_openapi_version(openapi_version)
 
         # Start with the bare minimum required for a valid OpenAPI schema
         info: Dict[str, Any] = {"title": title, "version": version}
@@ -1581,6 +1568,25 @@ class ApiGatewayResolver(BaseRouter):
         output["paths"] = {k: PathItem(**v) for k, v in paths.items()}
 
         return OpenAPI(**output)
+
+    @staticmethod
+    def _determine_openapi_version(openapi_version):
+        from aws_lambda_powertools.event_handler.openapi.pydantic_loader import PYDANTIC_V2
+
+        # Pydantic V2 has no support for OpenAPI schema 3.0
+        if PYDANTIC_V2 and not openapi_version.startswith("3.1"):
+            warnings.warn(
+                "You are using Pydantic v2, which is incompatible with OpenAPI schema 3.0. Forcing OpenAPI 3.1",
+                stacklevel=2,
+            )
+            openapi_version = "3.1.0"
+        elif not PYDANTIC_V2 and not openapi_version.startswith("3.0"):
+            warnings.warn(
+                "You are using Pydantic v1, which is incompatible with OpenAPI schema 3.1. Forcing OpenAPI 3.0",
+                stacklevel=2,
+            )
+            openapi_version = "3.0.3"
+        return openapi_version
 
     def get_openapi_json_schema(
         self,

--- a/aws_lambda_powertools/event_handler/bedrock_agent.py
+++ b/aws_lambda_powertools/event_handler/bedrock_agent.py
@@ -102,6 +102,8 @@ class BedrockAgentResolver(ApiGatewayResolver):
         include_in_schema: bool = True,
         middlewares: Optional[List[Callable[..., Any]]] = None,
     ) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
+        security = None
+
         return super(BedrockAgentResolver, self).get(
             rule,
             cors,
@@ -114,6 +116,7 @@ class BedrockAgentResolver(ApiGatewayResolver):
             tags,
             operation_id,
             include_in_schema,
+            security,
             middlewares,
         )
 
@@ -134,6 +137,8 @@ class BedrockAgentResolver(ApiGatewayResolver):
         include_in_schema: bool = True,
         middlewares: Optional[List[Callable[..., Any]]] = None,
     ):
+        security = None
+
         return super().post(
             rule,
             cors,
@@ -146,6 +151,7 @@ class BedrockAgentResolver(ApiGatewayResolver):
             tags,
             operation_id,
             include_in_schema,
+            security,
             middlewares,
         )
 
@@ -166,6 +172,8 @@ class BedrockAgentResolver(ApiGatewayResolver):
         include_in_schema: bool = True,
         middlewares: Optional[List[Callable[..., Any]]] = None,
     ):
+        security = None
+
         return super().put(
             rule,
             cors,
@@ -178,6 +186,7 @@ class BedrockAgentResolver(ApiGatewayResolver):
             tags,
             operation_id,
             include_in_schema,
+            security,
             middlewares,
         )
 
@@ -198,6 +207,8 @@ class BedrockAgentResolver(ApiGatewayResolver):
         include_in_schema: bool = True,
         middlewares: Optional[List[Callable]] = None,
     ):
+        security = None
+
         return super().patch(
             rule,
             cors,
@@ -210,6 +221,7 @@ class BedrockAgentResolver(ApiGatewayResolver):
             tags,
             operation_id,
             include_in_schema,
+            security,
             middlewares,
         )
 
@@ -230,6 +242,8 @@ class BedrockAgentResolver(ApiGatewayResolver):
         include_in_schema: bool = True,
         middlewares: Optional[List[Callable[..., Any]]] = None,
     ):
+        security = None
+
         return super().delete(
             rule,
             cors,
@@ -242,6 +256,7 @@ class BedrockAgentResolver(ApiGatewayResolver):
             tags,
             operation_id,
             include_in_schema,
+            security,
             middlewares,
         )
 

--- a/aws_lambda_powertools/event_handler/openapi/models.py
+++ b/aws_lambda_powertools/event_handler/openapi/models.py
@@ -447,6 +447,7 @@ class SecurityBase(BaseModel):
 
         class Config:
             extra = "allow"
+            allow_population_by_field_name = True
 
 
 class APIKeyIn(Enum):

--- a/aws_lambda_powertools/event_handler/openapi/models.py
+++ b/aws_lambda_powertools/event_handler/openapi/models.py
@@ -441,7 +441,7 @@ class SecurityBase(BaseModel):
     description: Optional[str] = None
 
     if PYDANTIC_V2:
-        model_config = {"extra": "allow"}
+        model_config = {"extra": "allow", "populate_by_name": True}
 
     else:
 

--- a/aws_lambda_powertools/event_handler/openapi/swagger_ui/__init__.py
+++ b/aws_lambda_powertools/event_handler/openapi/swagger_ui/__init__.py
@@ -1,0 +1,15 @@
+from aws_lambda_powertools.event_handler.openapi.swagger_ui.html import (
+    generate_swagger_html,
+)
+from aws_lambda_powertools.event_handler.openapi.swagger_ui.oauth2 import (
+    OAuth2Config,
+    OAuth2UnsafeConfig,
+    generate_oauth2_redirect_html,
+)
+
+__all__ = [
+    "generate_swagger_html",
+    "generate_oauth2_redirect_html",
+    "OAuth2Config",
+    "OAuth2UnsafeConfig",
+]

--- a/aws_lambda_powertools/event_handler/openapi/swagger_ui/__init__.py
+++ b/aws_lambda_powertools/event_handler/openapi/swagger_ui/__init__.py
@@ -3,7 +3,6 @@ from aws_lambda_powertools.event_handler.openapi.swagger_ui.html import (
 )
 from aws_lambda_powertools.event_handler.openapi.swagger_ui.oauth2 import (
     OAuth2Config,
-    OAuth2UnsafeConfig,
     generate_oauth2_redirect_html,
 )
 
@@ -11,5 +10,4 @@ __all__ = [
     "generate_swagger_html",
     "generate_oauth2_redirect_html",
     "OAuth2Config",
-    "OAuth2UnsafeConfig",
 ]

--- a/aws_lambda_powertools/event_handler/openapi/swagger_ui/html.py
+++ b/aws_lambda_powertools/event_handler/openapi/swagger_ui/html.py
@@ -66,6 +66,9 @@ def generate_swagger_html(
 {swagger_js_content}
 
 <script>
+  var currentUrl = new URL(window.location.href);
+  var baseUrl = currentUrl.protocol + "//" + currentUrl.host + currentUrl.pathname;
+
   var swaggerUIOptions = {{
     dom_id: "#swagger-ui",
     docExpansion: "list",
@@ -81,7 +84,9 @@ def generate_swagger_html(
     ],
     plugins: [
       SwaggerUIBundle.plugins.DownloadUrl
-    ]
+    ],
+    withCredentials: true,
+    oauth2RedirectUrl: baseUrl + "?format=oauth2-redirect",
   }}
 
   var ui = SwaggerUIBundle(swaggerUIOptions)

--- a/aws_lambda_powertools/event_handler/openapi/swagger_ui/html.py
+++ b/aws_lambda_powertools/event_handler/openapi/swagger_ui/html.py
@@ -9,7 +9,7 @@ def generate_swagger_html(
     swagger_js: str,
     swagger_css: str,
     swagger_base_url: str,
-    oauth2: Optional[OAuth2Config],
+    oauth2_config: Optional[OAuth2Config],
 ) -> str:
     """
     Generate Swagger UI HTML page
@@ -26,7 +26,7 @@ def generate_swagger_html(
         The URL to the Swagger UI CSS file
     swagger_base_url: str
         The base URL for Swagger UI
-    oauth2: OAuth2Config, optional
+    oauth2_config: OAuth2Config, optional
         The OAuth2 configuration.
     """
 
@@ -40,7 +40,9 @@ def generate_swagger_html(
         swagger_js_content = f"<script>{swagger_js}</script>"
 
     # Prepare oauth2 config
-    oauth2_content = f"ui.initOAuth({oauth2.json(exclude_none=True, exclude_unset=True)});" if oauth2 else ""
+    oauth2_content = (
+        f"ui.initOAuth({oauth2_config.json(exclude_none=True, exclude_unset=True)});" if oauth2_config else ""
+    )
 
     return f"""
 <!DOCTYPE html>

--- a/aws_lambda_powertools/event_handler/openapi/swagger_ui/html.py
+++ b/aws_lambda_powertools/event_handler/openapi/swagger_ui/html.py
@@ -21,9 +21,9 @@ def generate_swagger_html(
     path: str
         The path to the Swagger documentation
     swagger_js: str
-        The URL to the Swagger UI JavaScript file
+       Swagger UI JavaScript source code or URL
     swagger_css: str
-        The URL to the Swagger UI CSS file
+        Swagger UI CSS source code or URL
     swagger_base_url: str
         The base URL for Swagger UI
     oauth2_config: OAuth2Config, optional

--- a/aws_lambda_powertools/event_handler/openapi/swagger_ui/html.py
+++ b/aws_lambda_powertools/event_handler/openapi/swagger_ui/html.py
@@ -1,4 +1,16 @@
-def generate_swagger_html(spec: str, path: str, swagger_js: str, swagger_css: str, swagger_base_url: str) -> str:
+from typing import Optional
+
+from aws_lambda_powertools.event_handler.openapi.swagger_ui.oauth2 import OAuth2Config
+
+
+def generate_swagger_html(
+    spec: str,
+    path: str,
+    swagger_js: str,
+    swagger_css: str,
+    swagger_base_url: str,
+    oauth2: Optional[OAuth2Config],
+) -> str:
     """
     Generate Swagger UI HTML page
 
@@ -8,10 +20,14 @@ def generate_swagger_html(spec: str, path: str, swagger_js: str, swagger_css: st
         The OpenAPI spec
     path: str
         The path to the Swagger documentation
-    js_url: str
+    swagger_js: str
         The URL to the Swagger UI JavaScript file
-    css_url: str
+    swagger_css: str
         The URL to the Swagger UI CSS file
+    swagger_base_url: str
+        The base URL for Swagger UI
+    oauth2: OAuth2Config, optional
+        The OAuth2 configuration.
     """
 
     # If Swagger base URL is present, generate HTML content with linked CSS and JavaScript files
@@ -22,6 +38,9 @@ def generate_swagger_html(spec: str, path: str, swagger_js: str, swagger_css: st
     else:
         swagger_css_content = f"<style>{swagger_css}</style>"
         swagger_js_content = f"<script>{swagger_js}</script>"
+
+    # Prepare oauth2 config
+    oauth2_content = f"ui.initOAuth({oauth2.json(exclude_none=True, exclude_unset=True)});" if oauth2 else ""
 
     return f"""
 <!DOCTYPE html>
@@ -65,6 +84,7 @@ def generate_swagger_html(spec: str, path: str, swagger_js: str, swagger_css: st
 
   var ui = SwaggerUIBundle(swaggerUIOptions)
   ui.specActions.updateUrl('{path}?format=json');
+  {oauth2_content}
 </script>
 </html>
             """.strip()

--- a/aws_lambda_powertools/event_handler/openapi/swagger_ui/oauth2.py
+++ b/aws_lambda_powertools/event_handler/openapi/swagger_ui/oauth2.py
@@ -1,0 +1,27 @@
+from typing import Dict, Sequence
+
+from pydantic import BaseModel, Field
+
+from aws_lambda_powertools.event_handler.openapi.pydantic_loader import PYDANTIC_V2
+
+
+# Based on https://swagger.io/docs/open-source-tools/swagger-ui/usage/oauth2/
+class OAuth2Config(BaseModel):
+    clientId: str = Field(alias="client_id")
+    realm: str
+    appName: str = Field(alias="app_name")
+    scopes: Sequence[str] = Field(default=[])
+    additionalQueryStringParams: Dict[str, str] = Field(alias="additional_query_string_params", default={})
+    useBasicAuthenticationWithAccessCodeGrant: bool = Field(
+        alias="use_basic_authentication_with_access_code_grant",
+        default=False,
+    )
+    usePkceWithAuthorizationCodeGrant: bool = Field(alias="use_pkce_with_authorization_code_grant", default=False)
+
+    if PYDANTIC_V2:
+        model_config = {"extra": "allow"}
+    else:
+
+        class Config:
+            extra = "allow"
+            allow_population_by_field_name = True

--- a/aws_lambda_powertools/event_handler/openapi/swagger_ui/oauth2.py
+++ b/aws_lambda_powertools/event_handler/openapi/swagger_ui/oauth2.py
@@ -14,7 +14,7 @@ class OAuth2Config(BaseModel):
     """
 
     # The client ID for the OAuth2 application
-    clientId: str = Field(alias="client_id")
+    clientId: Optional[str] = Field(alias="client_id", default=None)
 
     # The client secret for the OAuth2 application. This is sensitive information and requires the explicit presence
     # of the POWERTOOLS_DEV environment variable.

--- a/aws_lambda_powertools/event_handler/openapi/swagger_ui/oauth2.py
+++ b/aws_lambda_powertools/event_handler/openapi/swagger_ui/oauth2.py
@@ -1,4 +1,5 @@
-from typing import Dict, Sequence
+# ruff: noqa: E501
+from typing import Dict, Optional, Sequence
 
 from pydantic import BaseModel, Field
 
@@ -7,15 +8,32 @@ from aws_lambda_powertools.event_handler.openapi.pydantic_loader import PYDANTIC
 
 # Based on https://swagger.io/docs/open-source-tools/swagger-ui/usage/oauth2/
 class OAuth2Config(BaseModel):
+    """
+    OAuth2 configuration for Swagger UI
+    """
+
+    # The client ID for the OAuth2 application
     clientId: str = Field(alias="client_id")
-    realm: str
+
+    # The realm in which the OAuth2 application is registered. Optional.
+    realm: Optional[str]
+
+    # The name of the OAuth2 application
     appName: str = Field(alias="app_name")
+
+    # The scopes that the OAuth2 application requires. Defaults to an empty list.
     scopes: Sequence[str] = Field(default=[])
+
+    # Additional query string parameters to be included in the OAuth2 request. Defaults to an empty dictionary.
     additionalQueryStringParams: Dict[str, str] = Field(alias="additional_query_string_params", default={})
+
+    # Whether to use basic authentication with the access code grant type. Defaults to False.
     useBasicAuthenticationWithAccessCodeGrant: bool = Field(
         alias="use_basic_authentication_with_access_code_grant",
         default=False,
     )
+
+    # Whether to use PKCE with the authorization code grant type. Defaults to False.
     usePkceWithAuthorizationCodeGrant: bool = Field(alias="use_pkce_with_authorization_code_grant", default=False)
 
     if PYDANTIC_V2:
@@ -25,3 +43,100 @@ class OAuth2Config(BaseModel):
         class Config:
             extra = "allow"
             allow_population_by_field_name = True
+
+
+class OAuth2UnsafeConfig(OAuth2Config):
+    """
+    This class extends the OAuth2Config class and includes the client secret.
+    This class NEVER BE USED IN PRODUCTION as it will expose sensitive information.
+    """
+
+    # The client secret for the OAuth2 application. This is sensitive information.
+    clientSecret: str = Field(alias="client_secret")
+
+
+def generate_oauth2_redirect_html() -> str:
+    """
+    Generates the HTML content for the OAuth2 redirect page.
+    """
+    return """
+<!doctype html>
+<html lang="en-US">
+<head>
+    <title>Swagger UI: OAuth2 Redirect</title>
+</head>
+<body>
+<script>
+    'use strict';
+    function run () {
+        var oauth2 = window.opener.swaggerUIRedirectOauth2;
+        var sentState = oauth2.state;
+        var redirectUrl = oauth2.redirectUrl;
+        var isValid, qp, arr;
+
+        if (/code|token|error/.test(window.location.hash)) {
+            qp = window.location.hash.substring(1).replace('?', '&');
+        } else {
+            qp = location.search.substring(1);
+        }
+
+        arr = qp.split("&");
+        arr.forEach(function (v,i,_arr) { _arr[i] = '"' + v.replace('=', '":"') + '"';});
+        qp = qp ? JSON.parse('{' + arr.join() + '}',
+                function (key, value) {
+                    return key === "" ? value : decodeURIComponent(value);
+                }
+        ) : {};
+
+        isValid = qp.state === sentState;
+
+        if ((
+          oauth2.auth.schema.get("flow") === "accessCode" ||
+          oauth2.auth.schema.get("flow") === "authorizationCode" ||
+          oauth2.auth.schema.get("flow") === "authorization_code"
+        ) && !oauth2.auth.code) {
+            if (!isValid) {
+                oauth2.errCb({
+                    authId: oauth2.auth.name,
+                    source: "auth",
+                    level: "warning",
+                    message: "Authorization may be unsafe, passed state was changed in server. The passed state wasn't returned from auth server."
+                });
+            }
+
+            if (qp.code) {
+                delete oauth2.state;
+                oauth2.auth.code = qp.code;
+                oauth2.callback({auth: oauth2.auth, redirectUrl: redirectUrl});
+            } else {
+                let oauthErrorMsg;
+                if (qp.error) {
+                    oauthErrorMsg = "["+qp.error+"]: " +
+                        (qp.error_description ? qp.error_description+ ". " : "no accessCode received from the server. ") +
+                        (qp.error_uri ? "More info: "+qp.error_uri : "");
+                }
+
+                oauth2.errCb({
+                    authId: oauth2.auth.name,
+                    source: "auth",
+                    level: "error",
+                    message: oauthErrorMsg || "[Authorization failed]: no accessCode received from the server."
+                });
+            }
+        } else {
+            oauth2.callback({auth: oauth2.auth, token: qp, isValid: isValid, redirectUrl: redirectUrl});
+        }
+        window.close();
+    }
+
+    if (document.readyState !== 'loading') {
+        run();
+    } else {
+        document.addEventListener('DOMContentLoaded', function () {
+            run();
+        });
+    }
+</script>
+</body>
+</html>
+    """.strip()

--- a/aws_lambda_powertools/event_handler/openapi/swagger_ui/oauth2.py
+++ b/aws_lambda_powertools/event_handler/openapi/swagger_ui/oauth2.py
@@ -1,4 +1,5 @@
 # ruff: noqa: E501
+import warnings
 from typing import Dict, Optional, Sequence
 
 from pydantic import BaseModel, Field, validator
@@ -56,6 +57,13 @@ class OAuth2Config(BaseModel):
                 "cannot use client_secret without POWERTOOLS_DEV mode. See "
                 "https://docs.powertools.aws.dev/lambda/python/latest/#optimizing-for-non-production-environments",
             )
+        else:
+            warnings.warn(
+                "OAuth2Config is using client_secret and POWERTOOLS_DEV is set. This reveals sensitive information. "
+                "DO NOT USE THIS OUTSIDE LOCAL DEVELOPMENT",
+                stacklevel=2,
+            )
+
         return v
 
 

--- a/aws_lambda_powertools/event_handler/openapi/swagger_ui/oauth2.py
+++ b/aws_lambda_powertools/event_handler/openapi/swagger_ui/oauth2.py
@@ -16,7 +16,7 @@ class OAuth2Config(BaseModel):
     clientId: str = Field(alias="client_id")
 
     # The realm in which the OAuth2 application is registered. Optional.
-    realm: Optional[str]
+    realm: Optional[str] = Field(default=None)
 
     # The name of the OAuth2 application
     appName: str = Field(alias="app_name")

--- a/aws_lambda_powertools/event_handler/openapi/swagger_ui/oauth2.py
+++ b/aws_lambda_powertools/event_handler/openapi/swagger_ui/oauth2.py
@@ -52,7 +52,10 @@ class OAuth2Config(BaseModel):
 
     @validator("clientSecret", always=True)
     def client_secret_only_on_dev(cls, v: Optional[str]) -> Optional[str]:
-        if v and not powertools_dev_is_set():
+        if not v:
+            return None
+
+        if not powertools_dev_is_set():
             raise ValueError(
                 "cannot use client_secret without POWERTOOLS_DEV mode. See "
                 "https://docs.powertools.aws.dev/lambda/python/latest/#optimizing-for-non-production-environments",
@@ -63,8 +66,7 @@ class OAuth2Config(BaseModel):
                 "DO NOT USE THIS OUTSIDE LOCAL DEVELOPMENT",
                 stacklevel=2,
             )
-
-        return v
+            return v
 
 
 def generate_oauth2_redirect_html() -> str:

--- a/aws_lambda_powertools/event_handler/openapi/swagger_ui/oauth2.py
+++ b/aws_lambda_powertools/event_handler/openapi/swagger_ui/oauth2.py
@@ -58,6 +58,8 @@ class OAuth2UnsafeConfig(OAuth2Config):
 def generate_oauth2_redirect_html() -> str:
     """
     Generates the HTML content for the OAuth2 redirect page.
+
+    Source: https://github.com/swagger-api/swagger-ui/blob/master/dist/oauth2-redirect.html
     """
     return """
 <!doctype html>

--- a/docs/core/event_handler/api_gateway.md
+++ b/docs/core/event_handler/api_gateway.md
@@ -1029,7 +1029,7 @@ Below is an example configuration for serving Swagger UI from a custom path or C
 #### Security schemes
 
 ???-info "Does Powertools implement any of the security schemes?"
-    No. Powertools adds support for generating OpenAPI documentation with security schemes, but it doesn't implement any of the security schemes itself.
+    No. Powertools adds support for generating OpenAPI documentation with [security schemes](https://swagger.io/docs/specification/authentication/), but it doesn't implement any of the security schemes itself, so you must implement the security mechanisms separately.
 
 OpenAPI uses the term security scheme for [authentication and authorization schemes](https://swagger.io/docs/specification/authentication/){target="_blank"}.
 When you're describing your API, declare security schemes at the top level, and reference them globally or per operation.

--- a/docs/core/event_handler/api_gateway.md
+++ b/docs/core/event_handler/api_gateway.md
@@ -991,6 +991,18 @@ To implement these customizations, include extra parameters when defining your r
 --8<-- "examples/event_handler_rest/src/customizing_api_operations.py"
 ```
 
+#### Customizing OpenAPI metadata
+
+--8<-- "docs/core/event_handler/_openapi_customization_metadata.md"
+
+Include extra parameters when exporting your OpenAPI specification to apply these customizations:
+
+=== "customizing_api_metadata.py"
+
+    ```python hl_lines="25-31"
+    --8<-- "examples/event_handler_rest/src/customizing_api_metadata.py"
+    ```
+
 #### Customizing Swagger UI
 
 ???+note "Customizing the Swagger metadata"
@@ -1014,16 +1026,44 @@ Below is an example configuration for serving Swagger UI from a custom path or C
    --8<-- "examples/event_handler_rest/src/customizing_swagger_middlewares.py"
    ```
 
-#### Customizing OpenAPI metadata
+#### Security schemes
 
---8<-- "docs/core/event_handler/_openapi_customization_metadata.md"
+???-info "Does Powertools implement any of the security schemes?"
+    No. Powertools adds support for generating OpenAPI documentation with security schemes, but it doesn't implement any of the security schemes itself.
 
-Include extra parameters when exporting your OpenAPI specification to apply these customizations:
+OpenAPI uses the term security scheme for [authentication and authorization schemes](https://swagger.io/docs/specification/authentication/){target="_blank"}.
+When you're describing your API, declare security schemes at the top level, and reference them globally or per operation.
 
-=== "customizing_api_metadata.py"
+=== "Global OpenAPI security schemes"
 
-    ```python hl_lines="25-31"
-    --8<-- "examples/event_handler_rest/src/customizing_api_metadata.py"
+    ```python title="security_schemes_global.py" hl_lines="32-42"
+    --8<-- "examples/event_handler_rest/src/security_schemes_global.py"
+    ```
+
+    1. Using the oauth security scheme defined earlier, scoped to the "admin" role.
+
+=== "Per Operation security"
+
+    ```python title="security_schemes_per_operation.py" hl_lines="17 32-41"
+    --8<-- "examples/event_handler_rest/src/security_schemes_per_operation.py"
+    ```
+
+    1. Using the oauth security scheme defined bellow, scoped to the "admin" role.
+
+OpenAPI 3 lets you describe APIs protected using the following security schemes:
+
+| Security Scheme                                                                                                                                                                         | Type            | Description                                                                                                                                                                                                                                                                         |
+|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-----------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| [HTTP auth](https://www.iana.org/assignments/http-authschemes/http-authschemes.xhtml){target="_blank"}                                                                                  | `HTTPBase`      | HTTP authentication schemes using the Authorization header (e.g: [Basic auth](https://swagger.io/docs/specification/authentication/basic-authentication/){target="_blank"}, [Bearer](https://swagger.io/docs/specification/authentication/bearer-authentication/){target="_blank"}) |
+| [API keys](https://swagger.io/docs/specification/authentication/api-keys/https://swagger.io/docs/specification/authentication/api-keys/){target="_blank"} (e.g: query strings, cookies) | `APIKey`        | API keys in headers, query strings or [cookies](https://swagger.io/docs/specification/authentication/cookie-authentication/){target="_blank"}.                                                                                                                                      |
+| [OAuth 2](https://swagger.io/docs/specification/authentication/oauth2/){target="_blank"}                                                                                                | `OAuth2`        | Authorization protocol that gives an API client limited access to user data on a web server.                                                                                                                                                                                        |
+| [OpenID Connect Discovery](https://swagger.io/docs/specification/authentication/openid-connect-discovery/){target="_blank"}                                                             | `OpenIdConnect` | Identity layer built [on top of the OAuth 2.0 protocol](https://openid.net/developers/how-connect-works/){target="_blank"} and supported by some OAuth 2.0.                                                                                                                         |
+
+???-note "Using OAuth2 with the Swagger UI?"
+    You can use the `OAuth2Config` option to configure a default OAuth2 app on the generated Swagger UI.
+
+    ```python hl_lines="10 15-18 22"
+    --8<-- "examples/event_handler_rest/src/swagger_with_oauth2.py"
     ```
 
 ### Custom serializer

--- a/examples/event_handler_rest/sam/swagger_ui_oauth2_template.yaml
+++ b/examples/event_handler_rest/sam/swagger_ui_oauth2_template.yaml
@@ -1,0 +1,28 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Transform: AWS::Serverless-2016-10-31
+Description: Sample SAM Template for Oauth2 Cognito User Pool + Swagger UI
+
+Globals:
+  Function:
+    Timeout: 5
+    Runtime: python3.12
+    Tracing: Active
+    Environment:
+      Variables:
+        LOG_LEVEL: INFO
+        POWERTOOLS_LOGGER_SAMPLE_RATE: 0.1
+        POWERTOOLS_LOGGER_LOG_EVENT: true
+        POWERTOOLS_SERVICE_NAME: example
+
+Resources:
+  HelloWorldFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      CodeUri: hello_world/
+      Handler: swagger_ui_oauth2.lambda_handler
+      Events:
+        AnyApiEvent:
+          Type: Api
+          Properties:
+            Path: /{proxy+} # Send requests on any path to the lambda function
+            Method: ANY # Send requests using any http method to the lambda function

--- a/examples/event_handler_rest/sam/swagger_ui_oauth2_template.yaml
+++ b/examples/event_handler_rest/sam/swagger_ui_oauth2_template.yaml
@@ -18,11 +18,67 @@ Resources:
   HelloWorldFunction:
     Type: AWS::Serverless::Function
     Properties:
-      CodeUri: hello_world/
+      CodeUri: ../src
       Handler: swagger_ui_oauth2.lambda_handler
+      Environment:
+        Variables:
+          COGNITO_USER_POOL_DOMAIN: !Ref UserPoolDomain
       Events:
         AnyApiEvent:
           Type: Api
           Properties:
             Path: /{proxy+} # Send requests on any path to the lambda function
             Method: ANY # Send requests using any http method to the lambda function
+
+  CognitoUserPool:
+    Type: AWS::Cognito::UserPool
+    Properties:
+      UserPoolName: PowertoolsUserPool
+      Policies:
+        PasswordPolicy:
+          MinimumLength: 8
+          RequireLowercase: true
+          RequireNumbers: true
+          RequireSymbols: true
+          RequireUppercase: true
+
+  CognitoUserPoolClient:
+    Type: AWS::Cognito::UserPoolClient
+    Properties:
+      ClientName: PowertoolsClient
+      UserPoolId: !Ref CognitoUserPool
+      GenerateSecret: true
+      RefreshTokenValidity: 30
+      ExplicitAuthFlows:
+        - ALLOW_USER_PASSWORD_AUTH
+        - ALLOW_REFRESH_TOKEN_AUTH
+      SupportedIdentityProviders:
+        - COGNITO
+      CallbackURLs:
+        # NOTE: for this to work, your OAuth2 redirect url needs to precisely follow this format:
+        # https://<your_api_id>.execute-api.<region>.amazonaws.com/<stage>/swagger?format=oauth2-redirect
+        - !Sub "https://${ServerlessRestApi}.execute-api.${AWS::Region}.amazonaws.com/${ServerlessRestApi.Stage}/swagger?format=oauth2-redirect"
+      AllowedOAuthFlows:
+        - code
+      AllowedOAuthScopes:
+        - openid
+        - email
+        - profile
+        - aws.cognito.signin.user.admin
+      AllowedOAuthFlowsUserPoolClient: true
+
+  UserPoolDomain:
+    Type: AWS::Cognito::UserPoolDomain
+    Properties:
+      Domain: powertools-swagger-oauth2
+      UserPoolId: !Ref CognitoUserPool
+
+Outputs:
+  HelloWorldApiUrl:
+    Value: !Sub "https://${ServerlessRestApi}.execute-api.${AWS::Region}.amazonaws.com/${ServerlessRestApi.Stage}/swagger"
+
+  CognitoOAuthClientId:
+    Value: !GetAtt CognitoUserPoolClient.ClientId
+
+  CognitoDomain:
+    Value: !Ref UserPoolDomain

--- a/examples/event_handler_rest/src/security_schemes_global.py
+++ b/examples/event_handler_rest/src/security_schemes_global.py
@@ -1,0 +1,44 @@
+from aws_lambda_powertools import Logger, Tracer
+from aws_lambda_powertools.event_handler import (
+    APIGatewayRestResolver,
+)
+from aws_lambda_powertools.event_handler.openapi.models import (
+    OAuth2,
+    OAuthFlowAuthorizationCode,
+    OAuthFlows,
+)
+
+tracer = Tracer()
+logger = Logger()
+
+app = APIGatewayRestResolver(enable_validation=True)
+
+
+@app.get("/")
+def helloworld() -> dict:
+    return {"hello": "world"}
+
+
+@logger.inject_lambda_context
+@tracer.capture_lambda_handler
+def lambda_handler(event, context):
+    return app.resolve(event, context)
+
+
+if __name__ == "__main__":
+    print(
+        app.get_openapi_json_schema(
+            title="My API",
+            security_schemes={
+                "oauth": OAuth2(
+                    flows=OAuthFlows(
+                        authorizationCode=OAuthFlowAuthorizationCode(
+                            authorizationUrl="https://xxx.amazoncognito.com/oauth2/authorize",
+                            tokenUrl="https://xxx.amazoncognito.com/oauth2/token",
+                        ),
+                    ),
+                ),
+            },
+            security=[{"oauth": ["admin"]}],  # (1)!
+        ),
+    )

--- a/examples/event_handler_rest/src/security_schemes_per_operation.py
+++ b/examples/event_handler_rest/src/security_schemes_per_operation.py
@@ -1,0 +1,43 @@
+from aws_lambda_powertools import Logger, Tracer
+from aws_lambda_powertools.event_handler import (
+    APIGatewayRestResolver,
+)
+from aws_lambda_powertools.event_handler.openapi.models import (
+    OAuth2,
+    OAuthFlowAuthorizationCode,
+    OAuthFlows,
+)
+
+tracer = Tracer()
+logger = Logger()
+
+app = APIGatewayRestResolver(enable_validation=True)
+
+
+@app.get("/", security=[{"oauth": ["admin"]}])  # (1)!
+def helloworld() -> dict:
+    return {"hello": "world"}
+
+
+@logger.inject_lambda_context
+@tracer.capture_lambda_handler
+def lambda_handler(event, context):
+    return app.resolve(event, context)
+
+
+if __name__ == "__main__":
+    print(
+        app.get_openapi_json_schema(
+            title="My API",
+            security_schemes={
+                "oauth": OAuth2(
+                    flows=OAuthFlows(
+                        authorizationCode=OAuthFlowAuthorizationCode(
+                            authorizationUrl="https://xxx.amazoncognito.com/oauth2/authorize",
+                            tokenUrl="https://xxx.amazoncognito.com/oauth2/token",
+                        ),
+                    ),
+                ),
+            },
+        ),
+    )

--- a/examples/event_handler_rest/src/swagger_ui_oauth2.py
+++ b/examples/event_handler_rest/src/swagger_ui_oauth2.py
@@ -1,3 +1,5 @@
+import os
+
 from aws_lambda_powertools import Logger, Tracer
 from aws_lambda_powertools.event_handler import (
     APIGatewayRestResolver,
@@ -13,24 +15,20 @@ from aws_lambda_powertools.event_handler.openapi.swagger_ui import OAuth2Config
 tracer = Tracer()
 logger = Logger()
 
-oauth2 = OAuth2Config(
-    client_id="your_oauth2_client_id",
-    client_secret="your_oauth2_secret",
-    app_name="OAuth2 Test",
-)
+region = os.getenv("AWS_REGION")
+cognito_domain = os.getenv("COGNITO_USER_POOL_DOMAIN")
 
 app = APIGatewayRestResolver(enable_validation=True)
-
-# NOTE: for this to work, your OAuth2 redirect url needs to precisely follow this format:
-# https://<your_api_id>.execute-api.<region>.amazonaws.com/<stage>/swagger?format=oauth2-redirect
 app.enable_swagger(
-    oauth2_config=oauth2,
+    # NOTE: for this to work, your OAuth2 redirect url needs to precisely follow this format:
+    # https://<your_api_id>.execute-api.<region>.amazonaws.com/<stage>/swagger?format=oauth2-redirect
+    oauth2_config=OAuth2Config(app_name="OAuth2 Test"),
     security_schemes={
         "oauth": OAuth2(
             flows=OAuthFlows(
                 authorizationCode=OAuthFlowAuthorizationCode(
-                    authorizationUrl="https://your-cognito-domain.eu-central-1.amazoncognito.com/oauth2/authorize",
-                    tokenUrl="https://your-cognito-domain.eu-central-1.amazoncognito.com/oauth2/token",
+                    authorizationUrl=f"https://{cognito_domain}.auth.{region}.amazoncognito.com/oauth2/authorize",
+                    tokenUrl=f"https://{cognito_domain}.auth.{region}.amazoncognito.com/oauth2/token",
                 ),
             ),
         ),

--- a/examples/event_handler_rest/src/swagger_ui_oauth2.py
+++ b/examples/event_handler_rest/src/swagger_ui_oauth2.py
@@ -1,0 +1,55 @@
+from aws_lambda_powertools import Logger, Tracer
+from aws_lambda_powertools.event_handler import (
+    APIGatewayRestResolver,
+    Response,
+)
+from aws_lambda_powertools.event_handler.openapi.models import (
+    OAuth2,
+    OAuthFlowAuthorizationCode,
+    OAuthFlows,
+)
+from aws_lambda_powertools.event_handler.openapi.swagger_ui import OAuth2Config
+
+tracer = Tracer()
+logger = Logger()
+
+oauth2 = OAuth2Config(
+    client_id="your_oauth2_client_id",
+    client_secret="your_oauth2_secret",
+    app_name="OAuth2 Test",
+)
+
+app = APIGatewayRestResolver(enable_validation=True)
+
+# NOTE: for this to work, your OAuth2 redirect url needs to precisely follow this format:
+# https://<your_api_id>.execute-api.<region>.amazonaws.com/<stage>/swagger?format=oauth2-redirect
+app.enable_swagger(
+    oauth2_config=oauth2,
+    security_schemes={
+        "oauth": OAuth2(
+            flows=OAuthFlows(
+                authorizationCode=OAuthFlowAuthorizationCode(
+                    authorizationUrl="https://your-cognito-domain.eu-central-1.amazoncognito.com/oauth2/authorize",
+                    tokenUrl="https://your-cognito-domain.eu-central-1.amazoncognito.com/oauth2/token",
+                ),
+            ),
+        ),
+    },
+    security=[{"oauth": []}],
+)
+
+
+@app.get("/")
+def helloworld() -> Response[dict]:
+    logger.info("Hello, World!")
+    return Response(
+        status_code=200,
+        body={"message": "Hello, World"},
+        content_type="application/json",
+    )
+
+
+@logger.inject_lambda_context(log_event=True)
+@tracer.capture_lambda_handler
+def lambda_handler(event, context):
+    return app.resolve(event, context)

--- a/examples/event_handler_rest/src/swagger_with_oauth2.py
+++ b/examples/event_handler_rest/src/swagger_with_oauth2.py
@@ -1,0 +1,45 @@
+from aws_lambda_powertools import Logger, Tracer
+from aws_lambda_powertools.event_handler import (
+    APIGatewayRestResolver,
+)
+from aws_lambda_powertools.event_handler.openapi.models import (
+    OAuth2,
+    OAuthFlowAuthorizationCode,
+    OAuthFlows,
+)
+from aws_lambda_powertools.event_handler.openapi.swagger_ui import OAuth2Config
+
+tracer = Tracer()
+logger = Logger()
+
+oauth2 = OAuth2Config(
+    client_id="xxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+    app_name="OAuth2 app",
+)
+
+app = APIGatewayRestResolver(enable_validation=True)
+app.enable_swagger(
+    oauth2_config=oauth2,
+    security_schemes={
+        "oauth": OAuth2(
+            flows=OAuthFlows(
+                authorizationCode=OAuthFlowAuthorizationCode(
+                    authorizationUrl="https://xxx.amazoncognito.com/oauth2/authorize",
+                    tokenUrl="https://xxx.amazoncognito.com/oauth2/token",
+                ),
+            ),
+        ),
+    },
+    security=[{"oauth": []}],
+)
+
+
+@app.get("/")
+def hello() -> str:
+    return "world"
+
+
+@logger.inject_lambda_context
+@tracer.capture_lambda_handler
+def lambda_handler(event, context):
+    return app.resolve(event, context)

--- a/tests/functional/event_handler/test_openapi_security.py
+++ b/tests/functional/event_handler/test_openapi_security.py
@@ -1,0 +1,62 @@
+import pytest
+
+from aws_lambda_powertools.event_handler import APIGatewayRestResolver
+from aws_lambda_powertools.event_handler.openapi.models import APIKey, APIKeyIn
+
+
+def test_openapi_top_level_security():
+    app = APIGatewayRestResolver()
+
+    @app.get("/")
+    def handler():
+        raise NotImplementedError()
+
+    schema = app.get_openapi_schema(
+        security_schemes={
+            "apiKey": APIKey(name="X-API-KEY", description="API Key", in_=APIKeyIn.header),
+        },
+        security=[{"apiKey": []}],
+    )
+
+    security = schema.security
+    assert security is not None
+
+    assert len(security) == 1
+    assert security[0] == {"apiKey": []}
+
+
+def test_openapi_top_level_security_missing():
+    app = APIGatewayRestResolver()
+
+    @app.get("/")
+    def handler():
+        raise NotImplementedError()
+
+    with pytest.raises(ValueError):
+        app.get_openapi_schema(
+            security=[{"apiKey": []}],
+        )
+
+
+def test_openapi_operation_security():
+    app = APIGatewayRestResolver()
+
+    @app.get("/", security=[{"apiKey": []}])
+    def handler():
+        raise NotImplementedError()
+
+    schema = app.get_openapi_schema(
+        security_schemes={
+            "apiKey": APIKey(name="X-API-KEY", description="API Key", in_=APIKeyIn.header),
+        },
+    )
+
+    security = schema.security
+    assert security is None
+
+    operation = schema.paths["/"].get
+    security = operation.security
+    assert security is not None
+
+    assert len(security) == 1
+    assert security[0] == {"apiKey": []}

--- a/tests/functional/event_handler/test_openapi_security_schemes.py
+++ b/tests/functional/event_handler/test_openapi_security_schemes.py
@@ -1,0 +1,112 @@
+from aws_lambda_powertools.event_handler import APIGatewayRestResolver
+from aws_lambda_powertools.event_handler.openapi.models import (
+    APIKey,
+    APIKeyIn,
+    HTTPBearer,
+    OAuth2,
+    OAuthFlowImplicit,
+    OAuthFlows,
+    OpenIdConnect,
+)
+
+
+def test_openapi_security_scheme_api_key():
+    app = APIGatewayRestResolver()
+
+    @app.get("/")
+    def handler():
+        raise NotImplementedError()
+
+    schema = app.get_openapi_schema(
+        security_schemes={
+            "apiKey": APIKey(name="X-API-KEY", description="API Key", in_=APIKeyIn.header),
+        },
+    )
+
+    security_schemes = schema.components.securitySchemes
+    assert security_schemes is not None
+
+    assert "apiKey" in security_schemes
+    api_key_scheme = security_schemes["apiKey"]
+    assert api_key_scheme.type_.value == "apiKey"
+    assert api_key_scheme.name == "X-API-KEY"
+    assert api_key_scheme.description == "API Key"
+    assert api_key_scheme.in_.value == "header"
+
+
+def test_openapi_security_scheme_http():
+    app = APIGatewayRestResolver()
+
+    @app.get("/")
+    def handler():
+        raise NotImplementedError()
+
+    schema = app.get_openapi_schema(
+        security_schemes={
+            "bearerAuth": HTTPBearer(
+                description="JWT Token",
+                bearerFormat="JWT",
+            ),
+        },
+    )
+
+    security_schemes = schema.components.securitySchemes
+    assert security_schemes is not None
+
+    assert "bearerAuth" in security_schemes
+    http_scheme = security_schemes["bearerAuth"]
+    assert http_scheme.type_.value == "http"
+    assert http_scheme.scheme == "bearer"
+    assert http_scheme.bearerFormat == "JWT"
+
+
+def test_openapi_security_scheme_oauth2():
+    app = APIGatewayRestResolver()
+
+    @app.get("/")
+    def handler():
+        raise NotImplementedError()
+
+    schema = app.get_openapi_schema(
+        security_schemes={
+            "oauth2": OAuth2(
+                flows=OAuthFlows(
+                    implicit=OAuthFlowImplicit(
+                        authorizationUrl="https://example.com/oauth2/authorize",
+                    ),
+                ),
+            ),
+        },
+    )
+
+    security_schemes = schema.components.securitySchemes
+    assert security_schemes is not None
+
+    assert "oauth2" in security_schemes
+    oauth2_scheme = security_schemes["oauth2"]
+    assert oauth2_scheme.type_.value == "oauth2"
+    assert oauth2_scheme.flows.implicit.authorizationUrl == "https://example.com/oauth2/authorize"
+
+
+def test_openapi_security_scheme_open_id_connect():
+    app = APIGatewayRestResolver()
+
+    @app.get("/")
+    def handler():
+        raise NotImplementedError()
+
+    schema = app.get_openapi_schema(
+        security_schemes={
+            "openIdConnect": OpenIdConnect(
+                openIdConnectUrl="https://example.com/oauth2/authorize",
+            ),
+        },
+    )
+
+    security_schemes = schema.components.securitySchemes
+    assert security_schemes is not None
+
+    assert "openIdConnect" in security_schemes
+    open_id_connect_scheme = security_schemes["openIdConnect"]
+    assert open_id_connect_scheme.type_.value == "openIdConnect"
+    assert open_id_connect_scheme.openIdConnectUrl == "https://example.com/oauth2/authorize"


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
**Issue number:** #4036

## Summary

This PR adds support for OpenAPI security schemes to OpenAPI generation and the Swagger UI.

### Changes

> Please provide a summary of what's being changed

- Added support for declaring security schemes when generating OpenAPI schemas and when enabling the Swagger UI
- Added support for using those schemas globally or per operation
- Added support for configuring an OAuth2 client when enabling the Swagger UI, and implemented the logic for the OAuth redirect.
- Updated the documentation

### User experience

> Please share what the user experience looks like before and after this change

For instance, here's how to declare an OAuth2 security scheme globally and test it on Swagger UI:

```python
from aws_lambda_powertools.event_handler import (
    APIGatewayRestResolver,
)
from aws_lambda_powertools.event_handler.openapi.models import (
    OAuth2,
    OAuthFlowAuthorizationCode,
    OAuthFlows,
)
from aws_lambda_powertools.event_handler.openapi.swagger_ui import OAuth2Config

oauth2 = OAuth2Config(
    client_id="xxxxxxxxxxxxxxxxxxxxxxxxxxxx",
    app_name="OAuth2 app",
)

app = APIGatewayRestResolver(enable_validation=True)
app.enable_swagger(
    oauth2_config=oauth2,
    security_schemes={
        "oauth": OAuth2(
            flows=OAuthFlows(
                authorizationCode=OAuthFlowAuthorizationCode(
                    authorizationUrl="https://xxx.amazoncognito.com/oauth2/authorize",
                    tokenUrl="https://xxx.amazoncognito.com/oauth2/token",
                ),
            ),
        ),
    },
    security=[{"oauth": []}],
)
```

<img width="1031" alt="image" src="https://github.com/aws-powertools/powertools-lambda-python/assets/10713/7e4331e6-b62b-40fa-a61d-c644b70934f8">

## TODO

- [x] add tests for the new code
- [x] add support for security schemes in the Swagger UI
- [x] update documentation and examples
- [x] aws_lambda_powertools/event_handler/api_gateway.py:1429:9: C901 `get_openapi_schema` is too complex (16 > 15)
- [x] aws_lambda_powertools/event_handler/api_gateway.py:1429:9: PLR0912 Too many branches (16 > 15)
- [x] ERROR:xenon:block "aws_lambda_powertools/event_handler/api_gateway.py:1430 get_openapi_schema" has a rank of D
- [x] Fix pydantic v2 tests
- [x] Create a sample to test OAuth2 via Swagger

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] [Meet tenets criteria](https://docs.powertools.aws.dev/lambda/python/#tenets)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented
* [x] PR title follows [conventional commit semantics](https://github.com/aws-powertools/powertools-lambda-python/blob/develop/.github/semantic.yml)

<details>
<summary>Is this a breaking change?</summary>

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
