### PR TITLE
refactor(shared): add from __future__ import annotations

### DIFF
--- a/aws_lambda_powertools/shared/cookies.py
+++ b/aws_lambda_powertools/shared/cookies.py
@@ -1,7 +1,11 @@
-from datetime import datetime
+from __future__ import annotations
+
 from enum import Enum
 from io import StringIO
-from typing import List, Optional
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from datetime import datetime
 
 
 class SameSite(Enum):
@@ -41,10 +45,10 @@ class Cookie:
         domain: str = "",
         secure: bool = True,
         http_only: bool = False,
-        max_age: Optional[int] = None,
-        expires: Optional[datetime] = None,
-        same_site: Optional[SameSite] = None,
-        custom_attributes: Optional[List[str]] = None,
+        max_age: int | None = None,
+        expires: datetime | None = None,
+        same_site: SameSite | None = None,
+        custom_attributes: list[str] | None = None,
     ):
         """
 
@@ -62,13 +66,13 @@ class Cookie:
             Marks the cookie as secure, only sendable to the server with an encrypted request over the HTTPS protocol
         http_only: bool
             Enabling this attribute makes the cookie inaccessible to the JavaScript `Document.cookie` API
-        max_age: Optional[int]
+        max_age: int | None
             Defines the period of time after which the cookie is invalid. Use negative values to force cookie deletion.
-        expires: Optional[datetime]
+        expires: datetime | None
             Defines a date where the permanent cookie expires.
-        same_site: Optional[SameSite]
+        same_site: SameSite | None
             Determines if the cookie should be sent to third party websites
-        custom_attributes: Optional[List[str]]
+        custom_attributes: list[str] | None
             List of additional custom attributes to set on the cookie
         """
         self.name = name

--- a/aws_lambda_powertools/shared/dynamodb_deserializer.py
+++ b/aws_lambda_powertools/shared/dynamodb_deserializer.py
@@ -1,5 +1,7 @@
+from __future__ import annotations
+
 from decimal import Clamped, Context, Decimal, Inexact, Overflow, Rounded, Underflow
-from typing import Any, Callable, Dict, Optional, Sequence, Set
+from typing import Any, Callable, Sequence
 
 # NOTE: DynamoDB supports up to 38 digits precision
 # Therefore, this ensures our Decimal follows what's stored in the table
@@ -21,7 +23,7 @@ class TypeDeserializer:
     since we don't support Python 2.
     """
 
-    def deserialize(self, value: Dict) -> Any:
+    def deserialize(self, value: dict) -> Any:
         """Deserialize DynamoDB data types into Python types.
 
         Parameters
@@ -57,7 +59,7 @@ class TypeDeserializer:
         """
 
         dynamodb_type = list(value.keys())[0]
-        deserializer: Optional[Callable] = getattr(self, f"_deserialize_{dynamodb_type}".lower(), None)
+        deserializer: Callable | None = getattr(self, f"_deserialize_{dynamodb_type}".lower(), None)
         if deserializer is None:
             raise TypeError(f"Dynamodb type {dynamodb_type} is not supported")
 
@@ -78,17 +80,17 @@ class TypeDeserializer:
     def _deserialize_b(self, value: bytes) -> bytes:
         return value
 
-    def _deserialize_ns(self, value: Sequence[str]) -> Set[Decimal]:
+    def _deserialize_ns(self, value: Sequence[str]) -> set[Decimal]:
         return set(map(self._deserialize_n, value))
 
-    def _deserialize_ss(self, value: Sequence[str]) -> Set[str]:
+    def _deserialize_ss(self, value: Sequence[str]) -> set[str]:
         return set(map(self._deserialize_s, value))
 
-    def _deserialize_bs(self, value: Sequence[bytes]) -> Set[bytes]:
+    def _deserialize_bs(self, value: Sequence[bytes]) -> set[bytes]:
         return set(map(self._deserialize_b, value))
 
-    def _deserialize_l(self, value: Sequence[Dict]) -> Sequence[Any]:
+    def _deserialize_l(self, value: Sequence[dict]) -> Sequence[Any]:
         return [self.deserialize(v) for v in value]
 
-    def _deserialize_m(self, value: Dict) -> Dict:
+    def _deserialize_m(self, value: dict) -> dict:
         return {k: self.deserialize(v) for k, v in value.items()}

--- a/aws_lambda_powertools/shared/functions.py
+++ b/aws_lambda_powertools/shared/functions.py
@@ -8,7 +8,7 @@ import re
 import warnings
 from binascii import Error as BinAsciiError
 from pathlib import Path
-from typing import Any, Dict, Generator, Optional, Union, overload
+from typing import Any, Generator, overload
 
 from aws_lambda_powertools.shared import constants
 
@@ -32,7 +32,7 @@ def strtobool(value: str) -> bool:
     raise ValueError(f"invalid truth value {value!r}")
 
 
-def resolve_truthy_env_var_choice(env: str, choice: Optional[bool] = None) -> bool:
+def resolve_truthy_env_var_choice(env: str, choice: bool | None = None) -> bool:
     """Pick explicit choice over truthy env value, if available, otherwise return truthy env value
 
     NOTE: Environment variable should be resolved by the caller.
