### PR TITLE
fix(event_handler): security scheme unhashable list when working with router

### DIFF
--- a/aws_lambda_powertools/event_handler/api_gateway.py
+++ b/aws_lambda_powertools/event_handler/api_gateway.py
@@ -703,6 +703,7 @@ class Route:
         from aws_lambda_powertools.event_handler.openapi.params import Param
 
         parameters = []
+        parameter: Dict[str, Any]
         for param in all_route_params:
             field_info = param.field_info
             field_info = cast(Param, field_info)

--- a/aws_lambda_powertools/event_handler/api_gateway.py
+++ b/aws_lambda_powertools/event_handler/api_gateway.py
@@ -1600,7 +1600,8 @@ class ApiGatewayResolver(BaseRouter):
                 security_schemes=security_schemes,
             ):
                 raise SchemaValidationError(
-                    "Security configuration was not found in security_schemas or security_schema was not defined.",
+                    "Security configuration was not found in security_schemas or security_schema was not defined. "
+                    "See: https://docs.powertools.aws.dev/lambda/python/latest/core/event_handler/api_gateway/#security-schemes",
                 )
 
             if not route.include_in_schema:
@@ -1651,7 +1652,8 @@ class ApiGatewayResolver(BaseRouter):
 
         if not _validate_openapi_security_parameters(security=security, security_schemes=security_schemes):
             raise SchemaValidationError(
-                "Security configuration was not found in security_schemas or security_schema was not defined.",
+                "Security configuration was not found in security_schemas or security_schema was not defined. "
+                "See: https://docs.powertools.aws.dev/lambda/python/latest/core/event_handler/api_gateway/#security-schemes",
             )
 
         return security

