### PR TITLE
refactor(parser): only infer type hints when necessary

### DIFF
--- a/aws_lambda_powertools/utilities/parser/parser.py
+++ b/aws_lambda_powertools/utilities/parser/parser.py
@@ -83,16 +83,17 @@ def event_parser(
         When envelope given does not implement BaseEnvelope
     """
 
-    # The first parameter of a Lambda function is always the event
-    # This line get the model informed in the event_parser function
-    # or the first parameter of the function by using typing.get_type_hints
-    type_hints = typing.get_type_hints(handler)
-    model = model or (list(type_hints.values())[0] if type_hints else None)
     if model is None:
-        raise InvalidModelTypeError(
-            "The model must be provided either as the `model` argument to `event_parser`"
-            "or as the type hint of `event` in the handler that it wraps",
-        )
+        # The first parameter of a Lambda function is always the event.
+        # Get the first parameter's type by using typing.get_type_hints.
+        type_hints = typing.get_type_hints(handler)
+        if type_hints:
+            model = list(type_hints.values())[0]
+        if model is None:
+            raise InvalidModelTypeError(
+                "The model must be provided either as the `model` argument to `event_parser`"
+                "or as the type hint of `event` in the handler that it wraps",
+            )
 
     if envelope:
         parsed_event = parse(event=event, model=model, envelope=envelope)


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
**Issue number:** #4184 

## Summary

### Changes

> Please provide a summary of what's being changed

This changes the `event_parser` decorator to only infer type hints when necessary.

It was breaking in codebases that conditionally import type hints using the `typing.TYPE_CHECKING` constant as described in [PEP 563](https://peps.python.org/pep-0563/#runtime-annotation-resolution-and-type-checking).

When the model is provided, there is no need to infer anything.

### User experience

> Please share what the user experience looks like before and after this change

N/A

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] [Meet tenets criteria](https://docs.powertools.aws.dev/lambda/python/#tenets)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [ ] Changes are documented
* [x] PR title follows [conventional commit semantics](https://github.com/aws-powertools/powertools-lambda-python/blob/develop/.github/semantic.yml)

<details>
<summary>Is this a breaking change? No.</summary>

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
