### PR TITLE
chore(ci): fix Redis e2e tests in v3 branch

### DIFF
--- a/tests/e2e/idempotency_redis/infrastructure.py
+++ b/tests/e2e/idempotency_redis/infrastructure.py
@@ -17,7 +17,7 @@ from tests.e2e.utils.infrastructure import BaseInfrastructure
 
 class IdempotencyRedisServerlessStack(BaseInfrastructure):
     def create_resources(self) -> None:
-        service_name = build_random_value(10)
+        service_name = build_random_value(10).replace("_", "")
 
         vpc_stack: Vpc = self._create_vpc(service_name, "172.150.0.0/16")
         security_groups: Tuple = self._create_security_groups(vpc_stack)


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
Issue number: https://github.com/aws-powertools/powertools-lambda-python/issues/4846

## Summary

### Changes

This PR fixes Redis e2e tests.

### User experience

> Please share what the user experience looks like before and after this change

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] [Meet tenets criteria](https://docs.powertools.aws.dev/lambda/python/#tenets)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented
* [x] PR title follows [conventional commit semantics](https://github.com/aws-powertools/powertools-lambda-python/blob/develop/.github/semantic.yml)

<details>
<summary>Is this a breaking change?</summary>

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
