### PR TITLE
feat(layers): add ARM64 support for ca-west-1

### DIFF
--- a/.github/workflows/reusable_deploy_v2_layer_stack.yml
+++ b/.github/workflows/reusable_deploy_v2_layer_stack.yml
@@ -105,7 +105,7 @@ jobs:
           - region: "ca-central-1"
             has_arm64_support: "true"
           - region: "ca-west-1"
-            has_arm64_support: "false"
+            has_arm64_support: "true"
           - region: "eu-central-1"
             has_arm64_support: "true"
           - region: "eu-central-2"


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
**Issue number:** #3545

## Summary

### Changes

Enables ARM64 support for `ca-west-1`, all previous versions of v2 are backfilled.

### User experience

Users can now use ca-west-1 with ARM Lambda functions

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [X] [Meet tenets criteria](https://docs.powertools.aws.dev/lambda/python/#tenets)
* [X] I have performed a self-review of this change
* [X] Changes have been tested
* [X] Changes are documented
* [X] PR title follows [conventional commit semantics](https://github.com/aws-powertools/powertools-lambda-python/blob/develop/.github/semantic.yml)

<details>
<summary>Is this a breaking change?</summary>

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
