### PR TITLE
fix(event_handler): convert null body to empty string in ALBResolver to avoid HTTP 502

### DIFF
--- a/aws_lambda_powertools/event_handler/api_gateway.py
+++ b/aws_lambda_powertools/event_handler/api_gateway.py
@@ -30,6 +30,8 @@ from typing import (
     cast,
 )
 
+from typing_extensions import override
+
 from aws_lambda_powertools.event_handler import content_types
 from aws_lambda_powertools.event_handler.exceptions import NotFoundError, ServiceError
 from aws_lambda_powertools.event_handler.openapi.constants import DEFAULT_API_VERSION, DEFAULT_OPENAPI_VERSION
@@ -2652,3 +2654,24 @@ class ALBResolver(ApiGatewayResolver):
     def _get_base_path(self) -> str:
         # ALB doesn't have a stage variable, so we just return an empty string
         return ""
+
+    @override
+    def _to_response(self, result: Union[Dict, Tuple, Response]) -> Response:
+        """Convert the route's result to a Response
+
+        ALB requires a non-null body otherwise it converts as HTTP 5xx
+
+         3 main result types are supported:
+
+        - Dict[str, Any]: Rest api response with just the Dict to json stringify and content-type is set to
+          application/json
+        - Tuple[dict, int]: Same dict handling as above but with the option of including a status code
+        - Response: returned as is, and allows for more flexibility
+        """
+
+        # NOTE: Minor override for early return on Response with null body for ALB
+        if isinstance(result, Response) and result.body is None:
+            logger.debug("ALB doesn't allow None responses; converting to empty string")
+            result.body = ""
+
+        return super()._to_response(result)

--- a/docs/core/event_handler/api_gateway.md
+++ b/docs/core/event_handler/api_gateway.md
@@ -51,11 +51,17 @@ This is the sample infrastructure for API Gateway and Lambda Function URLs we ar
 
 ### Event Resolvers
 
