### PR TITLE
docs(public_reference): add BusPatrol as a public reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ Knowing which companies are using this library is important to help prioritize t
 The following companies, among others, use Powertools:
 
 * [Brsk](https://www.brsk.co.uk/)
+* [BusPatrol](https://buspatrol.com/)
 * [Capital One](https://www.capitalone.com/)
 * [CPQi (Exadel Financial Services)](https://cpqi.com/)
 * [CloudZero](https://www.cloudzero.com/)

--- a/docs/index.md
+++ b/docs/index.md
@@ -427,6 +427,9 @@ Knowing which companies are using this library is important to help prioritize t
 [**Brsk**](https://www.brsk.co.uk/){target="_blank" rel="nofollow"}
 { .card }
 
+[**BusPatrol**](https://buspatrol.com/){target="_blank" rel="nofollow"}
+{ .card }
+
 [**Capital One**](https://www.capitalone.com/){target="_blank" rel="nofollow"}
 { .card }
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
**Issue number:** #4709 

## Summary

### Changes

Tony Sherman, Software Engineer, opened a issue to add [BusPatrol](https://buspatrol.com/) as a public reference for Powertools for AWS Lambda (Python).

### User experience

> Please share what the user experience looks like before and after this change

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] [Meet tenets criteria](https://docs.powertools.aws.dev/lambda/python/#tenets)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented
* [x] PR title follows [conventional commit semantics](https://github.com/aws-powertools/powertools-lambda-python/blob/develop/.github/semantic.yml)

<details>
<summary>Is this a breaking change?</summary>

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
