### PR TITLE
chore: Add token to codecov action

### DIFF
--- a/.github/workflows/quality_check.yml
+++ b/.github/workflows/quality_check.yml
@@ -77,6 +77,7 @@ jobs:
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@e28ff129e5465c2c0dcc6f003fc735cb6ae0c673 # 4.5.0
         with:
+          token: ${{ secrets.CODECOV_TOKEN }}
           file: ./coverage.xml
           env_vars: PYTHON
           name: aws-lambda-powertools-python-codecov


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
**Issue number:** #4681 

## Summary

Codecov upload is failing on non fork pull requests as per documentation
![image](https://github.com/aws-powertools/powertools-lambda-python/assets/999396/7562e2e8-1a07-4e28-892f-ca62ddfa0152)

### Changes

⚠️ **Before merging this pull request, _CODECOV_TOKEN_ environment variable must be present in GitHub settings**

Add token parameter to codecov action, as per the documentation https://about.codecov.io/blog/january-product-update-updating-the-codecov-ci-uploaders-to-the-codecov-cli/

### User experience

> Please share what the user experience looks like before and after this change

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] [Meet tenets criteria](https://docs.powertools.aws.dev/lambda/python/#tenets)
* [x] I have performed a self-review of this change
* [ ] Changes have been tested
* [x] Changes are documented
* [x] PR title follows [conventional commit semantics](https://github.com/aws-powertools/powertools-lambda-python/blob/develop/.github/semantic.yml)

<details>
<summary>Is this a breaking change?</summary>

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
