### PR TITLE
refactor(metrics): add from __future__ import annotations

### DIFF
--- a/aws_lambda_powertools/metrics/functions.py
+++ b/aws_lambda_powertools/metrics/functions.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from datetime import datetime
-from typing import List
 
 from aws_lambda_powertools.metrics.provider.cloudwatch_emf.exceptions import (
     MetricResolutionError,
@@ -11,12 +10,12 @@ from aws_lambda_powertools.metrics.provider.cloudwatch_emf.metric_properties imp
 from aws_lambda_powertools.shared import constants
 
 
-def extract_cloudwatch_metric_resolution_value(metric_resolutions: List, resolution: int | MetricResolution) -> int:
+def extract_cloudwatch_metric_resolution_value(metric_resolutions: list, resolution: int | MetricResolution) -> int:
     """Return metric value from CloudWatch metric unit whether that's str or MetricResolution enum
 
     Parameters
     ----------
-    unit : Union[int, MetricResolution]
+    resolution : int | MetricResolution
         Metric resolution
 
     Returns
@@ -40,12 +39,12 @@ def extract_cloudwatch_metric_resolution_value(metric_resolutions: List, resolut
     )
 
 
-def extract_cloudwatch_metric_unit_value(metric_units: List, metric_valid_options: List, unit: str | MetricUnit) -> str:
+def extract_cloudwatch_metric_unit_value(metric_units: list, metric_valid_options: list, unit: str | MetricUnit) -> str:
     """Return metric value from CloudWatch metric unit whether that's str or MetricUnit enum
 
     Parameters
     ----------
-    unit : Union[str, MetricUnit]
+    unit : str | MetricUnit
         Metric unit
 
     Returns

--- a/aws_lambda_powertools/metrics/metrics.py
+++ b/aws_lambda_powertools/metrics/metrics.py
@@ -1,12 +1,14 @@
 # NOTE: keeps for compatibility
 from __future__ import annotations
 
-from typing import Any, Dict
+from typing import TYPE_CHECKING, Any
 
-from aws_lambda_powertools.metrics.base import MetricResolution, MetricUnit
 from aws_lambda_powertools.metrics.provider.cloudwatch_emf.cloudwatch import AmazonCloudWatchEMFProvider
-from aws_lambda_powertools.metrics.provider.cloudwatch_emf.types import CloudWatchEMFOutput
-from aws_lambda_powertools.shared.types import AnyCallableT
+
+if TYPE_CHECKING:
+    from aws_lambda_powertools.metrics.base import MetricResolution, MetricUnit
+    from aws_lambda_powertools.metrics.provider.cloudwatch_emf.types import CloudWatchEMFOutput
+    from aws_lambda_powertools.shared.types import AnyCallableT
 
 
 class Metrics:
@@ -72,10 +74,10 @@ class Metrics:
     # and not get caught by accident with metrics data loss, or data deduplication
     # e.g., m1 and m2 add metric ProductCreated, however m1 has 'version' dimension  but m2 doesn't
     # Result: ProductCreated is created twice as we now have 2 different EMF blobs
-    _metrics: Dict[str, Any] = {}
-    _dimensions: Dict[str, str] = {}
-    _metadata: Dict[str, Any] = {}
-    _default_dimensions: Dict[str, Any] = {}
+    _metrics: dict[str, Any] = {}
+    _dimensions: dict[str, str] = {}
+    _metadata: dict[str, Any] = {}
+    _default_dimensions: dict[str, Any] = {}
 
     def __init__(
         self,
@@ -116,9 +118,9 @@ class Metrics:
 
     def serialize_metric_set(
         self,
-        metrics: Dict | None = None,
-        dimensions: Dict | None = None,
-        metadata: Dict | None = None,
+        metrics: dict | None = None,
+        dimensions: dict | None = None,
+        metadata: dict | None = None,
     ) -> CloudWatchEMFOutput:
         return self.provider.serialize_metric_set(metrics=metrics, dimensions=dimensions, metadata=metadata)
 
@@ -146,7 +148,7 @@ class Metrics:
         lambda_handler: AnyCallableT | None = None,
         capture_cold_start_metric: bool = False,
         raise_on_empty_metrics: bool = False,
-        default_dimensions: Dict[str, str] | None = None,
+        default_dimensions: dict[str, str] | None = None,
         **kwargs,
     ):
         return self.provider.log_metrics(
@@ -163,7 +165,7 @@ class Metrics:
 
         Parameters
         ----------
-        dimensions : Dict[str, Any], optional
+        dimensions : dict[str, Any], optional
             metric dimensions as key=value
 
         Example

--- a/aws_lambda_powertools/metrics/provider/base.py
+++ b/aws_lambda_powertools/metrics/provider/base.py
@@ -3,11 +3,13 @@ from __future__ import annotations
 import functools
 import logging
 from abc import ABC, abstractmethod
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from aws_lambda_powertools.metrics.provider import cold_start
-from aws_lambda_powertools.shared.types import AnyCallableT
-from aws_lambda_powertools.utilities.typing import LambdaContext
+
+if TYPE_CHECKING:
+    from aws_lambda_powertools.shared.types import AnyCallableT
+    from aws_lambda_powertools.utilities.typing import LambdaContext
 
 logger = logging.getLogger(__name__)
 
@@ -40,7 +42,7 @@ class BaseProvider(ABC):
 
         Returns
         ----------
-        Dict
+        dict
             A combined metrics dictionary.
 
         Raises
@@ -66,7 +68,7 @@ class BaseProvider(ABC):
 
         Returns
         ----------
-        Dict
+        dict
             Serialized metrics
 
         Raises
@@ -172,7 +174,7 @@ class BaseProvider(ABC):
             captures cold start metric, by default False
         raise_on_empty_metrics : bool, optional
             raise exception if no metrics are emitted, by default False
-        default_dimensions: Dict[str, str], optional
+        default_dimensions: dict[str, str], optional
             metric dimensions as key=value that will always be present
 
         Raises

--- a/aws_lambda_powertools/metrics/provider/cloudwatch_emf/cloudwatch.py
+++ b/aws_lambda_powertools/metrics/provider/cloudwatch_emf/cloudwatch.py
@@ -7,7 +7,7 @@ import numbers
 import os
 import warnings
 from collections import defaultdict
-from typing import Any, Dict, List
+from typing import TYPE_CHECKING, Any
 
 from aws_lambda_powertools.metrics.base import single_metric
 from aws_lambda_powertools.metrics.exceptions import MetricValueError, SchemaValidationError
@@ -20,12 +20,14 @@ from aws_lambda_powertools.metrics.functions import (
 from aws_lambda_powertools.metrics.provider.base import BaseProvider
 from aws_lambda_powertools.metrics.provider.cloudwatch_emf.constants import MAX_DIMENSIONS, MAX_METRICS
 from aws_lambda_powertools.metrics.provider.cloudwatch_emf.metric_properties import MetricResolution, MetricUnit
-from aws_lambda_powertools.metrics.provider.cloudwatch_emf.types import CloudWatchEMFOutput
-from aws_lambda_powertools.metrics.types import MetricNameUnitResolution
 from aws_lambda_powertools.shared import constants
 from aws_lambda_powertools.shared.functions import resolve_env_var_choice
-from aws_lambda_powertools.shared.types import AnyCallableT
-from aws_lambda_powertools.utilities.typing import LambdaContext
+
+if TYPE_CHECKING:
+    from aws_lambda_powertools.metrics.provider.cloudwatch_emf.types import CloudWatchEMFOutput
+    from aws_lambda_powertools.metrics.types import MetricNameUnitResolution
+    from aws_lambda_powertools.shared.types import AnyCallableT
+    from aws_lambda_powertools.utilities.typing import LambdaContext
 
 logger = logging.getLogger(__name__)
 
@@ -62,12 +64,12 @@ class AmazonCloudWatchEMFProvider(BaseProvider):
 
     def __init__(
         self,
-        metric_set: Dict[str, Any] | None = None,
-        dimension_set: Dict | None = None,
+        metric_set: dict[str, Any] | None = None,
+        dimension_set: dict | None = None,
         namespace: str | None = None,
-        metadata_set: Dict[str, Any] | None = None,
+        metadata_set: dict[str, Any] | None = None,
         service: str | None = None,
-        default_dimensions: Dict[str, Any] | None = None,
+        default_dimensions: dict[str, Any] | None = None,
     ):
         self.metric_set = metric_set if metric_set is not None else {}
         self.dimension_set = dimension_set if dimension_set is not None else {}
@@ -110,11 +112,11 @@ class AmazonCloudWatchEMFProvider(BaseProvider):
         ----------
         name : str
             Metric name
-        unit : Union[MetricUnit, str]
+        unit : MetricUnit | str
             `aws_lambda_powertools.helper.models.MetricUnit`
         value : float
             Metric value
-        resolution : Union[MetricResolution, int]
+        resolution : MetricResolution | int
             `aws_lambda_powertools.helper.models.MetricResolution`
 
         Raises
@@ -136,7 +138,7 @@ class AmazonCloudWatchEMFProvider(BaseProvider):
             metric_resolutions=self._metric_resolutions,
             resolution=resolution,
         )
-        metric: Dict = self.metric_set.get(name, defaultdict(list))
+        metric: dict = self.metric_set.get(name, defaultdict(list))
         metric["Unit"] = unit
         metric["StorageResolution"] = resolution
         metric["Value"].append(float(value))
@@ -154,19 +156,19 @@ class AmazonCloudWatchEMFProvider(BaseProvider):
 
     def serialize_metric_set(
         self,
-        metrics: Dict | None = None,
-        dimensions: Dict | None = None,
-        metadata: Dict | None = None,
+        metrics: dict | None = None,
+        dimensions: dict | None = None,
+        metadata: dict | None = None,
     ) -> CloudWatchEMFOutput:
         """Serializes metric and dimensions set
 
         Parameters
         ----------
-        metrics : Dict, optional
+        metrics : dict, optional
             Dictionary of metrics to serialize, by default None
-        dimensions : Dict, optional
+        dimensions : dict, optional
             Dictionary of dimensions to serialize, by default None
-        metadata: Dict, optional
+        metadata: dict, optional
             Dictionary of metadata to serialize, by default None
 
         Example
@@ -179,7 +181,7 @@ class AmazonCloudWatchEMFProvider(BaseProvider):
 
         Returns
         -------
-        Dict
+        CloudWatchEMFOutput
             Serialized metrics following EMF specification
 
         Raises
@@ -213,8 +215,8 @@ class AmazonCloudWatchEMFProvider(BaseProvider):
         #
         # In case using high-resolution metrics, add StorageResolution field
         # Example: [ { "Name": "metric_name", "Unit": "Count", "StorageResolution": 1 } ] # noqa ERA001
-        metric_definition: List[MetricNameUnitResolution] = []
-        metric_names_and_values: Dict[str, float] = {}  # { "metric_name": 1.0 }
+        metric_definition: list[MetricNameUnitResolution] = []
+        metric_names_and_values: dict[str, float] = {}  # { "metric_name": 1.0 }
 
         for metric_name in metrics:
             metric: dict = metrics[metric_name]
@@ -433,7 +435,7 @@ class AmazonCloudWatchEMFProvider(BaseProvider):
 
         Parameters
         ----------
-        dimensions : Dict[str, Any], optional
+        dimensions : dict[str, Any], optional
             metric dimensions as key=value
 
         Example

--- a/aws_lambda_powertools/metrics/provider/cloudwatch_emf/types.py
+++ b/aws_lambda_powertools/metrics/provider/cloudwatch_emf/types.py
@@ -1,4 +1,6 @@
-from typing import List, TypedDict
+from __future__ import annotations
+
+from typing import TypedDict
 
 from typing_extensions import NotRequired
 
@@ -11,13 +13,13 @@ class CloudWatchEMFMetric(TypedDict):
 
 class CloudWatchEMFMetrics(TypedDict):
     Namespace: str
-    Dimensions: List[List[str]]  # [ [ 'test_dimension' ] ]
-    Metrics: List[CloudWatchEMFMetric]
+    Dimensions: list[list[str]]  # [ [ 'test_dimension' ] ]
+    Metrics: list[CloudWatchEMFMetric]
 
 
 class CloudWatchEMFRoot(TypedDict):
     Timestamp: int
-    CloudWatchMetrics: List[CloudWatchEMFMetrics]
+    CloudWatchMetrics: list[CloudWatchEMFMetrics]
 
 
 class CloudWatchEMFOutput(TypedDict):

--- a/aws_lambda_powertools/metrics/provider/datadog/datadog.py
+++ b/aws_lambda_powertools/metrics/provider/datadog/datadog.py
@@ -7,15 +7,17 @@ import os
 import re
 import time
 import warnings
-from typing import Any, Dict, List
+from typing import TYPE_CHECKING, Any
 
 from aws_lambda_powertools.metrics.exceptions import MetricValueError, SchemaValidationError
 from aws_lambda_powertools.metrics.provider import BaseProvider
 from aws_lambda_powertools.metrics.provider.datadog.warnings import DatadogDataValidationWarning
 from aws_lambda_powertools.shared import constants
 from aws_lambda_powertools.shared.functions import resolve_env_var_choice
-from aws_lambda_powertools.shared.types import AnyCallableT
-from aws_lambda_powertools.utilities.typing import LambdaContext
+
+if TYPE_CHECKING:
+    from aws_lambda_powertools.shared.types import AnyCallableT
+    from aws_lambda_powertools.utilities.typing import LambdaContext
 
 METRIC_NAME_REGEX = re.compile(r"^[a-zA-Z0-9_.]+$")
 
@@ -51,10 +53,10 @@ class DatadogProvider(BaseProvider):
 
     def __init__(
         self,
-        metric_set: List | None = None,
+        metric_set: list | None = None,
         namespace: str | None = None,
         flush_to_log: bool | None = None,
-        default_tags: Dict[str, Any] | None = None,
+        default_tags: dict[str, Any] | None = None,
     ):
         self.metric_set = metric_set if metric_set is not None else []
         self.namespace = (
@@ -83,8 +85,8 @@ class DatadogProvider(BaseProvider):
             Value for the metrics
         timestamp: int
             Timestamp in int for the metrics, default = time.time()
-        tags: List[str]
-            In format like List["tag:value","tag2:value2"]
+        tags: list[str]
+            In format like ["tag:value", "tag2:value2"]
         args: Any
             extra args will be dropped for compatibility
         kwargs: Any
@@ -122,7 +124,7 @@ class DatadogProvider(BaseProvider):
         logger.debug({"details": "Appending metric", "metrics": name})
         self.metric_set.append({"m": name, "v": value, "e": timestamp, "t": tags})
 
-    def serialize_metric_set(self, metrics: List | None = None) -> List:
+    def serialize_metric_set(self, metrics: list | None = None) -> list:
         """Serializes metrics
 
         Example
@@ -135,7 +137,7 @@ class DatadogProvider(BaseProvider):
 
         Returns
         -------
-        List
+        list
             Serialized metrics following Datadog specification
 
         Raises
@@ -150,7 +152,7 @@ class DatadogProvider(BaseProvider):
         if len(metrics) == 0:
             raise SchemaValidationError("Must contain at least one metric.")
 
-        output_list: List = []
+        output_list: list = []
 
         logger.debug({"details": "Serializing metrics", "metrics": metrics})
 
@@ -304,7 +306,7 @@ class DatadogProvider(BaseProvider):
         self.default_tags.update(**tags)
 
     @staticmethod
-    def _serialize_datadog_tags(metric_tags: Dict[str, Any], default_tags: Dict[str, Any]) -> List[str]:
+    def _serialize_datadog_tags(metric_tags: dict[str, Any], default_tags: dict[str, Any]) -> list[str]:
         """
         Serialize metric tags into a list of formatted strings for Datadog integration.
 
@@ -313,14 +315,14 @@ class DatadogProvider(BaseProvider):
 
         Parameters
         ----------
-        metric_tags: Dict[str, Any]
+        metric_tags: dict[str, Any]
             A dictionary containing metric-specific tags.
-        default_tags: Dict[str, Any]
+        default_tags: dict[str, Any]
             A dictionary containing default tags applicable to all metrics.
 
         Returns:
         -------
-        List[str]
+        list[str]
             A list of formatted tag strings, each in the "tag_key:tag_value" format.
 
         Example:
@@ -337,7 +339,7 @@ class DatadogProvider(BaseProvider):
         return [f"{tag_key}:{tag_value}" for tag_key, tag_value in tags.items()]
 
     @staticmethod
-    def _validate_datadog_tags_name(tags: Dict):
+    def _validate_datadog_tags_name(tags: dict):
         """
         Validate a metric tag according to specific requirements.
 
@@ -348,7 +350,7 @@ class DatadogProvider(BaseProvider):
 
         Parameters:
         ----------
-        tags: Dict
+        tags: dict
             The metric tags to be validated.
         """
         for tag_key, tag_value in tags.items():

--- a/aws_lambda_powertools/metrics/provider/datadog/metrics.py
+++ b/aws_lambda_powertools/metrics/provider/datadog/metrics.py
@@ -1,10 +1,12 @@
 # NOTE: keeps for compatibility
 from __future__ import annotations
 
-from typing import Any, Dict, List
+from typing import TYPE_CHECKING, Any
 
 from aws_lambda_powertools.metrics.provider.datadog.datadog import DatadogProvider
-from aws_lambda_powertools.shared.types import AnyCallableT
+
+if TYPE_CHECKING:
+    from aws_lambda_powertools.shared.types import AnyCallableT
 
 
 class DatadogMetrics:
@@ -53,8 +55,8 @@ class DatadogMetrics:
     # and not get caught by accident with metrics data loss, or data deduplication
     # e.g., m1 and m2 add metric ProductCreated, however m1 has 'version' dimension  but m2 doesn't
     # Result: ProductCreated is created twice as we now have 2 different EMF blobs
-    _metrics: List = []
-    _default_tags: Dict[str, Any] = {}
+    _metrics: list = []
+    _default_tags: dict[str, Any] = {}
 
     def __init__(
         self,
@@ -83,7 +85,7 @@ class DatadogMetrics:
     ) -> None:
         self.provider.add_metric(name=name, value=value, timestamp=timestamp, **tags)
 
-    def serialize_metric_set(self, metrics: List | None = None) -> List:
+    def serialize_metric_set(self, metrics: list | None = None) -> list:
         return self.provider.serialize_metric_set(metrics=metrics)
 
     def flush_metrics(self, raise_on_empty_metrics: bool = False) -> None:
@@ -94,7 +96,7 @@ class DatadogMetrics:
         lambda_handler: AnyCallableT | None = None,
         capture_cold_start_metric: bool = False,
         raise_on_empty_metrics: bool = False,
-        default_tags: Dict[str, Any] | None = None,
+        default_tags: dict[str, Any] | None = None,
     ):
         return self.provider.log_metrics(
             lambda_handler=lambda_handler,


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
**Issue number:** #4953 

## Summary

### Changes

Add `from __future__ import annotations` to metrics package

### User experience

Discussed in #4607

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [X] [Meet tenets criteria](https://docs.powertools.aws.dev/lambda/python/#tenets)
* [X] I have performed a self-review of this change
* [X] Changes have been tested
* [ ] Changes are documented
* [X] PR title follows [conventional commit semantics](https://github.com/aws-powertools/powertools-lambda-python/blob/develop/.github/semantic.yml)

<details>
<summary>Is this a breaking change?</summary>

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
