### PR TITLE
feat(metrics): add unit None for CloudWatch EMF Metrics

### DIFF
--- a/aws_lambda_powertools/metrics/provider/cloudwatch_emf/metric_properties.py
+++ b/aws_lambda_powertools/metrics/provider/cloudwatch_emf/metric_properties.py
@@ -30,6 +30,7 @@ class MetricUnit(Enum):
     GigabitsPerSecond = "Gigabits/Second"
     TerabitsPerSecond = "Terabits/Second"
     CountPerSecond = "Count/Second"
+    NoUnit = "None"
 
 
 class MetricResolution(Enum):


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
**Issue number:** #4834

## Summary

### Changes

> Please provide a summary of what's being changed

Adds a `NoUnit` type to MetricUnit so customers can use the `None` metric unit (as per https://docs.aws.amazon.com/AmazonCloudWatch/latest/APIReference/API_MetricDatum.html).

### User experience

> Please share what the user experience looks like before and after this change

None is a reserved word in Python so we have to alias `NoUnit` to the `None` type.

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [X] [Meet tenets criteria](https://docs.powertools.aws.dev/lambda/python/#tenets)
* [X] I have performed a self-review of this change
* [X] Changes have been tested
* [X] Changes are documented
* [X] PR title follows [conventional commit semantics](https://github.com/aws-powertools/powertools-lambda-python/blob/develop/.github/semantic.yml)

<details>
<summary>Is this a breaking change?</summary>

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
