### PR TITLE
fix(event_handler): regression making pydantic required (it should not)

### DIFF
--- a/aws_lambda_powertools/event_handler/util.py
+++ b/aws_lambda_powertools/event_handler/util.py
@@ -1,6 +1,5 @@
 from typing import Any, Dict, List, Optional
 
-from aws_lambda_powertools.event_handler.openapi.models import SecurityScheme
 from aws_lambda_powertools.utilities.data_classes.shared_functions import get_header_value
 
 
@@ -73,7 +72,7 @@ def extract_origin_header(resolver_headers: Dict[str, Any]):
 
 def _validate_openapi_security_parameters(
     security: List[Dict[str, List[str]]],
-    security_schemes: Optional[Dict[str, "SecurityScheme"]] = None,
+    security_schemes: Optional[Dict[str, Any]] = None,
 ) -> bool:
     """
     This function checks if all security requirements listed in the 'security'
@@ -84,7 +83,7 @@ def _validate_openapi_security_parameters(
     ----------
     security: List[Dict[str, List[str]]]
         A list of security requirements
-    security_schemes: Optional[Dict[str, "SecurityScheme"]]
+    security_schemes: Optional[Dict[str, Any]]
         A dictionary mapping security scheme names to their corresponding security scheme objects.
 
     Returns


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
**Issue number:** #4498

## Summary

### Changes

> Please provide a summary of what's being changed

### User experience

> Please share what the user experience looks like before and after this change

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] [Meet tenets criteria](https://docs.powertools.aws.dev/lambda/python/#tenets)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented
* [x] PR title follows [conventional commit semantics](https://github.com/aws-powertools/powertools-lambda-python/blob/develop/.github/semantic.yml)

<details>
<summary>Is this a breaking change?</summary>

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
