### PR TITLE
refactor(middleware_factory): add from __future__ import annotations

### DIFF
--- a/aws_lambda_powertools/middleware_factory/factory.py
+++ b/aws_lambda_powertools/middleware_factory/factory.py
@@ -6,10 +6,10 @@ import logging
 import os
 from typing import Any, Callable
 
-from ..shared import constants
-from ..shared.functions import resolve_truthy_env_var_choice
-from ..tracing import Tracer
-from .exceptions import MiddlewareInvalidArgumentError
+from aws_lambda_powertools.middleware_factory.exceptions import MiddlewareInvalidArgumentError
+from aws_lambda_powertools.shared import constants
+from aws_lambda_powertools.shared.functions import resolve_truthy_env_var_choice
+from aws_lambda_powertools.tracing import Tracer
 
 logger = logging.getLogger(__name__)
 

--- a/aws_lambda_powertools/middleware_factory/factory.py
+++ b/aws_lambda_powertools/middleware_factory/factory.py
@@ -1,8 +1,10 @@
+from __future__ import annotations
+
 import functools
 import inspect
 import logging
 import os
-from typing import Any, Callable, Optional
+from typing import Any, Callable
 
 from ..shared import constants
 from ..shared.functions import resolve_truthy_env_var_choice
@@ -13,7 +15,7 @@ logger = logging.getLogger(__name__)
 
 
 # Maintenance: we can't yet provide an accurate return type without ParamSpec etc. see #1066
-def lambda_handler_decorator(decorator: Optional[Callable] = None, trace_execution: Optional[bool] = None) -> Callable:
+def lambda_handler_decorator(decorator: Callable | None = None, trace_execution: bool | None = None) -> Callable:
     """Decorator factory for decorating Lambda handlers.
 
     You can use lambda_handler_decorator to create your own middlewares,
@@ -112,7 +114,7 @@ def lambda_handler_decorator(decorator: Optional[Callable] = None, trace_executi
     )
 
     @functools.wraps(decorator)
-    def final_decorator(func: Optional[Callable] = None, **kwargs: Any):
+    def final_decorator(func: Callable | None = None, **kwargs: Any):
         # If called with kwargs return new func with kwargs
         if func is None:
             return functools.partial(final_decorator, **kwargs)


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
**Issue number:** #4951 

## Summary

### Changes

Add `from __future__ import annotations` to middleware_factory package

### User experience

Discussed in #4607

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [X] [Meet tenets criteria](https://docs.powertools.aws.dev/lambda/python/#tenets)
* [X] I have performed a self-review of this change
* [X] Changes have been tested
* [ ] Changes are documented
* [X] PR title follows [conventional commit semantics](https://github.com/aws-powertools/powertools-lambda-python/blob/develop/.github/semantic.yml)

<details>
<summary>Is this a breaking change?</summary>

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