-Before you decorate your functions to handle a given path and HTTP method(s), you need to initialize a resolver.
+Before you decorate your functions to handle a given path and HTTP method(s), you need to initialize a resolver. A resolver will handle request resolution, including [one or more routers](#split-routes-with-router), and give you access to the current event via typed properties.
 
-A resolver will handle request resolution, including [one or more routers](#split-routes-with-router), and give you access to the current event via typed properties.
+By default, we will use `APIGatewayRestResolver` throughout the documentation. You can use any of the following:
 
-For resolvers, we provide: `APIGatewayRestResolver`, `APIGatewayHttpResolver`, `ALBResolver`, `LambdaFunctionUrlResolver`, and `VPCLatticeResolver`. From here on, we will default to `APIGatewayRestResolver` across examples.
+| Resolver                                                | AWS service                            |
+| ------------------------------------------------------- | -------------------------------------- |
+| **[`APIGatewayRestResolver`](#api-gateway-rest-api)**   | Amazon API Gateway REST API            |
+| **[`APIGatewayHttpResolver`](#api-gateway-http-api)**   | Amazon API Gateway HTTP API            |
+| **[`ALBResolver`](#application-load-balancer)**         | Amazon Application Load Balancer (ALB) |
+| **[`LambdaFunctionUrlResolver`](#lambda-function-url)** | AWS Lambda Function URL                |
+| **[`VPCLatticeResolver`](#vpc-lattice)**                | Amazon VPC Lattice                     |
 
 ???+ info "Auto-serialization"
     We serialize `Dict` responses as JSON, trim whitespace for compact responses, set content-type to `application/json`, and
@@ -462,16 +468,16 @@ In the following example, we use a new `Header` OpenAPI type to add [one out of 
 
 With data validation enabled, we natively support serializing the following data types to JSON:
 
-| Data type                                                            | Serialized type                                                                  |
-| -------------------------------------------------------------------- | -------------------------------------------------------------------------------- |
-| **Pydantic models**                                                  | `dict`                                                                           |
-| **Python Dataclasses**                                               | `dict`                                                                           |
-| **Enum**                                                             | Enum values                                                                      |
-| **Datetime**                                                         | Datetime ISO format string                                                       |
-| **Decimal**                                                          | `int` if no exponent, or `float`                                                 |
-| **Path**                                                             | `str`                                                                            |
-| **UUID**                                                             | `str`                                                                            |
-| **Set**                                                              | `list`                                                                           |
+| Data type                                                            | Serialized type                                                                                                                               |
+| -------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Pydantic models**                                                  | `dict`                                                                                                                                        |
+| **Python Dataclasses**                                               | `dict`                                                                                                                                        |
+| **Enum**                                                             | Enum values                                                                                                                                   |
+| **Datetime**                                                         | Datetime ISO format string                                                                                                                    |
+| **Decimal**                                                          | `int` if no exponent, or `float`                                                                                                              |
+| **Path**                                                             | `str`                                                                                                                                         |
+| **UUID**                                                             | `str`                                                                                                                                         |
+| **Set**                                                              | `list`                                                                                                                                        |
 | **Python primitives** _(dict, string, sequences, numbers, booleans)_ | [Python's default JSON serializable types](https://docs.python.org/3/library/json.html#encoders-and-decoders){target="_blank" rel="nofollow"} |
 
 ???+ info "See [custom serializer section](#custom-serializer) for bringing your own."

--- a/docs/core/event_handler/api_gateway.md
+++ b/docs/core/event_handler/api_gateway.md
@@ -63,9 +63,33 @@ By default, we will use `APIGatewayRestResolver` throughout the documentation. Y
 | **[`LambdaFunctionUrlResolver`](#lambda-function-url)** | AWS Lambda Function URL                |
 | **[`VPCLatticeResolver`](#vpc-lattice)**                | Amazon VPC Lattice                     |
 
-???+ info "Auto-serialization"
-    We serialize `Dict` responses as JSON, trim whitespace for compact responses, set content-type to `application/json`, and
-    return a 200 OK HTTP status. You can optionally set a different HTTP status code as the second argument of the tuple:
+#### Response auto-serialization
+
+> Want full control of the response, headers and status code? [Read about `Response` object here](#fine-grained-responses).
+
+For your convenience, we automatically perform these if you return a dictionary response:
+
+1. Auto-serialize `dictionary` responses to JSON and trim it
+2. Include the response under each resolver's equivalent of a `body`
+3. Set `Content-Type` to `application/json`
+4. Set `status_code` to 200 (OK)
+
+=== "getting_started_resolvers_response_serialization.py"
+
+    ```python hl_lines="9"
+    --8<-- "examples/event_handler_rest/src/getting_started_resolvers_response_serialization.py"
+    ```
+
+    1. This dictionary will be serialized, trimmed, and included under the `body` key
+
+=== "getting_started_resolvers_response_serialization_output.json"
+
+    ```json hl_lines="8"
+    --8<-- "examples/event_handler_rest/src/getting_started_resolvers_response_serialization_output.json"
+    ```
+
+??? info "Coming from Flask? We also support tuple response"
+    You can optionally set a different HTTP status code as the second argument of the tuple.
 
     ```python hl_lines="15 16"
     --8<-- "examples/event_handler_rest/src/getting_started_return_tuple.py"

--- a/examples/event_handler_rest/src/getting_started_resolvers_response_serialization.py
+++ b/examples/event_handler_rest/src/getting_started_resolvers_response_serialization.py
@@ -1,0 +1,13 @@
+from aws_lambda_powertools.event_handler import APIGatewayRestResolver
+from aws_lambda_powertools.utilities.typing.lambda_context import LambdaContext
+
+app = APIGatewayRestResolver()
+
+
+@app.get("/ping")
+def ping():
+    return {"message": "pong"}  # (1)!
+
+
+def lambda_handler(event: dict, context: LambdaContext) -> dict:
+    return app.resolve(event, context)

--- a/examples/event_handler_rest/src/getting_started_resolvers_response_serialization_output.json
+++ b/examples/event_handler_rest/src/getting_started_resolvers_response_serialization_output.json
@@ -1,0 +1,10 @@
+{
+    "statusCode": 200,
+    "multiValueHeaders": {
+        "Content-Type": [
+            "application/json"
+        ]
+    },
+    "body": "{'message':'pong'}",
+    "isBase64Encoded": false
+}

--- a/tests/e2e/event_handler/handlers/alb_handler_with_body_none.py
+++ b/tests/e2e/event_handler/handlers/alb_handler_with_body_none.py
@@ -1,0 +1,17 @@
+from aws_lambda_powertools.event_handler import (
+    ALBResolver,
+    Response,
+)
+
+app = ALBResolver()
+
+
+@app.get("/todos_with_no_body")
+def todos():
+    return Response(
+        status_code=200,
+    )
+
+
+def lambda_handler(event, context):
+    return app.resolve(event, context)

--- a/tests/e2e/event_handler/test_response_code.py
+++ b/tests/e2e/event_handler/test_response_code.py
@@ -1,0 +1,29 @@
+import pytest
+from requests import Request
+
+from tests.e2e.utils import data_fetcher
+from tests.e2e.utils.auth import build_iam_auth
+
+
+@pytest.fixture
+def alb_basic_without_body_listener_endpoint(infrastructure: dict) -> str:
+    dns_name = infrastructure.get("ALBDnsName")
+    port = infrastructure.get("ALBBasicWithoutBodyListenerPort", "")
+    return f"http://{dns_name}:{port}"
+
+
+@pytest.mark.xdist_group(name="event_handler")
+def test_alb_with_body_empty(alb_basic_without_body_listener_endpoint):
+    # GIVEN url has a trailing slash - it should behave as if there was not one
+    url = f"{alb_basic_without_body_listener_endpoint}/todos_with_no_body"
+
+    # WHEN calling an invalid URL (with trailing slash) expect HTTPError exception from data_fetcher
+    response = data_fetcher.get_http_response(
+        Request(
+            method="GET",
+            url=url,
+            auth=build_iam_auth(url=url, aws_service="lambda"),
+        ),
+    )
+
+    assert response.status_code == 200

--- a/tests/functional/event_handler/required_dependencies/test_api_gateway.py
+++ b/tests/functional/event_handler/required_dependencies/test_api_gateway.py
@@ -1820,3 +1820,21 @@ def test_route_match_prioritize_full_match():
     # THEN the static_handler should have been called, because it fully matches the path directly
     response_body = json.loads(response["body"])
     assert response_body["hello"] == "static"
+
+
+def test_alb_empty_response_object():
+    # GIVEN an ALB Resolver
+    app = ALBResolver()
+    event = {"path": "/my/request", "httpMethod": "GET"}
+
+    # AND route returns a Response object with empty body
+    @app.get("/my/request")
+    def opa():
+        return Response(status_code=200, content_type=content_types.APPLICATION_JSON)
+
+    # WHEN calling the event handler
+    result = app(event, {})
+
+    # THEN body should be converted to an empty string
+    assert result["statusCode"] == 200
+    assert result["body"] == ""


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
**Issue number:** #4671

## Summary

Auto convert `None` body responses to empty strings when a `Response` object is used. By default, ALB raises a HTTP 502 if body is `null`.

This differs from other resolvers (API GW, Lattice, Function URL).

**Docs**. To prevent another confusion, this PR updates the doc to move a  auto-serialization banner into its own sub-section to explain why a `dict` in the route function will always end up inside `body` key.

### Changes

> Please provide a summary of what's being changed

* [x] Convert `None` response body to empty string `""`
* [x] Docs: reword `Auto-serialization` piece
* [x] Double check how ALB treats `json.dumps(None)` vs `""` in the body
	* `null` (json NONE) is treated as 4 bytes content-length
	* `""` is honoured and sends no content-length
* [x] Double check whether the lack of `content-type` also impacts ALB behaviour if a `Response` object w/o is returned
* [ ] @leandrodamascena agreed to do E2E to be triple sure so I can go on PTO on time :D 

### User experience

> Please share what the user experience looks like before and after this change

<img width="1168" alt="image" src="https://github.com/aws-powertools/powertools-lambda-python/assets/3340292/7fb2bb9e-6675-4b21-ad50-374f3d7d1a9a">

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] [Meet tenets criteria](https://docs.powertools.aws.dev/lambda/python/#tenets)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented
* [x] PR title follows [conventional commit semantics](https://github.com/aws-powertools/powertools-lambda-python/blob/develop/.github/semantic.yml)

<details>
<summary>Is this a breaking change?</summary>

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
