### PR TITLE
chore(docs): Add lambda layer policy to versioning docs

### DIFF
--- a/docs/versioning.md
+++ b/docs/versioning.md
@@ -45,6 +45,16 @@ Powertools for AWS Lambda follows the [AWS Lambda Runtime deprecation policy cyc
 
 !!! note "AWS reserves the right to stop support for an underlying dependency without increasing the major SDK version"
 
+### Lambda layer lifecycle
+
+Powertools for AWS Lambda provides public Lambda layers as an alternative method for including the Powertools SDK into your Lambda functions.
+
+Unlike package indexers such as PyPi and NPMJS, which use semantic versioning (e.g., v1.2.3, v1.3.0), Lambda layers employs incrementing sequential versions (e.g., 1, 2, 3, 4). With each new release of the SDK, Powertools for AWS Lambda publishes an updated layer, including the SDK version in the layer description.
+
+Powertools for AWS Lambda layers are immutable and remain available beyond their end-of-life dates.
+
+Each Powertools for AWS Lambda layer adheres to the versioning policy outlined above.
+
 ### Communication methods
 
 Maintenance announcements are communicated in several ways:


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
**Issue number:** #4810 

## Summary

### Changes

This pull request adds a new section to our versioning documentation that makes it clearer:

1.  What is our versioning policy
2. That Powertools for AWS Lambda layers are immutable and remain available beyond their end-of-life dates.

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] [Meet tenets criteria](https://docs.powertools.aws.dev/lambda/python/#tenets)
* [x] I have performed a self-review of this change
* [ ] Changes have been tested
* [x] Changes are documented
* [ ] PR title follows [conventional commit semantics](https://github.com/aws-powertools/powertools-lambda-python/blob/develop/.github/semantic.yml)

<details>
<summary>Is this a breaking change?</summary>

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
