### PR TITLE
fix(idempotency): ensure in_progress_expiration field is set on Lambda timeout.

### DIFF
--- a/aws_lambda_powertools/utilities/idempotency/persistence/base.py
+++ b/aws_lambda_powertools/utilities/idempotency/persistence/base.py
@@ -301,6 +301,10 @@ class BasePersistenceLayer(ABC):
             payload_hash=self._get_hashed_payload(data=data),
         )
 
+        # When Lambda kills the container after timeout, the remaining_time_in_millis is 0, which is considered False.
+        # Therefore, we need to check if remaining_time_in_millis is not None (>=0) to handle this case.
+        # See:
+
         if remaining_time_in_millis is not None:
             now = datetime.datetime.now()
             period = datetime.timedelta(milliseconds=remaining_time_in_millis)

--- a/aws_lambda_powertools/utilities/idempotency/persistence/base.py
+++ b/aws_lambda_powertools/utilities/idempotency/persistence/base.py
@@ -303,8 +303,7 @@ class BasePersistenceLayer(ABC):
 
         # When Lambda kills the container after timeout, the remaining_time_in_millis is 0, which is considered False.
         # Therefore, we need to check if remaining_time_in_millis is not None (>=0) to handle this case.
-        # See:
-
+        # See: https://github.com/aws-powertools/powertools-lambda-python/issues/4759
         if remaining_time_in_millis is not None:
             now = datetime.datetime.now()
             period = datetime.timedelta(milliseconds=remaining_time_in_millis)

--- a/aws_lambda_powertools/utilities/idempotency/persistence/base.py
+++ b/aws_lambda_powertools/utilities/idempotency/persistence/base.py
@@ -301,7 +301,7 @@ class BasePersistenceLayer(ABC):
             payload_hash=self._get_hashed_payload(data=data),
         )
 
-        if remaining_time_in_millis:
+        if remaining_time_in_millis is not None:
             now = datetime.datetime.now()
             period = datetime.timedelta(milliseconds=remaining_time_in_millis)
             timestamp = (now + period).timestamp()


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
**Issue number:** #4759 

## Summary

### Changes

Adds an explicit check for `not None` when checking remaining ms in the `BasePersistanceLayer`. The base persistence layer wouldn't complete and set a TTL for a record when the function timeout was too close to 0.

### User experience

No change

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [X] [Meet tenets criteria](https://docs.powertools.aws.dev/lambda/python/#tenets)
* [X] I have performed a self-review of this change
* [X] Changes have been tested
* [X] Changes are documented
* [X] PR title follows [conventional commit semantics](https://github.com/aws-powertools/powertools-lambda-python/blob/develop/.github/semantic.yml)

<details>
<summary>Is this a breaking change?</summary>

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
