### PR TITLE
refactor(batch_processing): mark batch_processor and async_batch_processor as deprecated 

### DIFF
--- a/aws_lambda_powertools/utilities/batch/decorators.py
+++ b/aws_lambda_powertools/utilities/batch/decorators.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
+import warnings
 from typing import Any, Awaitable, Callable, Dict, List
+
+from typing_extensions import deprecated
 
 from aws_lambda_powertools.middleware_factory import lambda_handler_decorator
 from aws_lambda_powertools.utilities.batch import (
@@ -11,9 +14,14 @@ from aws_lambda_powertools.utilities.batch import (
 )
 from aws_lambda_powertools.utilities.batch.types import PartialItemFailureResponse
 from aws_lambda_powertools.utilities.typing import LambdaContext
+from aws_lambda_powertools.warnings import PowertoolsDeprecationWarning
 
 
 @lambda_handler_decorator
+@deprecated(
+    "`async_batch_processor` decorator is deprecated; use `async_process_partial_response` function instead.",
+    category=None,
+)
 def async_batch_processor(
     handler: Callable,
     event: Dict,
@@ -61,6 +69,14 @@ def async_batch_processor(
     -----------
     * Sync batch processors. Use `batch_processor` instead.
     """
+
+    warnings.warn(
+        "The `async_batch_processor` decorator is deprecated in V3 "
+        "and will be removed in the next major version. Use `async_process_partial_response` function instead.",
+        category=PowertoolsDeprecationWarning,
+        stacklevel=2,
+    )
+
     records = event["Records"]
 
     with processor(records, record_handler, lambda_context=context):
@@ -70,6 +86,10 @@ def async_batch_processor(
 
 
 @lambda_handler_decorator
+@deprecated(
+    "`batch_processor` decorator is deprecated; use `process_partial_response` function instead.",
+    category=None,
+)
 def batch_processor(
     handler: Callable,
     event: Dict,
@@ -117,6 +137,14 @@ def batch_processor(
     -----------
     * Async batch processors. Use `async_batch_processor` instead.
     """
+
+    warnings.warn(
+        "The `batch_processor` decorator is deprecated in V3 "
+        "and will be removed in the next major version. Use `process_partial_response` function instead.",
+        category=PowertoolsDeprecationWarning,
+        stacklevel=2,
+    )
+
     records = event["Records"]
 
     with processor(records, record_handler, lambda_context=context):

--- a/docs/utilities/batch.md
+++ b/docs/utilities/batch.md
@@ -119,7 +119,7 @@ Processing batches from SQS works in three stages:
     --8<-- "examples/batch_processing/src/getting_started_sqs_context_manager.py"
     ```
 
-=== "As a decorator (legacy)"
+=== "As a decorator (deprecated)"
 
     ```python hl_lines="4-9 12 18 27 29"
     --8<-- "examples/batch_processing/src/getting_started_sqs_decorator.py"
@@ -161,7 +161,7 @@ Enable the `skip_group_on_error` option for seamless processing of messages from
     --8<-- "examples/batch_processing/src/getting_started_sqs_fifo_context_manager.py"
     ```
 
-=== "As a decorator (legacy)"
+=== "As a decorator (deprecated)"
 
     ```python hl_lines="5-6 11 26"
     --8<-- "examples/batch_processing/src/getting_started_sqs_fifo_decorator.py"
@@ -197,7 +197,7 @@ Processing batches from Kinesis works in three stages:
     --8<-- "examples/batch_processing/src/getting_started_kinesis_context_manager.py"
     ```
 
-=== "As a decorator (legacy)"
+=== "As a decorator (deprecated)"
 
     ```python hl_lines="2-9 12 18 26"
     --8<-- "examples/batch_processing/src/getting_started_kinesis_decorator.py"
@@ -241,7 +241,7 @@ Processing batches from DynamoDB Streams works in three stages:
     --8<-- "examples/batch_processing/src/getting_started_dynamodb_context_manager.py"
     ```
 
-=== "As a decorator (legacy)"
+=== "As a decorator (deprecated)"
 
     ```python hl_lines="4-11 14 20 31"
     --8<-- "examples/batch_processing/src/getting_started_dynamodb_decorator.py"
@@ -538,7 +538,7 @@ We can automatically inject the [Lambda context](https://docs.aws.amazon.com/lam
     --8<-- "examples/batch_processing/src/advanced_accessing_lambda_context.py"
     ```
 
-=== "As a decorator (legacy)"
+=== "As a decorator (deprecated)"
 
     ```python hl_lines="18 26"
     --8<-- "examples/batch_processing/src/advanced_accessing_lambda_context_decorator.py"
@@ -673,7 +673,7 @@ Use context manager when you want access to the processed messages or handle `Ba
 
 ### What's the difference between the decorator and process_partial_response functions?
 
-`batch_processor` and `async_batch_processor` decorators are now considered legacy. Historically, they were kept due to backwards compatibility and to minimize code changes between V1 and V2.
+`batch_processor` and `async_batch_processor` decorators are now marked as deprecated. Historically, they were kept due to backwards compatibility and to minimize code changes between V2 and V3. We will remove both in the next major release.
 
 As 2.12.0, `process_partial_response` and `async_process_partial_response` are the recommended instead. It reduces boilerplate, smaller memory/CPU cycles, and it makes it less error prone - e.g., decorators required an additional return.
 

--- a/tests/functional/test_utilities_batch.py
+++ b/tests/functional/test_utilities_batch.py
@@ -32,6 +32,7 @@ from aws_lambda_powertools.utilities.parser.models import (
     SqsRecordModel,
 )
 from aws_lambda_powertools.utilities.parser.types import Literal
+from aws_lambda_powertools.warnings import PowertoolsDeprecationWarning
 from tests.functional.batch.sample_models import (
     OrderDynamoDBRecord,
     OrderKinesisRecord,
@@ -857,10 +858,11 @@ def test_async_batch_processor_middleware_success_only(sqs_event_factory, async_
         return processor.response()
 
     # WHEN
-    result = lambda_handler(event, {})
+    with pytest.warns(PowertoolsDeprecationWarning, match="The `async_batch_processor` decorator is deprecated in V3*"):
+        result = lambda_handler(event, {})
 
-    # THEN
-    assert result["batchItemFailures"] == []
+        # THEN
+        assert result["batchItemFailures"] == []
 
 
 def test_async_batch_processor_middleware_with_failure(sqs_event_factory, async_record_handler):
@@ -877,10 +879,11 @@ def test_async_batch_processor_middleware_with_failure(sqs_event_factory, async_
         return processor.response()
 
     # WHEN
-    result = lambda_handler(event, {})
+    with pytest.warns(PowertoolsDeprecationWarning, match="The `async_batch_processor` decorator is deprecated in V3*"):
+        result = lambda_handler(event, {})
 
-    # THEN
-    assert len(result["batchItemFailures"]) == 2
+        # THEN
+        assert len(result["batchItemFailures"]) == 2
 
 
 def test_async_batch_processor_context_success_only(sqs_event_factory, async_record_handler):


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
**Issue number:** #4908 

## Summary

### Changes

As 2.12.0, We added two new functions to work with Batch Processing:`process_partial_response` and `async_process_partial_response` and we kept `batch_processor` and `async_batch_processor` decorators for backwards compatibility. 

Those two new functions reduces boilerplate, smaller memory/CPU cycles, and it makes it less error prone - e.g., decorators required an additional return.

In Powertools V3 we are marking `batch_processor` and `async_batch_processor` as deprecated as will remove in V4. 

### User experience

Both functions are marked as deprecated

![image](https://github.com/user-attachments/assets/40e77266-55ae-4859-9e41-9e0ccb0d4809)

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] [Meet tenets criteria](https://docs.powertools.aws.dev/lambda/python/#tenets)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented
* [x] PR title follows [conventional commit semantics](https://github.com/aws-powertools/powertools-lambda-python/blob/develop/.github/semantic.yml)

<details>
<summary>Is this a breaking change?</summary>

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
