### PR TITLE
fix(event_handler): current_event regression AppSyncResolver Router

### DIFF
--- a/aws_lambda_powertools/event_handler/appsync.py
+++ b/aws_lambda_powertools/event_handler/appsync.py
@@ -49,10 +49,6 @@ class AppSyncResolver(Router):
         super().__init__()
         self.context = {}  # early init as customers might add context before event resolution
 
-        self.current_batch_event: List[AppSyncResolverEvent] = []
-        self.current_event: Optional[AppSyncResolverEvent] = None
-        self.lambda_context: Optional[LambdaContext] = None
-
     def __call__(
         self,
         event: dict,
@@ -139,10 +135,13 @@ class AppSyncResolver(Router):
         """
 
         self.lambda_context = context
+        Router.lambda_context = context
 
         if isinstance(event, list):
+            Router.current_batch_event = [data_model(e) for e in event]
             response = self._call_batch_resolver(event=event, data_model=data_model)
         else:
+            Router.current_event = data_model(event)
             response = self._call_single_resolver(event=event, data_model=data_model)
 
         self.clear_context()
@@ -162,7 +161,6 @@ class AppSyncResolver(Router):
 
         logger.debug("Processing direct resolver event")
 
-        self.current_event = data_model(event)
         resolver = self._resolver_registry.find_resolver(self.current_event.type_name, self.current_event.field_name)
         if not resolver:
             raise ValueError(f"No resolver found for '{self.current_event.type_name}.{self.current_event.field_name}'")
@@ -309,7 +307,6 @@ class AppSyncResolver(Router):
         """
         logger.debug("Processing batch resolver event")
 
-        self.current_batch_event = [data_model(e) for e in event]
         type_name, field_name = self.current_batch_event[0].type_name, self.current_batch_event[0].field_name
 
         resolver = self._batch_resolver_registry.find_resolver(type_name, field_name)

--- a/aws_lambda_powertools/event_handler/appsync.py
+++ b/aws_lambda_powertools/event_handler/appsync.py
@@ -161,6 +161,7 @@ class AppSyncResolver(Router):
 
         logger.debug("Processing direct resolver event")
 
+        self.current_event = data_model(event)
         resolver = self._resolver_registry.find_resolver(self.current_event.type_name, self.current_event.field_name)
         if not resolver:
             raise ValueError(f"No resolver found for '{self.current_event.type_name}.{self.current_event.field_name}'")
@@ -307,6 +308,7 @@ class AppSyncResolver(Router):
         """
         logger.debug("Processing batch resolver event")
 
+        self.current_batch_event = [data_model(e) for e in event]
         type_name, field_name = self.current_batch_event[0].type_name, self.current_batch_event[0].field_name
 
         resolver = self._batch_resolver_registry.find_resolver(type_name, field_name)

--- a/aws_lambda_powertools/event_handler/graphql_appsync/router.py
+++ b/aws_lambda_powertools/event_handler/graphql_appsync/router.py
@@ -1,11 +1,16 @@
-from typing import Callable, Optional
+from typing import Callable, List, Optional
 
 from aws_lambda_powertools.event_handler.graphql_appsync._registry import ResolverRegistry
 from aws_lambda_powertools.event_handler.graphql_appsync.base import BaseRouter
+from aws_lambda_powertools.utilities.data_classes.appsync_resolver_event import AppSyncResolverEvent
+from aws_lambda_powertools.utilities.typing.lambda_context import LambdaContext
 
 
 class Router(BaseRouter):
     context: dict
+    current_batch_event: List[AppSyncResolverEvent] = []
+    current_event: Optional[AppSyncResolverEvent] = None
+    lambda_context: Optional[LambdaContext] = None
 
     def __init__(self):
         self.context = {}  # early init as customers might add context before event resolution

--- a/tests/events/appSyncBatchEvent.json
+++ b/tests/events/appSyncBatchEvent.json
@@ -1,7 +1,7 @@
 [
   {
     "arguments": {
-      "id": "1"
+      "user_id": "1"
     },
     "identity": {
       "sub": "192879fc-a240-4bf1-ab5a-d6a00f3063f9",
@@ -23,7 +23,7 @@
   },
   {
     "arguments": {
-      "id": "2"
+      "user_id": "2"
     },
     "identity": {
       "sub": "192879fc-a240-4bf1-ab5a-d6a00f3063f9",

--- a/tests/events/appSyncBatchEvent.json
+++ b/tests/events/appSyncBatchEvent.json
@@ -1,0 +1,46 @@
+[
+  {
+    "arguments": {
+      "id": "1"
+    },
+    "identity": {
+      "sub": "192879fc-a240-4bf1-ab5a-d6a00f3063f9",
+      "username": "jdoe"
+    },
+    "prev": null,
+    "info": {
+      "selectionSetList": [
+        "id",
+        "field1",
+        "field2"
+      ],
+      "selectionSetGraphQL": "{\n  id\n  field1\n  field2\n}",
+      "parentTypeName": "Mutation",
+      "fieldName": "createSomething",
+      "variables": {}
+    },
+    "stash": {}
+  },
+  {
+    "arguments": {
+      "id": "2"
+    },
+    "identity": {
+      "sub": "192879fc-a240-4bf1-ab5a-d6a00f3063f9",
+      "username": "jdoe"
+    },
+    "prev": null,
+    "info": {
+      "selectionSetList": [
+        "id",
+        "field1",
+        "field2"
+      ],
+      "selectionSetGraphQL": "{\n  id\n  field1\n  field2\n}",
+      "parentTypeName": "Mutation",
+      "fieldName": "createSomething",
+      "variables": {}
+    },
+    "stash": {}
+  }
+]

--- a/tests/functional/event_handler/required_dependencies/appsync/test_appsync_single_resolvers.py
+++ b/tests/functional/event_handler/required_dependencies/appsync/test_appsync_single_resolvers.py
@@ -251,3 +251,41 @@ def test_include_router_merges_context():
     app.include_router(router)
 
     assert app.context == router.context
+
+
+def test_include_router_access_current_event():
+    mock_event = load_event("appSyncDirectResolver.json")
+
+    # GIVEN An instance of AppSyncResolver, a Router instance, and a resolver function registered with the router
+    app = AppSyncResolver()
+    router = Router()
+
+    @router.resolver(field_name="createSomething")
+    def get_user(id_user: str) -> dict:
+        return router.current_event.identity.sub
+
+    app.include_router(router)
+
+    # WHEN we resolve the event
+    ret = app.resolve(mock_event, {})
+
+    # THEN the resolver must be able to return a field in the current_event
+    assert ret == mock_event["identity"]["sub"]
+
+
+def test_app_access_current_event():
+    # Check whether we can handle an example appsync direct resolver
+    mock_event = load_event("appSyncDirectResolver.json")
+
+    # GIVEN An instance of AppSyncResolver and a resolver function registered with the app
+    app = AppSyncResolver()
+
+    @app.resolver(field_name="createSomething")
+    def get_user(id_user: str) -> dict:
+        return app.current_event.identity.sub
+
+    # WHEN we resolve the event
+    ret = app.resolve(mock_event, {})
+
+    # THEN the resolver must be able to return a field in the current_event
+    assert ret == mock_event["identity"]["sub"]

--- a/tests/functional/event_handler/required_dependencies/appsync/test_appsync_single_resolvers.py
+++ b/tests/functional/event_handler/required_dependencies/appsync/test_appsync_single_resolvers.py
@@ -261,7 +261,7 @@ def test_include_router_access_current_event():
     router = Router()
 
     @router.resolver(field_name="createSomething")
-    def get_user(id_user: str) -> dict:
+    def get_user(id: str) -> dict:  # noqa AA03 VNE003
         return router.current_event.identity.sub
 
     app.include_router(router)
@@ -281,7 +281,7 @@ def test_app_access_current_event():
     app = AppSyncResolver()
 
     @app.resolver(field_name="createSomething")
-    def get_user(id_user: str) -> dict:
+    def get_user(id: str) -> dict:  # noqa AA03 VNE003
         return app.current_event.identity.sub
 
     # WHEN we resolve the event


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
**Issue number:** #4650 

## Summary

### Changes

In version 2.40.0, we introduced a breaking change by removing the `current_event` property from the Router object. This PR fixes this issue.

### User experience

> Please share what the user experience looks like before and after this change

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] [Meet tenets criteria](https://docs.powertools.aws.dev/lambda/python/#tenets)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented
* [x] PR title follows [conventional commit semantics](https://github.com/aws-powertools/powertools-lambda-python/blob/develop/.github/semantic.yml)

<details>
<summary>Is this a breaking change?</summary>

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
