### PR TITLE
fix(typing): improve overloads to ensure the return type follows the default_value type

### DIFF
--- a/aws_lambda_powertools/utilities/data_classes/api_gateway_authorizer_event.py
+++ b/aws_lambda_powertools/utilities/data_classes/api_gateway_authorizer_event.py
@@ -283,6 +283,17 @@ class APIGatewayAuthorizerEventV2(DictWrapper):
     def stage_variables(self) -> Optional[Dict[str, str]]:
         return self.get("stageVariables")
 
+    @overload
+    def get_header_value(self, name: str, default_value: str, case_sensitive: bool = False) -> str: ...
+
+    @overload
+    def get_header_value(
+        self,
+        name: str,
+        default_value: Optional[str] = None,
+        case_sensitive: Optional[bool] = False,
+    ) -> Optional[str]: ...
+
     def get_header_value(
         self,
         name: str,

--- a/aws_lambda_powertools/utilities/data_classes/appsync_resolver_event.py
+++ b/aws_lambda_powertools/utilities/data_classes/appsync_resolver_event.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Dict, List, Optional, Union, overload
 
 from aws_lambda_powertools.utilities.data_classes.common import DictWrapper
 from aws_lambda_powertools.utilities.data_classes.shared_functions import (
@@ -213,6 +213,22 @@ class AppSyncResolverEvent(DictWrapper):
         stash to pass arbitrary data across request and response mapping templates, and across functions in
         a pipeline resolver."""
         return self.get("stash")
+
+    @overload
+    def get_header_value(
+        self,
+        name: str,
+        default_value: str,
+        case_sensitive: Optional[bool] = False,
+    ) -> str: ...
+
+    @overload
+    def get_header_value(
+        self,
+        name: str,
+        default_value: Optional[str] = None,
+        case_sensitive: Optional[bool] = False,
+    ) -> Optional[str]: ...
 
     def get_header_value(
         self,

--- a/aws_lambda_powertools/utilities/data_classes/common.py
+++ b/aws_lambda_powertools/utilities/data_classes/common.py
@@ -88,13 +88,7 @@ class DictWrapper(Mapping):
     def _properties(self) -> List[str]:
         return [p for p in dir(self.__class__) if isinstance(getattr(self.__class__, p), property)]
 
-    @overload
-    def get(self, key: str, default: T) -> T: ...
-
-    @overload
-    def get(self, key: str, default: Optional[T] = None) -> Optional[T]: ...
-
-    def get(self, key: str, default: Optional[T] = None) -> Optional[T]:
+    def get(self, key: str, default: Optional[Any] = None) -> Optional[Any]:
         return self._data.get(key, default)
 
     @property

--- a/aws_lambda_powertools/utilities/data_classes/common.py
+++ b/aws_lambda_powertools/utilities/data_classes/common.py
@@ -2,7 +2,7 @@ import base64
 import json
 from collections.abc import Mapping
 from functools import cached_property
-from typing import Any, Callable, Dict, Iterator, List, Optional, TypeVar, overload
+from typing import Any, Callable, Dict, Iterator, List, Optional, overload
 
 from aws_lambda_powertools.shared.headers_serializer import BaseHeadersSerializer
 from aws_lambda_powertools.utilities.data_classes.shared_functions import (
@@ -10,8 +10,6 @@ from aws_lambda_powertools.utilities.data_classes.shared_functions import (
     get_multi_value_query_string_values,
     get_query_string_value,
 )
-
-T = TypeVar("T")
 
 
 class DictWrapper(Mapping):

--- a/aws_lambda_powertools/utilities/data_classes/common.py
+++ b/aws_lambda_powertools/utilities/data_classes/common.py
@@ -2,7 +2,7 @@ import base64
 import json
 from collections.abc import Mapping
 from functools import cached_property
-from typing import Any, Callable, Dict, Iterator, List, Optional, overload
+from typing import Any, Callable, Dict, Iterator, List, Optional, TypeVar, overload
 
 from aws_lambda_powertools.shared.headers_serializer import BaseHeadersSerializer
 from aws_lambda_powertools.utilities.data_classes.shared_functions import (
@@ -10,6 +10,8 @@ from aws_lambda_powertools.utilities.data_classes.shared_functions import (
     get_multi_value_query_string_values,
     get_query_string_value,
 )
+
+T = TypeVar("T")
 
 
 class DictWrapper(Mapping):
@@ -86,7 +88,13 @@ class DictWrapper(Mapping):
     def _properties(self) -> List[str]:
         return [p for p in dir(self.__class__) if isinstance(getattr(self.__class__, p), property)]
 
-    def get(self, key: str, default: Optional[Any] = None) -> Optional[Any]:
+    @overload
+    def get(self, key: str, default: T) -> T: ...
+
+    @overload
+    def get(self, key: str, default: Optional[T] = None) -> Optional[T]: ...
+
+    def get(self, key: str, default: Optional[T] = None) -> Optional[T]:
         return self._data.get(key, default)
 
     @property
@@ -171,6 +179,12 @@ class BaseProxyEvent(DictWrapper):
     def http_method(self) -> str:
         """The HTTP method used. Valid values include: DELETE, GET, HEAD, OPTIONS, PATCH, POST, and PUT."""
         return self["httpMethod"]
+
+    @overload
+    def get_query_string_value(self, name: str, default_value: str) -> str: ...
+
+    @overload
+    def get_query_string_value(self, name: str, default_value: Optional[str] = None) -> Optional[str]: ...
 
     def get_query_string_value(self, name: str, default_value: Optional[str] = None) -> Optional[str]:
         """Get query string value by name

--- a/aws_lambda_powertools/utilities/data_classes/kafka_event.py
+++ b/aws_lambda_powertools/utilities/data_classes/kafka_event.py
@@ -74,7 +74,7 @@ class KafkaEventRecord(DictWrapper):
         self,
         name: str,
         default_value: str,
-        case_sensitive: bool = False,
+        case_sensitive: bool = True,
     ) -> str: ...
 
     @overload
@@ -82,7 +82,7 @@ class KafkaEventRecord(DictWrapper):
         self,
         name: str,
         default_value: Optional[str] = None,
-        case_sensitive: bool = False,
+        case_sensitive: bool = True,
     ) -> Optional[str]: ...
 
     def get_header_value(

--- a/aws_lambda_powertools/utilities/data_classes/kafka_event.py
+++ b/aws_lambda_powertools/utilities/data_classes/kafka_event.py
@@ -1,6 +1,6 @@
 import base64
 from functools import cached_property
-from typing import Any, Dict, Iterator, List, Optional
+from typing import Any, Dict, Iterator, List, Optional, overload
 
 from aws_lambda_powertools.utilities.data_classes.common import DictWrapper
 from aws_lambda_powertools.utilities.data_classes.shared_functions import (
@@ -69,10 +69,26 @@ class KafkaEventRecord(DictWrapper):
         """Decodes the headers as a single dictionary."""
         return {k: bytes(v) for chunk in self.headers for k, v in chunk.items()}
 
+    @overload
     def get_header_value(
         self,
         name: str,
-        default_value: Optional[Any] = None,
+        default_value: str,
+        case_sensitive: bool = False,
+    ) -> str: ...
+
+    @overload
+    def get_header_value(
+        self,
+        name: str,
+        default_value: Optional[str] = None,
+        case_sensitive: bool = False,
+    ) -> Optional[str]: ...
+
+    def get_header_value(
+        self,
+        name: str,
+        default_value: Optional[str] = None,
         case_sensitive: bool = True,
     ) -> Optional[str]:
         """Get a decoded header value by name."""

--- a/aws_lambda_powertools/utilities/data_classes/s3_object_event.py
+++ b/aws_lambda_powertools/utilities/data_classes/s3_object_event.py
@@ -1,4 +1,4 @@
-from typing import Dict, Optional
+from typing import Dict, Optional, overload
 
 from aws_lambda_powertools.utilities.data_classes.common import DictWrapper
 from aws_lambda_powertools.utilities.data_classes.shared_functions import (
@@ -72,6 +72,22 @@ class S3ObjectUserRequest(DictWrapper):
         If the same header appears multiple times, their values are combined into a comma-delimited list.
         The case of the original headers is retained in this map."""
         return self["headers"]
+
+    @overload
+    def get_header_value(
+        self,
+        name: str,
+        default_value: str,
+        case_sensitive: Optional[bool] = False,
+    ) -> str: ...
+
+    @overload
+    def get_header_value(
+        self,
+        name: str,
+        default_value: Optional[str] = None,
+        case_sensitive: Optional[bool] = False,
+    ) -> Optional[str]: ...
 
     def get_header_value(
         self,

--- a/aws_lambda_powertools/utilities/data_classes/shared_functions.py
+++ b/aws_lambda_powertools/utilities/data_classes/shared_functions.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import base64
-from typing import Any, Dict, List, Optional, overload
+from typing import Any, overload
 
 
 def base64_decode(value: str) -> str:
@@ -26,7 +26,7 @@ def get_header_value(
     headers: dict[str, Any],
     name: str,
     default_value: str,
-    case_sensitive: bool,
+    case_sensitive: bool | None = None,
 ) -> str: ...
 
 
@@ -34,23 +34,23 @@ def get_header_value(
 def get_header_value(
     headers: dict[str, Any],
     name: str,
-    default_value: Optional[str],
-    case_sensitive: bool,
-) -> Optional[str]: ...
+    default_value: str | None = None,
+    case_sensitive: bool | None = None,
+) -> str | None: ...
 
 
 def get_header_value(
     headers: dict[str, Any],
     name: str,
-    default_value: Optional[str],
-    case_sensitive: bool,
-) -> Optional[str]:
+    default_value: str | None = None,
+    case_sensitive: bool | None = None,
+) -> str | None:
     """
     Get the value of a header by its name.
 
     Parameters
     ----------
-    headers: Dict[str, str]
+    headers: dict[str, str]
         The dictionary of headers.
     name: str
         The name of the header to retrieve.
@@ -82,7 +82,7 @@ def get_header_value(
 
 @overload
 def get_query_string_value(
-    query_string_parameters: Dict[str, str] | None,
+    query_string_parameters: dict[str, str] | None,
     name: str,
     default_value: str,
 ) -> str: ...
@@ -90,17 +90,17 @@ def get_query_string_value(
 
 @overload
 def get_query_string_value(
-    query_string_parameters: Dict[str, str] | None,
+    query_string_parameters: dict[str, str] | None,
     name: str,
-    default_value: Optional[str] = None,
-) -> Optional[str]: ...
+    default_value: str | None = None,
+) -> str | None: ...
 
 
 def get_query_string_value(
-    query_string_parameters: Dict[str, str] | None,
+    query_string_parameters: dict[str, str] | None,
     name: str,
-    default_value: Optional[str] = None,
-) -> Optional[str]:
+    default_value: str | None = None,
+) -> str | None:
     """
     Retrieves the value of a query string parameter specified by the given name.
 
@@ -121,10 +121,10 @@ def get_query_string_value(
 
 
 def get_multi_value_query_string_values(
-    multi_value_query_string_parameters: Dict[str, List[str]] | None,
+    multi_value_query_string_parameters: dict[str, list[str]] | None,
     name: str,
-    default_values: Optional[List[str]] = None,
-) -> List[str]:
+    default_values: list[str] | None = None,
+) -> list[str]:
     """
     Retrieves the values of a multi-value string parameters specified by the given name.
 
@@ -132,12 +132,12 @@ def get_multi_value_query_string_values(
     ----------
     name: str
         The name of the query string parameter to retrieve.
-    default_value: List[str], optional
+    default_value: list[str], optional
         The default value to return if the parameter is not found. Defaults to None.
 
     Returns
     -------
-    List[str]. optional
+    list[str]. optional
         The values of the query string parameter if found, or the default values if not found.
     """
 

--- a/aws_lambda_powertools/utilities/data_classes/shared_functions.py
+++ b/aws_lambda_powertools/utilities/data_classes/shared_functions.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import base64
-from typing import Any, overload
+from typing import Any, Dict, overload
 
 
 def base64_decode(value: str) -> str:
@@ -26,7 +26,7 @@ def get_header_value(
     headers: dict[str, Any],
     name: str,
     default_value: str,
-    case_sensitive: bool | None = None,
+    case_sensitive: bool | None = False,
 ) -> str: ...
 
 
@@ -35,7 +35,7 @@ def get_header_value(
     headers: dict[str, Any],
     name: str,
     default_value: str | None = None,
-    case_sensitive: bool | None = None,
+    case_sensitive: bool | None = False,
 ) -> str | None: ...
 
 
@@ -43,21 +43,21 @@ def get_header_value(
     headers: dict[str, Any],
     name: str,
     default_value: str | None = None,
-    case_sensitive: bool | None = None,
+    case_sensitive: bool | None = False,
 ) -> str | None:
     """
     Get the value of a header by its name.
 
     Parameters
     ----------
-    headers: dict[str, str]
+    headers: Dict[str, str]
         The dictionary of headers.
     name: str
         The name of the header to retrieve.
     default_value: str, optional
         The default value to return if the header is not found. Default is None.
     case_sensitive: bool, optional
-        Indicates whether the header name should be case-sensitive. Default is None.
+        Indicates whether the header name should be case-sensitive. Default is False.
 
     Returns
     -------
@@ -82,7 +82,7 @@ def get_header_value(
 
 @overload
 def get_query_string_value(
-    query_string_parameters: dict[str, str] | None,
+    query_string_parameters: Dict[str, str] | None,
     name: str,
     default_value: str,
 ) -> str: ...
@@ -90,14 +90,14 @@ def get_query_string_value(
 
 @overload
 def get_query_string_value(
-    query_string_parameters: dict[str, str] | None,
+    query_string_parameters: Dict[str, str] | None,
     name: str,
     default_value: str | None = None,
 ) -> str | None: ...
 
 
 def get_query_string_value(
-    query_string_parameters: dict[str, str] | None,
+    query_string_parameters: Dict[str, str] | None,
     name: str,
     default_value: str | None = None,
 ) -> str | None:
@@ -121,7 +121,7 @@ def get_query_string_value(
 
 
 def get_multi_value_query_string_values(
-    multi_value_query_string_parameters: dict[str, list[str]] | None,
+    multi_value_query_string_parameters: Dict[str, list[str]] | None,
     name: str,
     default_values: list[str] | None = None,
 ) -> list[str]:
@@ -137,7 +137,7 @@ def get_multi_value_query_string_values(
 
     Returns
     -------
-    list[str]. optional
+    List[str]. optional
         The values of the query string parameter if found, or the default values if not found.
     """
 

--- a/aws_lambda_powertools/utilities/data_classes/shared_functions.py
+++ b/aws_lambda_powertools/utilities/data_classes/shared_functions.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import base64
-from typing import Any, Dict
+from typing import Any, Dict, List, Optional, overload
 
 
 def base64_decode(value: str) -> str:
@@ -21,12 +21,30 @@ def base64_decode(value: str) -> str:
     return base64.b64decode(value).decode("UTF-8")
 
 
+@overload
 def get_header_value(
     headers: dict[str, Any],
     name: str,
-    default_value: str | None,
-    case_sensitive: bool | None,
-) -> str | None:
+    default_value: str,
+    case_sensitive: bool,
+) -> str: ...
+
+
+@overload
+def get_header_value(
+    headers: dict[str, Any],
+    name: str,
+    default_value: Optional[str],
+    case_sensitive: bool,
+) -> Optional[str]: ...
+
+
+def get_header_value(
+    headers: dict[str, Any],
+    name: str,
+    default_value: Optional[str],
+    case_sensitive: bool,
+) -> Optional[str]:
     """
     Get the value of a header by its name.
 
@@ -62,11 +80,27 @@ def get_header_value(
     )
 
 
+@overload
 def get_query_string_value(
     query_string_parameters: Dict[str, str] | None,
     name: str,
-    default_value: str | None = None,
-) -> str | None:
+    default_value: str,
+) -> str: ...
+
+
+@overload
+def get_query_string_value(
+    query_string_parameters: Dict[str, str] | None,
+    name: str,
+    default_value: Optional[str] = None,
+) -> Optional[str]: ...
+
+
+def get_query_string_value(
+    query_string_parameters: Dict[str, str] | None,
+    name: str,
+    default_value: Optional[str] = None,
+) -> Optional[str]:
     """
     Retrieves the value of a query string parameter specified by the given name.
 
@@ -87,10 +121,10 @@ def get_query_string_value(
 
 
 def get_multi_value_query_string_values(
-    multi_value_query_string_parameters: Dict[str, list[str]] | None,
+    multi_value_query_string_parameters: Dict[str, List[str]] | None,
     name: str,
-    default_values: list[str] | None = None,
-) -> list[str]:
+    default_values: Optional[List[str]] = None,
+) -> List[str]:
     """
     Retrieves the values of a multi-value string parameters specified by the given name.
 
@@ -98,7 +132,7 @@ def get_multi_value_query_string_values(
     ----------
     name: str
         The name of the query string parameter to retrieve.
-    default_value: list[str], optional
+    default_value: List[str], optional
         The default value to return if the parameter is not found. Defaults to None.
 
     Returns

--- a/aws_lambda_powertools/utilities/data_classes/vpc_lattice.py
+++ b/aws_lambda_powertools/utilities/data_classes/vpc_lattice.py
@@ -47,6 +47,12 @@ class VPCLatticeEventBase(BaseProxyEvent):
         """The HTTP method used. Valid values include: DELETE, GET, HEAD, OPTIONS, PATCH, POST, and PUT."""
         return self["method"]
 
+    @overload
+    def get_query_string_value(self, name: str, default_value: str) -> str: ...
+
+    @overload
+    def get_query_string_value(self, name: str, default_value: Optional[str] = None) -> Optional[str]: ...
+
     def get_query_string_value(self, name: str, default_value: Optional[str] = None) -> Optional[str]:
         """Get query string value by name
 

--- a/examples/event_handler_graphql/src/custom_models.py
+++ b/examples/event_handler_graphql/src/custom_models.py
@@ -26,11 +26,11 @@ class Location(TypedDict, total=False):
 class MyCustomModel(AppSyncResolverEvent):
     @property
     def country_viewer(self) -> str:
-        return self.get_header_value(name="cloudfront-viewer-country", default_value="", case_sensitive=False)  # type: ignore[return-value] # sentinel typing # noqa: E501
+        return self.get_header_value(name="cloudfront-viewer-country", default_value="", case_sensitive=False)
 
     @property
     def api_key(self) -> str:
-        return self.get_header_value(name="x-api-key", default_value="", case_sensitive=False)  # type: ignore[return-value] # sentinel typing # noqa: E501
+        return self.get_header_value(name="x-api-key", default_value="", case_sensitive=False)
 
 
 @app.resolver(type_name="Query", field_name="listLocations")


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
**Issue number: #4113**

## Summary

### Changes

Overload functions with `default_value` when it becomes not `Optional` anymore.

### User experience

Ensure return type without casting.

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] [Meet tenets criteria](https://docs.powertools.aws.dev/lambda/python/#tenets)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [ ] Changes are documented
* [x] PR title follows [conventional commit semantics](https://github.com/aws-powertools/powertools-lambda-python/blob/develop/.github/semantic.yml)

<details>
<summary>Is this a breaking change?</summary>

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