@@ -52,27 +52,27 @@ def resolve_truthy_env_var_choice(env: str, choice: Optional[bool] = None) -> bo
     return choice if choice is not None else strtobool(env)
 
 
-def resolve_max_age(env: str, choice: Optional[int]) -> int:
+def resolve_max_age(env: str, choice: int | None) -> int:
     """Resolve max age value"""
     return choice if choice is not None else int(env)
 
 
 @overload
-def resolve_env_var_choice(env: Optional[str], choice: float) -> float: ...
+def resolve_env_var_choice(env: str | None, choice: float) -> float: ...
 
 
 @overload
-def resolve_env_var_choice(env: Optional[str], choice: str) -> str: ...
+def resolve_env_var_choice(env: str | None, choice: str) -> str: ...
 
 
 @overload
-def resolve_env_var_choice(env: Optional[str], choice: Optional[str]) -> str: ...
+def resolve_env_var_choice(env: str | None, choice: str | None) -> str: ...
 
 
 def resolve_env_var_choice(
-    env: Optional[str] = None,
-    choice: Optional[Union[str, float]] = None,
-) -> Optional[Union[str, float]]:
+    env: str | None = None,
+    choice: str | float | None = None,
+) -> str | float | None:
     """Pick explicit choice over env, if available, otherwise return env value received
 
     NOTE: Environment variable should be resolved by the caller.
@@ -136,12 +136,12 @@ def powertools_debug_is_set() -> bool:
     return False
 
 
-def slice_dictionary(data: Dict, chunk_size: int) -> Generator[Dict, None, None]:
+def slice_dictionary(data: dict, chunk_size: int) -> Generator[dict, None, None]:
     for _ in range(0, len(data), chunk_size):
         yield {dict_key: data[dict_key] for dict_key in itertools.islice(data, chunk_size)}
 
 
-def extract_event_from_common_models(data: Any) -> Dict | Any:
+def extract_event_from_common_models(data: Any) -> dict | Any:
     """Extract raw event from common types used in Powertools
 
     If event cannot be extracted, return received data as is.

--- a/aws_lambda_powertools/shared/json_encoder.py
+++ b/aws_lambda_powertools/shared/json_encoder.py
@@ -13,9 +13,7 @@ class Encoder(json.JSONEncoder):
 
     def default(self, obj):
         if isinstance(obj, decimal.Decimal):
-            if obj.is_nan():
-                return math.nan
-            return str(obj)
+            return math.nan if obj.is_nan() else str(obj)
 
         if is_pydantic(obj):
             return pydantic_to_dict(obj)


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
**Issue number:** #4956 

## Summary

### Changes

Add `from __future__ import annotations` to shared package

### User experience

Discussed in #4607

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [X] [Meet tenets criteria](https://docs.powertools.aws.dev/lambda/python/#tenets)
* [X] I have performed a self-review of this change
* [X] Changes have been tested
* [ ] Changes are documented
* [X] PR title follows [conventional commit semantics](https://github.com/aws-powertools/powertools-lambda-python/blob/develop/.github/semantic.yml)

<details>
<summary>Is this a breaking change?</summary>

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
