### PR TITLE
chore(docs): update highlighted lines on the Typing examples

### DIFF
--- a/docs/utilities/typing.md
+++ b/docs/utilities/typing.md
@@ -38,7 +38,7 @@ Using `LambdaContext` typing makes it possible to access information and hints o
 
 === "working_with_context_function.py"
 
-	```python hl_lines="6 16 25 26"
+	```python hl_lines="6 15 22 23"
     --8<-- "examples/typing/src/working_with_context_function.py"
 	```
 


### PR DESCRIPTION
Enhancing clarity and correctness in the documentation by accurately reflecting the relevant lines in the code snippet.

<!-- markdownlint-disable MD041 MD043 -->
**Issue number:**
#4117
## Summary

### Changes

Updated the highlighted lines in /examples/typing/src/working_with_context_function.py to correctly point to lines 15, 22, and 23, ensuring accuracy for clarity and correctness in the documentation.

### User experience

> Please share what the user experience looks like before and after this change

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] [Meet tenets criteria](https://docs.powertools.aws.dev/lambda/python/#tenets)
* [ ] I have performed a self-review of this change
* [ ] Changes have been tested
* [ ] Changes are documented
* [x] PR title follows [conventional commit semantics](https://github.com/aws-powertools/powertools-lambda-python/blob/develop/.github/semantic.yml)

<details>
<summary>Is this a breaking change?</summary>

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
