### PR TITLE
fix(typing): make the case_sensitive field a boolean only

### DIFF
--- a/aws_lambda_powertools/utilities/data_classes/api_gateway_authorizer_event.py
+++ b/aws_lambda_powertools/utilities/data_classes/api_gateway_authorizer_event.py
@@ -167,7 +167,7 @@ class APIGatewayAuthorizerRequestEvent(DictWrapper):
         self,
         name: str,
         default_value: str,
-        case_sensitive: Optional[bool] = False,
+        case_sensitive: bool = False,
     ) -> str: ...
 
     @overload
@@ -175,14 +175,14 @@ class APIGatewayAuthorizerRequestEvent(DictWrapper):
         self,
         name: str,
         default_value: Optional[str] = None,
-        case_sensitive: Optional[bool] = False,
+        case_sensitive: bool = False,
     ) -> Optional[str]: ...
 
     def get_header_value(
         self,
         name: str,
         default_value: Optional[str] = None,
-        case_sensitive: Optional[bool] = False,
+        case_sensitive: bool = False,
     ) -> Optional[str]:
         """Get header value by name
 
@@ -291,14 +291,14 @@ class APIGatewayAuthorizerEventV2(DictWrapper):
         self,
         name: str,
         default_value: Optional[str] = None,
-        case_sensitive: Optional[bool] = False,
+        case_sensitive: bool = False,
     ) -> Optional[str]: ...
 
     def get_header_value(
         self,
         name: str,
         default_value: Optional[str] = None,
-        case_sensitive: Optional[bool] = False,
+        case_sensitive: bool = False,
     ) -> Optional[str]:
         """Get header value by name
 

--- a/aws_lambda_powertools/utilities/data_classes/appsync_resolver_event.py
+++ b/aws_lambda_powertools/utilities/data_classes/appsync_resolver_event.py
@@ -219,7 +219,7 @@ class AppSyncResolverEvent(DictWrapper):
         self,
         name: str,
         default_value: str,
-        case_sensitive: Optional[bool] = False,
+        case_sensitive: bool = False,
     ) -> str: ...
 
     @overload
@@ -227,14 +227,14 @@ class AppSyncResolverEvent(DictWrapper):
         self,
         name: str,
         default_value: Optional[str] = None,
-        case_sensitive: Optional[bool] = False,
+        case_sensitive: bool = False,
     ) -> Optional[str]: ...
 
     def get_header_value(
         self,
         name: str,
         default_value: Optional[str] = None,
-        case_sensitive: Optional[bool] = False,
+        case_sensitive: bool = False,
     ) -> Optional[str]:
         """Get header value by name
 

--- a/aws_lambda_powertools/utilities/data_classes/common.py
+++ b/aws_lambda_powertools/utilities/data_classes/common.py
@@ -228,7 +228,7 @@ class BaseProxyEvent(DictWrapper):
         self,
         name: str,
         default_value: str,
-        case_sensitive: Optional[bool] = False,
+        case_sensitive: bool = False,
     ) -> str: ...
 
     @overload
@@ -236,14 +236,14 @@ class BaseProxyEvent(DictWrapper):
         self,
         name: str,
         default_value: Optional[str] = None,
-        case_sensitive: Optional[bool] = False,
+        case_sensitive: bool = False,
     ) -> Optional[str]: ...
 
     def get_header_value(
         self,
         name: str,
         default_value: Optional[str] = None,
-        case_sensitive: Optional[bool] = False,
+        case_sensitive: bool = False,
     ) -> Optional[str]:
         """Get header value by name
 

--- a/aws_lambda_powertools/utilities/data_classes/s3_object_event.py
+++ b/aws_lambda_powertools/utilities/data_classes/s3_object_event.py
@@ -78,7 +78,7 @@ class S3ObjectUserRequest(DictWrapper):
         self,
         name: str,
         default_value: str,
-        case_sensitive: Optional[bool] = False,
+        case_sensitive: bool = False,
     ) -> str: ...
 
     @overload
@@ -86,14 +86,14 @@ class S3ObjectUserRequest(DictWrapper):
         self,
         name: str,
         default_value: Optional[str] = None,
-        case_sensitive: Optional[bool] = False,
+        case_sensitive: bool = False,
     ) -> Optional[str]: ...
 
     def get_header_value(
         self,
         name: str,
         default_value: Optional[str] = None,
-        case_sensitive: Optional[bool] = False,
+        case_sensitive: bool = False,
     ) -> Optional[str]:
         """Get header value by name
 

--- a/aws_lambda_powertools/utilities/data_classes/shared_functions.py
+++ b/aws_lambda_powertools/utilities/data_classes/shared_functions.py
@@ -26,7 +26,7 @@ def get_header_value(
     headers: dict[str, Any],
     name: str,
     default_value: str,
-    case_sensitive: bool | None = False,
+    case_sensitive: bool = False,
 ) -> str: ...
 
 
@@ -35,7 +35,7 @@ def get_header_value(
     headers: dict[str, Any],
     name: str,
     default_value: str | None = None,
-    case_sensitive: bool | None = False,
+    case_sensitive: bool = False,
 ) -> str | None: ...
 
 
@@ -43,7 +43,7 @@ def get_header_value(
     headers: dict[str, Any],
     name: str,
     default_value: str | None = None,
-    case_sensitive: bool | None = False,
+    case_sensitive: bool = False,
 ) -> str | None:
     """
     Get the value of a header by its name.

--- a/aws_lambda_powertools/utilities/data_classes/vpc_lattice.py
+++ b/aws_lambda_powertools/utilities/data_classes/vpc_lattice.py
@@ -78,7 +78,7 @@ class VPCLatticeEventBase(BaseProxyEvent):
         self,
         name: str,
         default_value: str,
-        case_sensitive: Optional[bool] = False,
+        case_sensitive: bool = False,
     ) -> str: ...
 
     @overload
@@ -86,14 +86,14 @@ class VPCLatticeEventBase(BaseProxyEvent):
         self,
         name: str,
         default_value: Optional[str] = None,
-        case_sensitive: Optional[bool] = False,
+        case_sensitive: bool = False,
     ) -> Optional[str]: ...
 
     def get_header_value(
         self,
         name: str,
         default_value: Optional[str] = None,
-        case_sensitive: Optional[bool] = False,
+        case_sensitive: bool = False,
     ) -> Optional[str]:
         """Get header value by name
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
**Issue number: #4127**

## Summary

### Changes

case_sensitive become bool only.

### User experience

It seems to be weird that case_sensitive could be None. It is case_sensitive or not. There is no environment variable where we could have a default value.

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] [Meet tenets criteria](https://docs.powertools.aws.dev/lambda/python/#tenets)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [ ] Changes are documented
* [x] PR title follows [conventional commit semantics](https://github.com/aws-powertools/powertools-lambda-python/blob/develop/.github/semantic.yml)

<details>
<summary>Is this a breaking change?</summary>

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
