### PR TITLE
fix(event_source): fix regression when working with zero numbers in DynamoDBStreamEvent

### DIFF
--- a/aws_lambda_powertools/utilities/data_classes/dynamo_db_stream_event.py
+++ b/aws_lambda_powertools/utilities/data_classes/dynamo_db_stream_event.py
@@ -73,7 +73,12 @@ class TypeDeserializer:
         return value
 
     def _deserialize_n(self, value: str) -> Decimal:
+        # value is None or "."? It's zero
+        # then return early
         value = value.lstrip("0")
+        if not value or value == ".":
+            return DYNAMODB_CONTEXT.create_decimal(0)
+
         if len(value) > 38:
             # See: https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/HowItWorks.NamingRulesDataTypes.html#HowItWorks.DataTypes.Number
             # Calculate the number of trailing zeros after the 38th character

--- a/tests/unit/data_classes/required_dependencies/test_dynamo_db_stream_event.py
+++ b/tests/unit/data_classes/required_dependencies/test_dynamo_db_stream_event.py
@@ -75,6 +75,22 @@ def test_dynamodb_stream_record_deserialization_large_int_without_trailing_zeros
     }
 
 
+def test_dynamodb_stream_record_deserialization_zero_value():
+
+    data = {
+        "Keys": {"key1": {"attr1": "value1"}},
+        "NewImage": {
+            "Name": {"S": "Joe"},
+            "Age": {"N": "0"},
+        },
+    }
+    record = StreamRecord(data)
+    assert record.new_image == {
+        "Name": "Joe",
+        "Age": DECIMAL_CONTEXT.create_decimal("0"),
+    }
+
+
 def test_dynamodb_stream_record_deserialization():
     byte_list = [s.encode("utf-8") for s in ["item1", "item2"]]
     decimal_context = Context(


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
**Issue number:** #4931 

## Summary

### Changes

This PR https://github.com/aws-powertools/powertools-lambda-python/pull/4863 intrudoced a regression when working with Zero numbers. It's now returning NaN instead of a 0 Decimal.

### User experience

```python
from aws_lambda_powertools.utilities.data_classes.dynamo_db_stream_event import (
    DynamoDBStreamEvent,
    DynamoDBRecordEventName
)

def lambda_handler(event, context):
    event: DynamoDBStreamEvent = DynamoDBStreamEvent(event)
    for record in event.records:
        print(record.dynamodb.new_image)
```

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] [Meet tenets criteria](https://docs.powertools.aws.dev/lambda/python/#tenets)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented
* [x] PR title follows [conventional commit semantics](https://github.com/aws-powertools/powertools-lambda-python/blob/develop/.github/semantic.yml)

<details>
<summary>Is this a breaking change?</summary>

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