--- a/aws_lambda_powertools/event_handler/api_gateway.py
+++ b/aws_lambda_powertools/event_handler/api_gateway.py
@@ -46,8 +46,8 @@ from aws_lambda_powertools.event_handler.openapi.types import (
 from aws_lambda_powertools.event_handler.util import (
     _FrozenDict,
     _FrozenListDict,
+    _validate_openapi_security_parameters,
     extract_origin_header,
-    validate_openapi_security_parameters,
 )
 from aws_lambda_powertools.shared.cookies import Cookie
 from aws_lambda_powertools.shared.functions import powertools_dev_is_set
@@ -1595,7 +1595,7 @@ class ApiGatewayResolver(BaseRouter):
         # Add routes to the OpenAPI schema
         for route in all_routes:
 
-            if route.security and not validate_openapi_security_parameters(
+            if route.security and not _validate_openapi_security_parameters(
                 security=route.security,
                 security_schemes=security_schemes,
             ):
@@ -1649,7 +1649,7 @@ class ApiGatewayResolver(BaseRouter):
         if not security:
             return None
 
-        if not validate_openapi_security_parameters(security=security, security_schemes=security_schemes):
+        if not _validate_openapi_security_parameters(security=security, security_schemes=security_schemes):
             raise SchemaValidationError(
                 "Security configuration was not found in security_schemas or security_schema was not defined.",
             )

--- a/aws_lambda_powertools/event_handler/api_gateway.py
+++ b/aws_lambda_powertools/event_handler/api_gateway.py
@@ -43,7 +43,7 @@ from aws_lambda_powertools.event_handler.openapi.types import (
     validation_error_definition,
     validation_error_response_definition,
 )
-from aws_lambda_powertools.event_handler.util import _FrozenDict, extract_origin_header
+from aws_lambda_powertools.event_handler.util import _FrozenDict, _FrozenListDict, extract_origin_header
 from aws_lambda_powertools.shared.cookies import Cookie
 from aws_lambda_powertools.shared.functions import powertools_dev_is_set
 from aws_lambda_powertools.shared.json_encoder import Encoder
@@ -2386,6 +2386,7 @@ class Router(BaseRouter):
             methods = (method,) if isinstance(method, str) else tuple(method)
             frozen_responses = _FrozenDict(responses) if responses else None
             frozen_tags = frozenset(tags) if tags else None
+            frozen_security = _FrozenListDict(security) if security else None
 
             route_key = (
                 rule,
@@ -2400,7 +2401,7 @@ class Router(BaseRouter):
                 frozen_tags,
                 operation_id,
                 include_in_schema,
-                security,
+                frozen_security,
             )
 
             # Collate Middleware for routes

--- a/aws_lambda_powertools/event_handler/openapi/exceptions.py
+++ b/aws_lambda_powertools/event_handler/openapi/exceptions.py
@@ -21,3 +21,9 @@ class RequestValidationError(ValidationException):
     def __init__(self, errors: Sequence[Any], *, body: Any = None) -> None:
         super().__init__(errors)
         self.body = body
+
+
+class SchemaValidationError(ValidationException):
+    """
+    Raised when the OpenAPI schema validation fails
+    """

--- a/aws_lambda_powertools/event_handler/util.py
+++ b/aws_lambda_powertools/event_handler/util.py
@@ -1,5 +1,6 @@
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional
 
+from aws_lambda_powertools.event_handler.openapi.models import SecurityScheme
 from aws_lambda_powertools.utilities.data_classes.shared_functions import get_header_value
 
 
@@ -48,11 +49,15 @@ def extract_origin_header(resolver_headers: Dict[str, Any]):
 
     The 'origin' or 'Origin' header can be either a single header or a multi-header.
 
-    Args:
-        resolver_headers (Dict): A dictionary containing the headers.
+    Parameters
+    ----------
+    resolver_headers: Dict
+        A dictionary containing the headers.
 
-    Returns:
-        Optional[str]: The value(s) of the origin header or None.
+    Returns
+    -------
+    Optional[str]
+        The value(s) of the origin header or None.
     """
     resolved_header = get_header_value(
         headers=resolver_headers,
@@ -64,3 +69,30 @@ def extract_origin_header(resolver_headers: Dict[str, Any]):
         return resolved_header[0]
 
     return resolved_header
+
+
+def validate_openapi_security_parameters(
+    security: List[Dict[str, List[str]]],
+    security_schemes: Optional[Dict[str, "SecurityScheme"]],
+) -> bool:
+    """
+    Validates the security parameters based on the provided security schemes.
+
+    Parameters
+    ----------
+    security: List[Dict[str, List[str]]]
+        A list of security requirements
+    security_schemes: Optional[Dict[str, "SecurityScheme"]]
+        A dictionary mapping security scheme names to their corresponding security scheme objects.
+
+    Returns
+    -------
+    bool
+        True if all security scheme names in the `security` parameter are present in the `security_schemes` parameter,
+        False otherwise.
+
+    """
+
+    return bool(
+        security_schemes and all(key in security_schemes for sec in security for key in sec),
+    )

--- a/aws_lambda_powertools/event_handler/util.py
+++ b/aws_lambda_powertools/event_handler/util.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, FrozenSet, List
+from typing import Any, Dict, List
 
 from aws_lambda_powertools.utilities.data_classes.shared_functions import get_header_value
 
@@ -36,7 +36,7 @@ class _FrozenListDict(List[Dict[str, List[str]]]):
     """
 
     def __hash__(self):
-        return hash(FrozenSet({_FrozenDict({key: FrozenSet(self) for key, self in item.items()}) for item in self}))
+        return hash(frozenset({_FrozenDict({key: frozenset(self) for key, self in item.items()}) for item in self}))
 
 
 def extract_origin_header(resolver_headers: Dict[str, Any]):

--- a/aws_lambda_powertools/event_handler/util.py
+++ b/aws_lambda_powertools/event_handler/util.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict
+from typing import Any, Dict, FrozenSet, List
 
 from aws_lambda_powertools.utilities.data_classes.shared_functions import get_header_value
 
@@ -18,7 +18,7 @@ class _FrozenDict(dict):
         return hash(frozenset(self.keys()))
 
 
-class _FrozenListDict(list[dict[str, list[str]]]):
+class _FrozenListDict(List[Dict[str, List[str]]]):
     """
     Freezes a list of dictionaries containing lists of strings.
 
@@ -36,7 +36,7 @@ class _FrozenListDict(list[dict[str, list[str]]]):
     """
 
     def __hash__(self):
-        return hash(frozenset({_FrozenDict({key: frozenset(self) for key, self in item.items()}) for item in self}))
+        return hash(FrozenSet({_FrozenDict({key: FrozenSet(self) for key, self in item.items()}) for item in self}))
 
 
 def extract_origin_header(resolver_headers: Dict[str, Any]):

--- a/aws_lambda_powertools/event_handler/util.py
+++ b/aws_lambda_powertools/event_handler/util.py
@@ -36,7 +36,10 @@ class _FrozenListDict(List[Dict[str, List[str]]]):
     """
 
     def __hash__(self):
-        return hash(frozenset({_FrozenDict({key: frozenset(self) for key, self in item.items()}) for item in self}))
+        hashable_items = []
+        for item in self:
+            hashable_items.extend((key, frozenset(value)) for key, value in item.items())
+        return hash(frozenset(hashable_items))
 
 
 def extract_origin_header(resolver_headers: Dict[str, Any]):

--- a/aws_lambda_powertools/event_handler/util.py
+++ b/aws_lambda_powertools/event_handler/util.py
@@ -18,6 +18,27 @@ class _FrozenDict(dict):
         return hash(frozenset(self.keys()))
 
 
+class _FrozenListDict(list[dict[str, list[str]]]):
+    """
+    Freezes a list of dictionaries containing lists of strings.
+
+    This function takes a list of dictionaries where the values are lists of strings and converts it into
+    a frozen set of frozen sets of frozen dictionaries. This is done by iterating over the input list,
+    converting each dictionary's values (lists of strings) into frozen sets of strings, and then
+    converting the resulting dictionary into a frozen dictionary. Finally, all these frozen dictionaries
+    are collected into a frozen set of frozen sets.
+
+    This operation is useful when you want to ensure the immutability of the data structure and make it
+    hashable, which is required for certain operations like using it as a key in a dictionary or as an
+    element in a set.
+
+    Example: [{"TestAuth": ["test", "test1"]}]
+    """
+
+    def __hash__(self):
+        return hash(frozenset({_FrozenDict({key: frozenset(self) for key, self in item.items()}) for item in self}))
+
+
 def extract_origin_header(resolver_headers: Dict[str, Any]):
     """
     Extracts the 'origin' or 'Origin' header from the provided resolver headers.

--- a/aws_lambda_powertools/event_handler/util.py
+++ b/aws_lambda_powertools/event_handler/util.py
@@ -71,12 +71,14 @@ def extract_origin_header(resolver_headers: Dict[str, Any]):
     return resolved_header
 
 
-def validate_openapi_security_parameters(
+def _validate_openapi_security_parameters(
     security: List[Dict[str, List[str]]],
     security_schemes: Optional[Dict[str, "SecurityScheme"]],
 ) -> bool:
     """
-    Validates the security parameters based on the provided security schemes.
+    This function checks if all security requirements listed in the 'security'
+    parameter are defined in the 'security_schemes' dictionary, as specified
+    in the OpenAPI schema.
 
     Parameters
     ----------
@@ -88,11 +90,11 @@ def validate_openapi_security_parameters(
     Returns
     -------
     bool
-        True if all security scheme names in the `security` parameter are present in the `security_schemes` parameter,
-        False otherwise.
-
+        Whether list of security schemes match allowed security_schemes.
     """
 
-    return bool(
-        security_schemes and all(key in security_schemes for sec in security for key in sec),
-    )
+    security_schemes = security_schemes or {}
+
+    security_schema_match = all(key in security_schemes for sec in security for key in sec)
+
+    return bool(security_schema_match and security_schemes)

--- a/aws_lambda_powertools/event_handler/util.py
+++ b/aws_lambda_powertools/event_handler/util.py
@@ -73,7 +73,7 @@ def extract_origin_header(resolver_headers: Dict[str, Any]):
 
 def _validate_openapi_security_parameters(
     security: List[Dict[str, List[str]]],
-    security_schemes: Optional[Dict[str, "SecurityScheme"]],
+    security_schemes: Optional[Dict[str, "SecurityScheme"]] = None,
 ) -> bool:
     """
     This function checks if all security requirements listed in the 'security'

--- a/docs/core/event_handler/api_gateway.md
+++ b/docs/core/event_handler/api_gateway.md
@@ -1033,7 +1033,7 @@ Below is an example configuration for serving Swagger UI from a custom path or C
     No. Powertools adds support for generating OpenAPI documentation with [security schemes](https://swagger.io/docs/specification/authentication/), but it doesn't implement any of the security schemes itself, so you must implement the security mechanisms separately.
 
 OpenAPI uses the term security scheme for [authentication and authorization schemes](https://swagger.io/docs/specification/authentication/){target="_blank"}.
-When you're describing your API, declare security schemes at the top level, and reference them globally or per operation.
+When you're describing your API, declare security schemes at the top level, and reference them globally or per operation. Remember to have the security configurations defined in the `security_schemes`, otherwise a `SchemaValidationError` will be raised.
 
 === "Global OpenAPI security schemes"
 

--- a/docs/core/event_handler/api_gateway.md
+++ b/docs/core/event_handler/api_gateway.md
@@ -1032,8 +1032,7 @@ Below is an example configuration for serving Swagger UI from a custom path or C
 ???-info "Does Powertools implement any of the security schemes?"
     No. Powertools adds support for generating OpenAPI documentation with [security schemes](https://swagger.io/docs/specification/authentication/), but it doesn't implement any of the security schemes itself, so you must implement the security mechanisms separately.
 
-OpenAPI uses the term security scheme for [authentication and authorization schemes](https://swagger.io/docs/specification/authentication/){target="_blank"}.
-When you're describing your API, declare security schemes at the top level, and reference them globally or per operation. Remember to have the security configurations defined in the `security_schemes`, otherwise a `SchemaValidationError` will be raised.
+Security schemes are declared at the top-level first. You can reference them globally or on a per path _(operation)_ level. **However**, if you reference security schemes that are not defined at the top-level it will lead to a `SchemaValidationError` _(invalid OpenAPI spec)_.
 
 === "Global OpenAPI security schemes"
 

--- a/tests/functional/event_handler/conftest.py
+++ b/tests/functional/event_handler/conftest.py
@@ -3,6 +3,7 @@ import json
 import fastjsonschema
 import pytest
 
+from aws_lambda_powertools.event_handler.openapi.models import APIKey, APIKeyIn
 from tests.functional.utils import load_event
 
 
@@ -114,3 +115,8 @@ def openapi31_schema():
         data,
         use_formats=False,
     )
+
+
+@pytest.fixture
+def security_scheme():
+    return {"apiKey": APIKey(name="X-API-KEY", description="API Key", in_=APIKeyIn.header)}

--- a/tests/functional/event_handler/test_openapi_security.py
+++ b/tests/functional/event_handler/test_openapi_security.py
@@ -1,16 +1,19 @@
 import pytest
 
 from aws_lambda_powertools.event_handler import APIGatewayRestResolver
+from aws_lambda_powertools.event_handler.api_gateway import Router
 from aws_lambda_powertools.event_handler.openapi.models import APIKey, APIKeyIn
 
 
 def test_openapi_top_level_security():
+    # GIVEN an APIGatewayRestResolver instance
     app = APIGatewayRestResolver()
 
     @app.get("/")
     def handler():
         raise NotImplementedError()
 
+    # WHEN the get_openapi_schema method is called with a security scheme
     schema = app.get_openapi_schema(
         security_schemes={
             "apiKey": APIKey(name="X-API-KEY", description="API Key", in_=APIKeyIn.header),
@@ -18,6 +21,7 @@ def test_openapi_top_level_security():
         security=[{"apiKey": []}],
     )
 
+    # THEN the resulting schema should have security defined at the top level
     security = schema.security
     assert security is not None
 
@@ -26,12 +30,15 @@ def test_openapi_top_level_security():
 
 
 def test_openapi_top_level_security_missing():
+    # GIVEN an APIGatewayRestResolver instance
     app = APIGatewayRestResolver()
 
     @app.get("/")
     def handler():
         raise NotImplementedError()
 
+    # WHEN the get_openapi_schema method is called with security defined without security schemes
+    # THEN a ValueError should be raised
     with pytest.raises(ValueError):
         app.get_openapi_schema(
             security=[{"apiKey": []}],
@@ -39,18 +46,51 @@ def test_openapi_top_level_security_missing():
 
 
 def test_openapi_operation_security():
+    # GIVEN an APIGatewayRestResolver instance
     app = APIGatewayRestResolver()
 
     @app.get("/", security=[{"apiKey": []}])
     def handler():
         raise NotImplementedError()
 
+    # WHEN the get_openapi_schema method is called with security defined at the operation level
     schema = app.get_openapi_schema(
         security_schemes={
             "apiKey": APIKey(name="X-API-KEY", description="API Key", in_=APIKeyIn.header),
         },
     )
 
+    # THEN the resulting schema should have security defined at the operation level, not the top level
+    security = schema.security
+    assert security is None
+
+    operation = schema.paths["/"].get
+    security = operation.security
+    assert security is not None
+
+    assert len(security) == 1
+    assert security[0] == {"apiKey": []}
+
+
+def test_openapi_operation_security_with_router():
+    # GIVEN an APIGatewayRestResolver instance with a Router
+    app = APIGatewayRestResolver()
+    router = Router()
+
+    @router.get("/", security=[{"apiKey": []}])
+    def handler():
+        raise NotImplementedError()
+
+    app.include_router(router)
+
+    # WHEN the get_openapi_schema method is called with security defined at the operation level in the Router
+    schema = app.get_openapi_schema(
+        security_schemes={
+            "apiKey": APIKey(name="X-API-KEY", description="API Key", in_=APIKeyIn.header),
+        },
+    )
+
+    # THEN the resulting schema should have security defined at the operation level
     security = schema.security
     assert security is None
 

--- a/tests/functional/event_handler/test_openapi_security.py
+++ b/tests/functional/event_handler/test_openapi_security.py
@@ -61,15 +61,10 @@ def test_openapi_operation_security():
     )
 
     # THEN the resulting schema should have security defined at the operation level, not the top level
-    security = schema.security
-    assert security is None
-
-    operation = schema.paths["/"].get
-    security = operation.security
-    assert security is not None
-
-    assert len(security) == 1
-    assert security[0] == {"apiKey": []}
+    top_level_security = schema.security
+    path_level_security = schema.paths["/"].get.security
+    assert top_level_security is None
+    assert path_level_security[0] == {"apiKey": []}
 
 
 def test_openapi_operation_security_with_router():
@@ -91,12 +86,7 @@ def test_openapi_operation_security_with_router():
     )
 
     # THEN the resulting schema should have security defined at the operation level
-    security = schema.security
-    assert security is None
-
-    operation = schema.paths["/"].get
-    security = operation.security
-    assert security is not None
-
-    assert len(security) == 1
-    assert security[0] == {"apiKey": []}
+    top_level_security = schema.security
+    path_level_security = schema.paths["/"].get.security
+    assert top_level_security is None
+    assert path_level_security[0] == {"apiKey": []}

--- a/tests/functional/event_handler/test_openapi_security.py
+++ b/tests/functional/event_handler/test_openapi_security.py
@@ -2,10 +2,10 @@ import pytest
 
 from aws_lambda_powertools.event_handler import APIGatewayRestResolver
 from aws_lambda_powertools.event_handler.api_gateway import Router
-from aws_lambda_powertools.event_handler.openapi.models import APIKey, APIKeyIn
+from aws_lambda_powertools.event_handler.openapi.exceptions import SchemaValidationError
 
 
-def test_openapi_top_level_security():
+def test_openapi_top_level_security(security_scheme):
     # GIVEN an APIGatewayRestResolver instance
     app = APIGatewayRestResolver()
 
@@ -14,12 +14,7 @@ def test_openapi_top_level_security():
         raise NotImplementedError()
 
     # WHEN the get_openapi_schema method is called with a security scheme
-    schema = app.get_openapi_schema(
-        security_schemes={
-            "apiKey": APIKey(name="X-API-KEY", description="API Key", in_=APIKeyIn.header),
-        },
-        security=[{"apiKey": []}],
-    )
+    schema = app.get_openapi_schema(security_schemes=security_scheme, security=[{"apiKey": []}])
 
     # THEN the resulting schema should have security defined at the top level
     security = schema.security
@@ -32,31 +27,47 @@ def test_openapi_top_level_security():
 def test_openapi_top_level_security_missing():
     # GIVEN an APIGatewayRestResolver instance
     app = APIGatewayRestResolver()
-    app.enable_swagger()
 
     @app.get("/")
     def handler():
         raise NotImplementedError()
 
     # WHEN the get_openapi_schema method is called with security defined without security schemes
-    # THEN a ValueError should be raised
-    with pytest.raises(ValueError):
+    # THEN a SchemaValidationError should be raised
+    with pytest.raises(SchemaValidationError):
         app.get_openapi_schema(
             security=[{"apiKey": []}],
         )
 
 
-def test_openapi_operation_security():
+def test_openapi_top_level_security_mismatch(security_scheme):
     # GIVEN an APIGatewayRestResolver instance
     app = APIGatewayRestResolver()
-    security_schemes = {"apiKey": APIKey(name="X-API-KEY", description="API Key", in_=APIKeyIn.header)}
+
+    @app.get("/")
+    def handler():
+        raise NotImplementedError()
+
+    # WHEN the get_openapi_schema method is called with security defined security schemes as APIKey
+    # WHEN top level security is defined as HTTPBearer
+    # THEN a SchemaValidationError should be raised
+    with pytest.raises(SchemaValidationError):
+        app.get_openapi_schema(
+            security_schemes=security_scheme,
+            security=[{"HTTPBearer": []}],
+        )
+
+
+def test_openapi_operation_level_security(security_scheme):
+    # GIVEN an APIGatewayRestResolver instance
+    app = APIGatewayRestResolver()
 
     @app.get("/", security=[{"apiKey": []}])
     def handler():
         raise NotImplementedError()
 
     # WHEN the get_openapi_schema method is called with security defined at the operation level
-    schema = app.get_openapi_schema(security_schemes=security_schemes)
+    schema = app.get_openapi_schema(security_schemes=security_scheme)
 
     # THEN the resulting schema should have security defined at the operation level, not the top level
     top_level_security = schema.security
@@ -65,11 +76,42 @@ def test_openapi_operation_security():
     assert path_level_security[0] == {"apiKey": []}
 
 
-def test_openapi_operation_security_with_router():
+def test_openapi_operation_level_security_missing():
+    # GIVEN an APIGatewayRestResolver instance
+    app = APIGatewayRestResolver()
+
+    # WHEN we define a security in operation
+    @app.get("/", security=[{"apiKey": []}])
+    def handler():
+        raise NotImplementedError()
+
+    # WHEN the get_openapi_schema method is called without security schemes defined
+    # THEN a SchemaValidationError should be raised
+    with pytest.raises(SchemaValidationError):
+        app.get_openapi_schema()
+
+
+def test_openapi_operation_level_security_mismatch(security_scheme):
+    # GIVEN an APIGatewayRestResolver instance
+    app = APIGatewayRestResolver()
+
+    # WHEN we define a security in operation with value HTTPBearer
+    @app.get("/", security=[{"HTTPBearer": []}])
+    def handler():
+        raise NotImplementedError()
+
+    # WHEN the get_openapi_schema method is called with security defined security schemes as APIKey
+    # THEN a SchemaValidationError should be raised
+    with pytest.raises(SchemaValidationError):
+        app.get_openapi_schema(
+            security_schemes=security_scheme,
+        )
+
+
+def test_openapi_operation_level_security_with_router(security_scheme):
     # GIVEN an APIGatewayRestResolver instance with a Router
     app = APIGatewayRestResolver()
     router = Router()
-    security_schemes = {"apiKey": APIKey(name="X-API-KEY", description="API Key", in_=APIKeyIn.header)}
 
     @router.get("/", security=[{"apiKey": []}])
     def handler():
@@ -78,7 +120,7 @@ def test_openapi_operation_security_with_router():
     app.include_router(router)
 
     # WHEN the get_openapi_schema method is called with security defined at the operation level in the Router
-    schema = app.get_openapi_schema(security_schemes=security_schemes)
+    schema = app.get_openapi_schema(security_schemes=security_scheme)
 
     # THEN the resulting schema should have security defined at the operation level
     top_level_security = schema.security

--- a/tests/functional/event_handler/test_openapi_security.py
+++ b/tests/functional/event_handler/test_openapi_security.py
@@ -49,7 +49,7 @@ def test_openapi_top_level_security_mismatch(security_scheme):
         raise NotImplementedError()
 
     # WHEN the get_openapi_schema method is called with security defined security schemes as APIKey
-    # WHEN top level security is defined as HTTPBearer
+    # AND top level security is defined as HTTPBearer
     # THEN a SchemaValidationError should be raised
     with pytest.raises(SchemaValidationError):
         app.get_openapi_schema(
@@ -80,7 +80,7 @@ def test_openapi_operation_level_security_missing():
     # GIVEN an APIGatewayRestResolver instance
     app = APIGatewayRestResolver()
 
-    # WHEN we define a security in operation
+    # AND a route with a security scheme defined
     @app.get("/", security=[{"apiKey": []}])
     def handler():
         raise NotImplementedError()
@@ -95,7 +95,7 @@ def test_openapi_operation_level_security_mismatch(security_scheme):
     # GIVEN an APIGatewayRestResolver instance
     app = APIGatewayRestResolver()
 
-    # WHEN we define a security in operation with value HTTPBearer
+    # AND a route with a security scheme using HTTPBearer
     @app.get("/", security=[{"HTTPBearer": []}])
     def handler():
         raise NotImplementedError()

--- a/tests/functional/event_handler/test_openapi_security.py
+++ b/tests/functional/event_handler/test_openapi_security.py
@@ -32,6 +32,7 @@ def test_openapi_top_level_security():
 def test_openapi_top_level_security_missing():
     # GIVEN an APIGatewayRestResolver instance
     app = APIGatewayRestResolver()
+    app.enable_swagger()
 
     @app.get("/")
     def handler():
@@ -48,17 +49,14 @@ def test_openapi_top_level_security_missing():
 def test_openapi_operation_security():
     # GIVEN an APIGatewayRestResolver instance
     app = APIGatewayRestResolver()
+    security_schemes = {"apiKey": APIKey(name="X-API-KEY", description="API Key", in_=APIKeyIn.header)}
 
     @app.get("/", security=[{"apiKey": []}])
     def handler():
         raise NotImplementedError()
 
     # WHEN the get_openapi_schema method is called with security defined at the operation level
-    schema = app.get_openapi_schema(
-        security_schemes={
-            "apiKey": APIKey(name="X-API-KEY", description="API Key", in_=APIKeyIn.header),
-        },
-    )
+    schema = app.get_openapi_schema(security_schemes=security_schemes)
 
     # THEN the resulting schema should have security defined at the operation level, not the top level
     top_level_security = schema.security
@@ -71,6 +69,7 @@ def test_openapi_operation_security_with_router():
     # GIVEN an APIGatewayRestResolver instance with a Router
     app = APIGatewayRestResolver()
     router = Router()
+    security_schemes = {"apiKey": APIKey(name="X-API-KEY", description="API Key", in_=APIKeyIn.header)}
 
     @router.get("/", security=[{"apiKey": []}])
     def handler():
@@ -79,11 +78,7 @@ def test_openapi_operation_security_with_router():
     app.include_router(router)
 
     # WHEN the get_openapi_schema method is called with security defined at the operation level in the Router
-    schema = app.get_openapi_schema(
-        security_schemes={
-            "apiKey": APIKey(name="X-API-KEY", description="API Key", in_=APIKeyIn.header),
-        },
-    )
+    schema = app.get_openapi_schema(security_schemes=security_schemes)
 
     # THEN the resulting schema should have security defined at the operation level
     top_level_security = schema.security


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
**Issue number:** #4375 

## Summary

### Changes

This pull request ensures that the `get_openapi_json_schema` method can correctly generate the OpenAPI JSON schema for routes that include security parameters when using the `APIGatewayHttpRouter`.

Previously, when the security parameter was included in a router, any endpoint would return an "Internal Server Error".

```sh
[ERROR] TypeError: unhashable type: 'list' Traceback (most recent call last): File "/var/lang/lib/python3.12/importlib/__init__.py", line 90, in import_module return _bootstrap._gcd_import(name[level:], package, level) File "<frozen importlib._bootstrap>", line 1387, in _gcd_import File "<frozen importlib._bootstrap>", line 1360, in _find_and_load File "<frozen importlib._bootstrap>", line 1331, in _find_and_load_unlocked File "<frozen importlib._bootstrap>", line 935, in _load_unlocked File "<frozen importlib._bootstrap_external>", line 995, in exec_module File "<frozen importlib._bootstrap>", line 488, in _call_with_frames_removed File "/var/task/app.py", line 14, in <module> from project_member_v1 import router as project_member_router File "/var/task/project_member_v1/router.py", line 27, in <module> @router.get( File "/opt/python/aws_lambda_powertools/event_handler/api_gateway.py", line 2412, in register_route self._routes_with_middleware[route_key] = []
```

### Example

#### app.py
```python
from aws_lambda_powertools.event_handler import APIGatewayHttpResolver
from router import OpenApiConfiguration, router


app = APIGatewayHttpResolver(enable_validation=True)
OpenApiConfiguration.configure_swagger(app)


app.include_router(router, prefix="/v1/test")

@app.get("/openapispec", tags=["Docs"], summary="Get the OpenAPI specification", security=[{"TestAuth": []}])
def get_openapi():
    return app.get_openapi_json_schema(**OpenApiConfiguration.get_meta_data())

def lambda_handler(event, context):
    return app.resolve(event, context)
```

#### router.py
```python
from aws_lambda_powertools.event_handler import APIGatewayHttpResolver
from aws_lambda_powertools.event_handler.api_gateway import Router
from aws_lambda_powertools.event_handler.openapi.models import HTTPBearer

router = Router()

@router.get(
    "/<test_id>",
    tags=["Test"],
    summary="Test endpoint",
    security=[{"TestAuth": ["a"]}],
)
def get_test_item(test_id: str) :
    return "OK"

class OpenApiConfiguration:
    @staticmethod
    def get_meta_data():
        return {
            "title": "TestAPI",
            "version": "0.0.1",
            "description": "TestAPI",
            "terms_of_service": None,
            "license_info": None,
            "openapi_version": "3.0.1",
            "security_schemes": {
                "TestAuth": HTTPBearer(scheme="bearer", bearerFormat="JWT", description="JWT token authentication"),
            },
        }

    @staticmethod
    def configure_swagger(resolver: APIGatewayHttpResolver) -> None:
        resolver.enable_swagger(
            **OpenApiConfiguration.get_meta_data(),
            path="/swagger",
            swagger_base_url="https://cdnjs.cloudflare.com/ajax/libs/swagger-ui/5.11.0"
        )
```

### User experience

> Please share what the user experience looks like before and after this change

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] [Meet tenets criteria](https://docs.powertools.aws.dev/lambda/python/#tenets)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented
* [x] PR title follows [conventional commit semantics](https://github.com/aws-powertools/powertools-lambda-python/blob/develop/.github/semantic.yml)

<details>
<summary>Is this a breaking change?</summary>

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
