### PR TITLE
docs(homepage): add link to new and official workshop

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -11,6 +11,7 @@ nav:
       - API reference: api/" target="_blank
       - Upgrade guide: upgrade.md
       - We Made This (Community): we_made_this.md
+      - Workshop 🆕: https://s12d.com/powertools-for-aws-lambda-workshop" target="_blank
       - Roadmap: roadmap.md
       - Features:
           - core/tracer.md


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
**Issue number:** #4291

## Summary

### Changes

> Please provide a summary of what's being changed

This PR adds a link to the Powertools for AWS Lambda workshop in the documentation sidebar. This will allow customers to know about the existence of the workshop.

### User experience

> Please share what the user experience looks like before and after this change

![image](https://github.com/aws-powertools/powertools-lambda-python/assets/7353869/c21aa1d1-7be7-414d-8f0c-4b2f661937b3)

_Note: the screenshot is from the TypeScript docs, however it'll look the same in yours_

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] [Meet tenets criteria](https://docs.powertools.aws.dev/lambda/python/#tenets)
* [x] I have performed a self-review of this change
* [ ] Changes have been tested
* [ ] Changes are documented
* [x] PR title follows [conventional commit semantics](https://github.com/aws-powertools/powertools-lambda-python/blob/develop/.github/semantic.yml)

<details>
<summary>Is this a breaking change?</summary>

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
