### PR TITLE
chore(ci): fix e2e tests in v3 branch

### DIFF
--- a/tests/e2e/utils/data_fetcher/logs.py
+++ b/tests/e2e/utils/data_fetcher/logs.py
@@ -4,22 +4,22 @@ from typing import List, Optional, Union
 
 import boto3
 from mypy_boto3_logs import CloudWatchLogsClient
-from pydantic import BaseModel, Extra
+from pydantic import BaseModel
 from retry import retry
 
 
-class Log(BaseModel, extra=Extra.allow):
+class Log(BaseModel, extra="allow"):
     level: str
     location: str
     message: Union[dict, str]
     timestamp: str
     service: str
-    cold_start: Optional[bool]
-    function_name: Optional[str]
-    function_memory_size: Optional[str]
-    function_arn: Optional[str]
-    function_request_id: Optional[str]
-    xray_trace_id: Optional[str]
+    cold_start: Optional[bool] = None
+    function_name: Optional[str] = None
+    function_memory_size: Optional[str] = None
+    function_arn: Optional[str] = None
+    function_request_id: Optional[str] = None
+    xray_trace_id: Optional[str] = None
 
 
 class LogFetcher:

--- a/tests/e2e/utils/data_fetcher/traces.py
+++ b/tests/e2e/utils/data_fetcher/traces.py
@@ -15,10 +15,10 @@ class TraceSubsegment(BaseModel):
     name: str
     start_time: float
     end_time: float
-    aws: Optional[dict]
-    subsegments: Optional[List["TraceSubsegment"]]
-    annotations: Optional[Dict[str, Any]]
-    metadata: Optional[Dict[str, Dict[str, Any]]]
+    aws: Optional[dict] = None
+    subsegments: Optional[List["TraceSubsegment"]] = None
+    annotations: Optional[Dict[str, Any]] = None
+    metadata: Optional[Dict[str, Dict[str, Any]]] = None
 
 
 class TraceDocument(BaseModel):
@@ -27,10 +27,10 @@ class TraceDocument(BaseModel):
     start_time: float
     end_time: float
     trace_id: str
-    parent_id: Optional[str]
+    parent_id: Optional[str] = None
     aws: Dict
     origin: str
-    subsegments: Optional[List[TraceSubsegment]]
+    subsegments: Optional[List[TraceSubsegment]] = None
 
 
 class TraceFetcher:


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
**Issue number:** #4846 

## Summary

### Changes

This PR makes Pydantic models compatible with Pydantic v2 in the e2e tests of the v3 branch.

### User experience

No changes

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] [Meet tenets criteria](https://docs.powertools.aws.dev/lambda/python/#tenets)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented
* [x] PR title follows [conventional commit semantics](https://github.com/aws-powertools/powertools-lambda-python/blob/develop/.github/semantic.yml)

<details>
<summary>Is this a breaking change?</summary>

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
