### PR TITLE
fix(event_sources): change partition and offset field types in KafkaEventRecord

### DIFF
--- a/aws_lambda_powertools/utilities/data_classes/kafka_event.py
+++ b/aws_lambda_powertools/utilities/data_classes/kafka_event.py
@@ -15,12 +15,12 @@ class KafkaEventRecord(DictWrapper):
         return self["topic"]
 
     @property
-    def partition(self) -> str:
+    def partition(self) -> int:
         """The Kafka record parition."""
         return self["partition"]
 
     @property
-    def offset(self) -> str:
+    def offset(self) -> int:
         """The Kafka record offset."""
         return self["offset"]
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
**Issue number: https://github.com/aws-powertools/powertools-lambda-python/issues/4504**

## Summary

### Changes

Updated `offset` and `partition` properties to be an `int` type instead of `str` on the `KafkaEventRecord` class.

### User experience

```python
from aws_lambda_powertools.utilities.data_classes import event_source, KafkaEvent

@event_source(data_class=KafkaEvent)
def lambda_handler(event: KafkaEvent, context):
    assert isinstance(event.record.offset, int)
    assert isinstance(event.record.partition, int)
```

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] [Meet tenets criteria](https://docs.powertools.aws.dev/lambda/python/#tenets)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented
* [x] PR title follows [conventional commit semantics](https://github.com/aws-powertools/powertools-lambda-python/blob/develop/.github/semantic.yml)

<details>
<summary>Is this a breaking change?</summary>

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
