### PR TITLE
chore(logger): use package logger over source logger to reduce noise

### DIFF
--- a/aws_lambda_powertools/logging/utils.py
+++ b/aws_lambda_powertools/logging/utils.py
@@ -4,6 +4,7 @@ from typing import Callable, List, Optional, Set, Union
 from .logger import Logger
 
 PACKAGE_LOGGER = "aws_lambda_powertools"
+LOGGER = logging.getLogger(__name__)
 
 
 def copy_config_to_registered_loggers(
@@ -56,7 +57,7 @@ def copy_config_to_registered_loggers(
         loggers = exclude
         filter_func = _exclude_registered_loggers_filter
 
-    registered_loggers = _find_registered_loggers(source_logger, loggers, filter_func)
+    registered_loggers = _find_registered_loggers(loggers=loggers, filter_func=filter_func)
     for logger in registered_loggers:
         _configure_logger(source_logger=source_logger, logger=logger, level=level, ignore_log_level=ignore_log_level)
 
@@ -72,13 +73,12 @@ def _exclude_registered_loggers_filter(loggers: Set[str]) -> List[logging.Logger
 
 
 def _find_registered_loggers(
-    source_logger: Logger,
     loggers: Set[str],
     filter_func: Callable[[Set[str]], List[logging.Logger]],
 ) -> List[logging.Logger]:
     """Filter root loggers based on provided parameters."""
     root_loggers = filter_func(loggers)
-    source_logger.debug(f"Filtered root loggers: {root_loggers}")
+    LOGGER.debug(f"Filtered root loggers: {root_loggers}")
     return root_loggers
 
 
@@ -91,7 +91,7 @@ def _configure_logger(
     # customers may not want to copy the same log level from Logger to discovered loggers
     if not ignore_log_level:
         logger.setLevel(level)
-        source_logger.debug(f"Logger {logger} reconfigured to use logging level {level}")
+        LOGGER.debug(f"Logger {logger} reconfigured to use logging level {level}")
 
     logger.handlers = []
     logger.propagate = False  # ensure we don't propagate logs to existing loggers, #1073
@@ -99,4 +99,4 @@ def _configure_logger(
 
     for source_handler in source_logger.handlers:
         logger.addHandler(source_handler)
-        source_logger.debug(f"Logger {logger} reconfigured to use {source_handler}")
+        LOGGER.debug(f"Logger {logger} reconfigured to use {source_handler}")


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
**Issue number:** #4714

## Summary

Use package logger over customers' Logger to add debugging context on operations.

This comes from a [series of good practices](https://docs.python.org/3/howto/logging.html#library-config) to follow from library owners when using logging, so you don't interfere with the application logging (customers), and only output something when explicitly enabled it.

### Changes

> Please provide a summary of what's being changed

### User experience

> Please share what the user experience looks like before and after this change

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] [Meet tenets criteria](https://docs.powertools.aws.dev/lambda/python/#tenets)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [ ] Changes are documented
* [x] PR title follows [conventional commit semantics](https://github.com/aws-powertools/powertools-lambda-python/blob/develop/.github/semantic.yml)

<details>
<summary>Is this a breaking change?</summary>

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
