### PR TITLE
fix(event_handler): make the max_age attribute comply with RFC specification

### DIFF
--- a/aws_lambda_powertools/shared/cookies.py
+++ b/aws_lambda_powertools/shared/cookies.py
@@ -99,10 +99,10 @@ class Cookie:
 
         if self.max_age:
             if self.max_age > 0:
-                payload.write(f"; MaxAge={self.max_age}")
+                payload.write(f"; Max-Age={self.max_age}")
             else:
                 # negative or zero max-age should be set to 0
-                payload.write("; MaxAge=0")
+                payload.write("; Max-Age=0")
 
         if self.http_only:
             payload.write("; HttpOnly")

--- a/tests/unit/test_cookie_class.py
+++ b/tests/unit/test_cookie_class.py
@@ -86,6 +86,7 @@ def test_cookie_with_http_only():
     assert cookie.name == "powertools"
     assert cookie.value == "test"
     assert cookie.path == "/"
+    assert cookie.http_only is True
     assert str(cookie) == "powertools=test; Path=/; HttpOnly; Secure"
 
 
@@ -98,6 +99,7 @@ def test_cookie_with_same_site():
     assert cookie.name == "powertools"
     assert cookie.value == "test"
     assert cookie.path == "/"
+    assert cookie.same_site == SameSite.STRICT_MODE
     assert str(cookie) == "powertools=test; Path=/; Secure; SameSite=Strict"
 
 
@@ -110,4 +112,5 @@ def test_cookie_with_custom_attribute():
     assert cookie.name == "powertools"
     assert cookie.value == "test"
     assert cookie.path == "/"
+    assert cookie.custom_attributes == ["extra1=value1", "extra2=value2"]
     assert str(cookie) == "powertools=test; Path=/; Secure; extra1=value1; extra2=value2"

--- a/tests/unit/test_cookie_class.py
+++ b/tests/unit/test_cookie_class.py
@@ -1,0 +1,113 @@
+from datetime import datetime
+
+from aws_lambda_powertools.shared.cookies import Cookie, SameSite
+
+
+def test_cookie_without_secure():
+    # GIVEN a cookie without secure
+    cookie = Cookie(name="powertools", value="test", path="/", secure=False)
+
+    # WHEN getting the cookie's attributes
+    # THEN the path attribute should be set to the provided value
+    assert cookie.secure is False
+    assert str(cookie) == "powertools=test; Path=/"
+
+
+def test_cookie_with_path():
+    # GIVEN a cookie with a path
+    cookie = Cookie(name="powertools", value="test", path="/")
+
+    # WHEN getting the cookie's attributes
+    # THEN the path attribute should be set to the provided value
+    assert cookie.name == "powertools"
+    assert cookie.value == "test"
+    assert cookie.path == "/"
+    assert str(cookie) == "powertools=test; Path=/; Secure"
+
+
+def test_cookie_with_domain():
+    # GIVEN a cookie with a domain
+    cookie = Cookie(name="powertools", value="test", path="/", domain="example.com")
+
+    # WHEN getting the cookie's attributes
+    # THEN the path attribute should be set to the provided value
+    assert cookie.name == "powertools"
+    assert cookie.value == "test"
+    assert cookie.path == "/"
+    assert cookie.domain == "example.com"
+    assert str(cookie) == "powertools=test; Path=/; Domain=example.com; Secure"
+
+
+def test_cookie_with_expires():
+    # GIVEN a cookie with a expires
+    time_to_expire = datetime(year=2022, month=12, day=31)
+    cookie = Cookie(name="powertools", value="test", path="/", expires=time_to_expire)
+
+    # WHEN getting the cookie's attributes
+    # THEN the path attribute should be set to the provided value
+    assert cookie.name == "powertools"
+    assert cookie.value == "test"
+    assert cookie.path == "/"
+    assert cookie.expires == time_to_expire
+    assert str(cookie) == "powertools=test; Path=/; Expires=Sat, 31 Dec 2022 00:00:00 GMT; Secure"
+
+
+def test_cookie_with_max_age_positive():
+    # GIVEN a cookie with a positive max age
+    cookie = Cookie(name="powertools", value="test", path="/", max_age=100)
+
+    # WHEN getting the cookie's attributes
+    # THEN the path attribute should be set to the provided value
+    assert cookie.name == "powertools"
+    assert cookie.value == "test"
+    assert cookie.path == "/"
+    assert cookie.max_age == 100
+    assert str(cookie) == "powertools=test; Path=/; Max-Age=100; Secure"
+
+
+def test_cookie_with_max_age_negative():
+    # GIVEN a cookie with a negative max age
+    cookie = Cookie(name="powertools", value="test", path="/", max_age=-100)
+
+    # WHEN getting the cookie's attributes
+    # THEN the path attribute should be set to the provided value and Max-Age must be 0
+    assert cookie.name == "powertools"
+    assert cookie.value == "test"
+    assert cookie.path == "/"
+    assert str(cookie) == "powertools=test; Path=/; Max-Age=0; Secure"
+
+
+def test_cookie_with_http_only():
+    # GIVEN a cookie with http_only
+    cookie = Cookie(name="powertools", value="test", path="/", http_only=True)
+
+    # WHEN getting the cookie's attributes
+    # THEN the path attribute should be set to the provided value
+    assert cookie.name == "powertools"
+    assert cookie.value == "test"
+    assert cookie.path == "/"
+    assert str(cookie) == "powertools=test; Path=/; HttpOnly; Secure"
+
+
+def test_cookie_with_same_site():
+    # GIVEN a cookie with same_site
+    cookie = Cookie(name="powertools", value="test", path="/", same_site=SameSite.STRICT_MODE)
+
+    # WHEN getting the cookie's attributes
+    # THEN the path attribute should be set to the provided value
+    assert cookie.name == "powertools"
+    assert cookie.value == "test"
+    assert cookie.path == "/"
+    assert str(cookie) == "powertools=test; Path=/; Secure; SameSite=Strict"
+
+
+def test_cookie_with_custom_attribute():
+    # GIVEN a cookie with custom_attributes
+    cookie = Cookie(name="powertools", value="test", path="/", custom_attributes=["extra1=value1", "extra2=value2"])
+
+    # WHEN getting the cookie's attributes
+    # THEN the path attribute should be set to the provided value
+    assert cookie.name == "powertools"
+    assert cookie.value == "test"
+    assert cookie.path == "/"
+    assert str(cookie) == "powertools=test; Path=/; Secure; extra1=value1; extra2=value2"


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
**Issue number:** #4730 

## Summary

### Changes

This PR fixes the cookie handling based on RFC6265 by ensuring the `Max-Age` field is hyphenated (Max-Age).

### User experience

```python
from aws_lambda_powertools.shared.cookies import Cookie
from aws_lambda_powertools.event_handler import Response
cookie = Cookie(name="Test", value="Test", max_age=60)
str(cookie)
>>> 'Test=Test; Max-Age=60; Secure'
```

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] [Meet tenets criteria](https://docs.powertools.aws.dev/lambda/python/#tenets)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented
* [x] PR title follows [conventional commit semantics](https://github.com/aws-powertools/powertools-lambda-python/blob/develop/.github/semantic.yml)

<details>
<summary>Is this a breaking change?</summary>

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
