### PR TITLE
fix(logger): reverting logger child modification

### DIFF
--- a/aws_lambda_powertools/logging/constants.py
+++ b/aws_lambda_powertools/logging/constants.py
@@ -1,5 +1,5 @@
 # logger.powertools_handler is set with Powertools Logger handler; useful when there are many handlers
 LOGGER_ATTRIBUTE_POWERTOOLS_HANDLER = "powertools_handler"
-# logger.init attribute is set when Logger has been configured 
+# logger.init attribute is set when Logger has been configured
 LOGGER_ATTRIBUTE_PRECONFIGURED = "init"
 LOGGER_ATTRIBUTE_HANDLER = "logger_handler"

--- a/aws_lambda_powertools/logging/exceptions.py
+++ b/aws_lambda_powertools/logging/exceptions.py
@@ -1,6 +1,2 @@
 class InvalidLoggerSamplingRateError(Exception):
     pass
-
-
-class OrphanedChildLoggerError(Exception):
-    pass

--- a/tests/functional/test_logger.py
+++ b/tests/functional/test_logger.py
@@ -17,7 +17,7 @@ import pytest
 
 from aws_lambda_powertools import Logger, Tracer, set_package_logger_handler
 from aws_lambda_powertools.logging import correlation_paths
-from aws_lambda_powertools.logging.exceptions import InvalidLoggerSamplingRateError, OrphanedChildLoggerError
+from aws_lambda_powertools.logging.exceptions import InvalidLoggerSamplingRateError
 from aws_lambda_powertools.logging.formatter import (
     BasePowertoolsFormatter,
     LambdaPowertoolsFormatter,
@@ -1176,63 +1176,3 @@ def test_logger_json_unicode(stdout, service_name):
 
     assert log["message"] == non_ascii_chars
     assert log[japanese_field] == japanese_string
-
-
-def test_logger_registered_handler_is_custom_handler(service_name):
-    # GIVEN a library or environment pre-setup a logger for us using the same name (see #4277)
-    class ForeignHandler(logging.StreamHandler): ...
-
-    foreign_handler = ForeignHandler()
-    logging.getLogger(service_name).addHandler(foreign_handler)
-
-    # WHEN Logger init with a custom handler
-    custom_handler = logging.StreamHandler()
-    logger = Logger(service=service_name, logger_handler=custom_handler)
-
-    # THEN registered handler should always return what we provided
-    assert logger.registered_handler is not foreign_handler
-    assert logger.registered_handler is custom_handler
-    assert logger.logger_handler is custom_handler
-    assert logger.handlers == [foreign_handler, custom_handler]
-
-
-def test_child_logger_registered_handler_is_custom_handler(service_name):
-    # GIVEN
-    class ForeignHandler(logging.StreamHandler): ...
-
-    foreign_handler = ForeignHandler()
-    logging.getLogger(service_name).addHandler(foreign_handler)
-
-    custom_handler = logging.StreamHandler()
-    custom_handler.name = "CUSTOM HANDLER"
-    parent = Logger(service=service_name, logger_handler=custom_handler)
-
-    # WHEN a child Logger init
-    child = Logger(service=service_name, child=True)
-
-    # THEN child registered handler should always return what we provided in the parent
-    assert child.registered_handler is not foreign_handler
-    assert child.registered_handler is custom_handler
-    assert child.registered_handler is parent.registered_handler
-
-
-def test_logger_handler_is_created_despite_env_pre_setup(service_name):
-    # GIVEN a library or environment pre-setup a logger for us using the same name
-    environment_handler = logging.StreamHandler()
-    logging.getLogger(service_name).addHandler(environment_handler)
-
-    # WHEN Logger init without a custom handler
-    logger = Logger(service=service_name)
-
-    # THEN registered handler should be Powertools default handler, not env
-    assert logger.registered_handler is not environment_handler
-
-
-def test_child_logger_append_keys_before_parent(stdout, service_name):
-    # GIVEN a child Logger is initialized before its/without parent
-    child = Logger(stream=stdout, service=service_name, child=True)
-
-    # WHEN a child Logger appends a key
-    # THEN it will raise an AttributeError
-    with pytest.raises(OrphanedChildLoggerError):
-        child.append_keys(customer_id="value")


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
**Issue number:** #4362

## Summary

### Changes

The PR https://github.com/aws-powertools/powertools-lambda-python/pull/4295/files potentially introduced a breaking change when customer is using many `Logger` instances with the same service name. This bug occurs locally or running in the Lambda environment.

Example:

### validate_log.py
```python
from collections import namedtuple
from aws_lambda_powertools.event_handler import (
    APIGatewayRestResolver,)
from aws_lambda_powertools.logging import correlation_paths
from aws_lambda_powertools.utilities.typing import LambdaContext
from aws_lambda_powertools import Logger

from event import EVENT

from validate_log1 import *

logger = Logger()
app = APIGatewayRestResolver(enable_validation=True)

@app.get("/hello")
def get_todos():
    return {"todos": "OK"}


@logger.inject_lambda_context(
    correlation_id_path=correlation_paths.API_GATEWAY_HTTP, log_event=True
)
def lambda_handler(request: dict, context: LambdaContext) -> dict:
    return app.resolve(request, context)


def lambda_context():
    lambda_context = {
        "function_name": "test",
        "memory_limit_in_mb": 128,
        "invoked_function_arn": "arn:aws:lambda:eu-west-1:809313241:function:test",
        "aws_request_id": "52fdfc07-2182-154f-163f-5f0f9a621d72",
    }

    return namedtuple("LambdaContext", lambda_context.keys())(*lambda_context.values())

lambda_handler(EVENT, lambda_context())
```

### validate_log1.py

```python
from aws_lambda_powertools import Logger

logger = Logger()
```

### output
```sh
(venv) ➜  bug-log python validate_log.py                          
Traceback (most recent call last):
  File "/Users//DEV/powertools/tmp-testes/bug-log/validate_log.py", line 37, in <module>
    lambda_handler(EVENT, lambda_context())
  File "/Users//DEV/powertools/tmp-testes/bug-log/venv/lib/python3.10/site-packages/aws_lambda_powertools/logging/logger.py", line 455, in decorate
    self.append_keys(cold_start=cold_start, **lambda_context.__dict__)
  File "/Users//DEV/powertools/tmp-testes/bug-log/venv/lib/python3.10/site-packages/aws_lambda_powertools/logging/logger.py", line 603, in append_keys
    self.registered_formatter.append_keys(**additional_keys)
AttributeError: 'NoneType' object has no attribute 'append_keys'
```
### User experience

> Please share what the user experience looks like before and after this change

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] [Meet tenets criteria](https://docs.powertools.aws.dev/lambda/python/#tenets)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented
* [x] PR title follows [conventional commit semantics](https://github.com/aws-powertools/powertools-lambda-python/blob/develop/.github/semantic.yml)

<details>
<summary>Is this a breaking change?</summary>

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
