### PR TITLE
refactor(examples): add from __future__ import annotations

### DIFF
--- a/examples/batch_processing/src/advanced_accessing_lambda_context.py
+++ b/examples/batch_processing/src/advanced_accessing_lambda_context.py
@@ -1,4 +1,6 @@
-from typing import Optional
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
 
 from aws_lambda_powertools import Logger, Tracer
 from aws_lambda_powertools.utilities.batch import (
@@ -6,8 +8,10 @@ from aws_lambda_powertools.utilities.batch import (
     EventType,
     process_partial_response,
 )
-from aws_lambda_powertools.utilities.data_classes.sqs_event import SQSRecord
-from aws_lambda_powertools.utilities.typing import LambdaContext
+
+if TYPE_CHECKING:
+    from aws_lambda_powertools.utilities.data_classes.sqs_event import SQSRecord
+    from aws_lambda_powertools.utilities.typing import LambdaContext
 
 processor = BatchProcessor(event_type=EventType.SQS)
 tracer = Tracer()
@@ -15,7 +19,7 @@ logger = Logger()
 
 
 @tracer.capture_method
-def record_handler(record: SQSRecord, lambda_context: Optional[LambdaContext] = None):
+def record_handler(record: SQSRecord, lambda_context: LambdaContext | None = None):
     if lambda_context is not None:
         remaining_time = lambda_context.get_remaining_time_in_millis()
         logger.info(remaining_time)

--- a/examples/batch_processing/src/advanced_accessing_lambda_context_decorator.py
+++ b/examples/batch_processing/src/advanced_accessing_lambda_context_decorator.py
@@ -1,4 +1,6 @@
-from typing import Optional
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
 
 from aws_lambda_powertools import Logger, Tracer
 from aws_lambda_powertools.utilities.batch import (
@@ -6,8 +8,10 @@ from aws_lambda_powertools.utilities.batch import (
     EventType,
     batch_processor,
 )
-from aws_lambda_powertools.utilities.data_classes.sqs_event import SQSRecord
-from aws_lambda_powertools.utilities.typing import LambdaContext
+
+if TYPE_CHECKING:
+    from aws_lambda_powertools.utilities.data_classes.sqs_event import SQSRecord
+    from aws_lambda_powertools.utilities.typing import LambdaContext
 
 processor = BatchProcessor(event_type=EventType.SQS)
 tracer = Tracer()
@@ -15,7 +19,7 @@ logger = Logger()
 
 
 @tracer.capture_method
-def record_handler(record: SQSRecord, lambda_context: Optional[LambdaContext] = None):
+def record_handler(record: SQSRecord, lambda_context: LambdaContext | None = None):
     if lambda_context is not None:
         remaining_time = lambda_context.get_remaining_time_in_millis()
         logger.info(remaining_time)

--- a/examples/batch_processing/src/advanced_accessing_lambda_context_manager.py
+++ b/examples/batch_processing/src/advanced_accessing_lambda_context_manager.py
@@ -1,9 +1,13 @@
-from typing import Optional
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
 
 from aws_lambda_powertools import Logger, Tracer
 from aws_lambda_powertools.utilities.batch import BatchProcessor, EventType
-from aws_lambda_powertools.utilities.data_classes.sqs_event import SQSRecord
-from aws_lambda_powertools.utilities.typing import LambdaContext
+
+if TYPE_CHECKING:
+    from aws_lambda_powertools.utilities.data_classes.sqs_event import SQSRecord
+    from aws_lambda_powertools.utilities.typing import LambdaContext
 
 processor = BatchProcessor(event_type=EventType.SQS)
 tracer = Tracer()
@@ -11,7 +15,7 @@ logger = Logger()
 
 
 @tracer.capture_method
-def record_handler(record: SQSRecord, lambda_context: Optional[LambdaContext] = None):
+def record_handler(record: SQSRecord, lambda_context: LambdaContext | None = None):
     if lambda_context is not None:
         remaining_time = lambda_context.get_remaining_time_in_millis()
         logger.info(remaining_time)

--- a/examples/batch_processing/src/context_manager_access.py
+++ b/examples/batch_processing/src/context_manager_access.py
@@ -1,14 +1,16 @@
 from __future__ import annotations
 
 import json
-from typing import List, Tuple
+from typing import TYPE_CHECKING
 
 from typing_extensions import Literal
 
 from aws_lambda_powertools import Logger, Tracer
 from aws_lambda_powertools.utilities.batch import BatchProcessor, EventType
-from aws_lambda_powertools.utilities.data_classes.sqs_event import SQSRecord
-from aws_lambda_powertools.utilities.typing import LambdaContext
+
+if TYPE_CHECKING:
+    from aws_lambda_powertools.utilities.data_classes.sqs_event import SQSRecord
+    from aws_lambda_powertools.utilities.typing import LambdaContext
 
 processor = BatchProcessor(event_type=EventType.SQS)
 tracer = Tracer()
@@ -28,7 +30,7 @@ def record_handler(record: SQSRecord):
 def lambda_handler(event, context: LambdaContext):
     batch = event["Records"]  # (1)!
     with processor(records=batch, handler=record_handler):
-        processed_messages: List[Tuple] = processor.process()
+        processed_messages: list[tuple] = processor.process()
 
     for message in processed_messages:
         status: Literal["success", "fail"] = message[0]

--- a/examples/batch_processing/src/custom_partial_processor.py
+++ b/examples/batch_processing/src/custom_partial_processor.py
@@ -1,8 +1,10 @@
+from __future__ import annotations
+
 import copy
 import os
 import sys
 from random import randint
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import boto3
 
@@ -11,7 +13,9 @@ from aws_lambda_powertools.utilities.batch import (
     BasePartialProcessor,
     process_partial_response,
 )
-from aws_lambda_powertools.utilities.batch.types import PartialItemFailureResponse
+
+if TYPE_CHECKING:
+    from aws_lambda_powertools.utilities.batch.types import PartialItemFailureResponse
 
 table_name = os.getenv("TABLE_NAME", "table_store_batch")
 

--- a/examples/batch_processing/src/disable_tracing.py
+++ b/examples/batch_processing/src/disable_tracing.py
@@ -1,4 +1,7 @@
+from __future__ import annotations
+
 import json
+from typing import TYPE_CHECKING
 
 from aws_lambda_powertools import Logger, Tracer
 from aws_lambda_powertools.utilities.batch import (
@@ -6,8 +9,10 @@ from aws_lambda_powertools.utilities.batch import (
     EventType,
     process_partial_response,
 )
-from aws_lambda_powertools.utilities.data_classes.sqs_event import SQSRecord
-from aws_lambda_powertools.utilities.typing import LambdaContext
+
+if TYPE_CHECKING:
+    from aws_lambda_powertools.utilities.data_classes.sqs_event import SQSRecord
+    from aws_lambda_powertools.utilities.typing import LambdaContext
 
 processor = BatchProcessor(event_type=EventType.SQS)
 tracer = Tracer()

--- a/examples/batch_processing/src/extending_processor_handlers.py
+++ b/examples/batch_processing/src/extending_processor_handlers.py
@@ -1,5 +1,7 @@
+from __future__ import annotations
+
 import json
-from typing import Any, Dict
+from typing import TYPE_CHECKING, Any
 
 from aws_lambda_powertools import Logger, Metrics, Tracer
 from aws_lambda_powertools.metrics import MetricUnit
@@ -10,13 +12,15 @@ from aws_lambda_powertools.utilities.batch import (
     FailureResponse,
     process_partial_response,
 )
-from aws_lambda_powertools.utilities.batch.base import SuccessResponse
-from aws_lambda_powertools.utilities.data_classes.sqs_event import SQSRecord
-from aws_lambda_powertools.utilities.typing import LambdaContext
+
+if TYPE_CHECKING:
+    from aws_lambda_powertools.utilities.batch.base import SuccessResponse
+    from aws_lambda_powertools.utilities.data_classes.sqs_event import SQSRecord
+    from aws_lambda_powertools.utilities.typing import LambdaContext
 
 
 class MyProcessor(BatchProcessor):
-    def success_handler(self, record: Dict[str, Any], result: Any) -> SuccessResponse:
+    def success_handler(self, record: dict[str, Any], result: Any) -> SuccessResponse:
         metrics.add_metric(name="BatchRecordSuccesses", unit=MetricUnit.Count, value=1)
         return super().success_handler(record, result)
 

--- a/examples/batch_processing/src/getting_started_async.py
+++ b/examples/batch_processing/src/getting_started_async.py
@@ -1,3 +1,7 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 import httpx  # external dependency
 
 from aws_lambda_powertools.utilities.batch import (
@@ -5,8 +9,10 @@ from aws_lambda_powertools.utilities.batch import (
     EventType,
     async_process_partial_response,
 )
-from aws_lambda_powertools.utilities.data_classes.sqs_event import SQSRecord
-from aws_lambda_powertools.utilities.typing import LambdaContext
+
+if TYPE_CHECKING:
+    from aws_lambda_powertools.utilities.data_classes.sqs_event import SQSRecord
+    from aws_lambda_powertools.utilities.typing import LambdaContext
 
 processor = AsyncBatchProcessor(event_type=EventType.SQS)
 

--- a/examples/batch_processing/src/getting_started_dynamodb.py
+++ b/examples/batch_processing/src/getting_started_dynamodb.py
@@ -1,4 +1,7 @@
+from __future__ import annotations
+
 import json
+from typing import TYPE_CHECKING
 
 from aws_lambda_powertools import Logger, Tracer
 from aws_lambda_powertools.utilities.batch import (
@@ -6,10 +9,12 @@ from aws_lambda_powertools.utilities.batch import (
     EventType,
     process_partial_response,
 )
-from aws_lambda_powertools.utilities.data_classes.dynamo_db_stream_event import (
-    DynamoDBRecord,
-)
-from aws_lambda_powertools.utilities.typing import LambdaContext
+
+if TYPE_CHECKING:
+    from aws_lambda_powertools.utilities.data_classes.dynamo_db_stream_event import (
+        DynamoDBRecord,
+    )
+    from aws_lambda_powertools.utilities.typing import LambdaContext
 
 processor = BatchProcessor(event_type=EventType.DynamoDBStreams)  # (1)!
 tracer = Tracer()

--- a/examples/batch_processing/src/getting_started_dynamodb_context_manager.py
+++ b/examples/batch_processing/src/getting_started_dynamodb_context_manager.py
@@ -1,11 +1,16 @@
+from __future__ import annotations
+
 import json
+from typing import TYPE_CHECKING
 
 from aws_lambda_powertools import Logger, Tracer
 from aws_lambda_powertools.utilities.batch import BatchProcessor, EventType
-from aws_lambda_powertools.utilities.data_classes.dynamo_db_stream_event import (
-    DynamoDBRecord,
-)
-from aws_lambda_powertools.utilities.typing import LambdaContext
+
+if TYPE_CHECKING:
+    from aws_lambda_powertools.utilities.data_classes.dynamo_db_stream_event import (
+        DynamoDBRecord,
+    )
+    from aws_lambda_powertools.utilities.typing import LambdaContext
 
 processor = BatchProcessor(event_type=EventType.DynamoDBStreams)
 tracer = Tracer()

--- a/examples/batch_processing/src/getting_started_dynamodb_decorator.py
+++ b/examples/batch_processing/src/getting_started_dynamodb_decorator.py
@@ -1,4 +1,7 @@
+from __future__ import annotations
+
 import json
+from typing import TYPE_CHECKING
 
 from aws_lambda_powertools import Logger, Tracer
 from aws_lambda_powertools.utilities.batch import (
@@ -6,10 +9,12 @@ from aws_lambda_powertools.utilities.batch import (
     EventType,
     batch_processor,
 )
-from aws_lambda_powertools.utilities.data_classes.dynamo_db_stream_event import (
-    DynamoDBRecord,
-)
-from aws_lambda_powertools.utilities.typing import LambdaContext
+
+if TYPE_CHECKING:
+    from aws_lambda_powertools.utilities.data_classes.dynamo_db_stream_event import (
+        DynamoDBRecord,
+    )
+    from aws_lambda_powertools.utilities.typing import LambdaContext
 
 processor = BatchProcessor(event_type=EventType.DynamoDBStreams)
 tracer = Tracer()

--- a/examples/batch_processing/src/getting_started_error_handling.py
+++ b/examples/batch_processing/src/getting_started_error_handling.py
@@ -1,19 +1,24 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 from aws_lambda_powertools import Logger, Tracer
 from aws_lambda_powertools.utilities.batch import (
     BatchProcessor,
     EventType,
     process_partial_response,
 )
-from aws_lambda_powertools.utilities.data_classes.sqs_event import SQSRecord
-from aws_lambda_powertools.utilities.typing import LambdaContext
+
+if TYPE_CHECKING:
+    from aws_lambda_powertools.utilities.data_classes.sqs_event import SQSRecord
+    from aws_lambda_powertools.utilities.typing import LambdaContext
 
 processor = BatchProcessor(event_type=EventType.SQS)
 tracer = Tracer()
 logger = Logger()
 
 
-class InvalidPayload(Exception):
-    ...
+class InvalidPayload(Exception): ...
 
 
 @tracer.capture_method

--- a/examples/batch_processing/src/getting_started_kinesis.py
+++ b/examples/batch_processing/src/getting_started_kinesis.py
@@ -1,13 +1,19 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 from aws_lambda_powertools import Logger, Tracer
 from aws_lambda_powertools.utilities.batch import (
     BatchProcessor,
     EventType,
     process_partial_response,
 )
-from aws_lambda_powertools.utilities.data_classes.kinesis_stream_event import (
-    KinesisStreamRecord,
-)
-from aws_lambda_powertools.utilities.typing import LambdaContext
+
+if TYPE_CHECKING:
+    from aws_lambda_powertools.utilities.data_classes.kinesis_stream_event import (
+        KinesisStreamRecord,
+    )
+    from aws_lambda_powertools.utilities.typing import LambdaContext
 
 processor = BatchProcessor(event_type=EventType.KinesisDataStreams)  # (1)!
 tracer = Tracer()

--- a/examples/batch_processing/src/getting_started_kinesis_context_manager.py
+++ b/examples/batch_processing/src/getting_started_kinesis_context_manager.py
@@ -1,9 +1,15 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 from aws_lambda_powertools import Logger, Tracer
 from aws_lambda_powertools.utilities.batch import BatchProcessor, EventType
-from aws_lambda_powertools.utilities.data_classes.kinesis_stream_event import (
-    KinesisStreamRecord,
-)
-from aws_lambda_powertools.utilities.typing import LambdaContext
+
+if TYPE_CHECKING:
+    from aws_lambda_powertools.utilities.data_classes.kinesis_stream_event import (
+        KinesisStreamRecord,
+    )
+    from aws_lambda_powertools.utilities.typing import LambdaContext
 
 processor = BatchProcessor(event_type=EventType.KinesisDataStreams)
 tracer = Tracer()

--- a/examples/batch_processing/src/getting_started_kinesis_decorator.py
+++ b/examples/batch_processing/src/getting_started_kinesis_decorator.py
@@ -1,13 +1,19 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 from aws_lambda_powertools import Logger, Tracer
 from aws_lambda_powertools.utilities.batch import (
     BatchProcessor,
     EventType,
     batch_processor,
 )
-from aws_lambda_powertools.utilities.data_classes.kinesis_stream_event import (
-    KinesisStreamRecord,
-)
-from aws_lambda_powertools.utilities.typing import LambdaContext
+
+if TYPE_CHECKING:
+    from aws_lambda_powertools.utilities.data_classes.kinesis_stream_event import (
+        KinesisStreamRecord,
+    )
+    from aws_lambda_powertools.utilities.typing import LambdaContext
 
 processor = BatchProcessor(event_type=EventType.KinesisDataStreams)
 tracer = Tracer()

--- a/examples/batch_processing/src/getting_started_sqs.py
+++ b/examples/batch_processing/src/getting_started_sqs.py
@@ -1,11 +1,17 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 from aws_lambda_powertools import Logger, Tracer
 from aws_lambda_powertools.utilities.batch import (
     BatchProcessor,
     EventType,
     process_partial_response,
 )
-from aws_lambda_powertools.utilities.data_classes.sqs_event import SQSRecord
-from aws_lambda_powertools.utilities.typing import LambdaContext
+
+if TYPE_CHECKING:
+    from aws_lambda_powertools.utilities.data_classes.sqs_event import SQSRecord
+    from aws_lambda_powertools.utilities.typing import LambdaContext
 
 processor = BatchProcessor(event_type=EventType.SQS)  # (1)!
 tracer = Tracer()

--- a/examples/batch_processing/src/getting_started_sqs_context_manager.py
+++ b/examples/batch_processing/src/getting_started_sqs_context_manager.py
@@ -1,9 +1,14 @@
+from __future__ import annotations
+
 import json
+from typing import TYPE_CHECKING
 
 from aws_lambda_powertools import Logger, Tracer
 from aws_lambda_powertools.utilities.batch import BatchProcessor, EventType
-from aws_lambda_powertools.utilities.data_classes.sqs_event import SQSRecord
-from aws_lambda_powertools.utilities.typing import LambdaContext
+
+if TYPE_CHECKING:
+    from aws_lambda_powertools.utilities.data_classes.sqs_event import SQSRecord
+    from aws_lambda_powertools.utilities.typing import LambdaContext
 
 processor = BatchProcessor(event_type=EventType.SQS)
 tracer = Tracer()

--- a/examples/batch_processing/src/getting_started_sqs_decorator.py
+++ b/examples/batch_processing/src/getting_started_sqs_decorator.py
@@ -1,4 +1,7 @@
+from __future__ import annotations
+
 import json
+from typing import TYPE_CHECKING
 
 from aws_lambda_powertools import Logger, Tracer
 from aws_lambda_powertools.utilities.batch import (
@@ -6,8 +9,10 @@ from aws_lambda_powertools.utilities.batch import (
     EventType,
     batch_processor,
 )
-from aws_lambda_powertools.utilities.data_classes.sqs_event import SQSRecord
-from aws_lambda_powertools.utilities.typing import LambdaContext
+
+if TYPE_CHECKING:
+    from aws_lambda_powertools.utilities.data_classes.sqs_event import SQSRecord
+    from aws_lambda_powertools.utilities.typing import LambdaContext
 
 processor = BatchProcessor(event_type=EventType.SQS)
 tracer = Tracer()

--- a/examples/batch_processing/src/getting_started_sqs_fifo.py
+++ b/examples/batch_processing/src/getting_started_sqs_fifo.py
@@ -1,10 +1,16 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 from aws_lambda_powertools import Logger, Tracer
 from aws_lambda_powertools.utilities.batch import (
     SqsFifoPartialProcessor,
     process_partial_response,
 )
-from aws_lambda_powertools.utilities.data_classes.sqs_event import SQSRecord
-from aws_lambda_powertools.utilities.typing import LambdaContext
+
+if TYPE_CHECKING:
+    from aws_lambda_powertools.utilities.data_classes.sqs_event import SQSRecord
+    from aws_lambda_powertools.utilities.typing import LambdaContext
 
 processor = SqsFifoPartialProcessor()  # (1)!
 tracer = Tracer()

--- a/examples/batch_processing/src/getting_started_sqs_fifo_context_manager.py
+++ b/examples/batch_processing/src/getting_started_sqs_fifo_context_manager.py
@@ -1,9 +1,14 @@
+from __future__ import annotations
+
 import json
+from typing import TYPE_CHECKING
 
 from aws_lambda_powertools import Logger, Tracer
 from aws_lambda_powertools.utilities.batch import SqsFifoPartialProcessor
-from aws_lambda_powertools.utilities.data_classes.sqs_event import SQSRecord
-from aws_lambda_powertools.utilities.typing import LambdaContext
+
+if TYPE_CHECKING:
+    from aws_lambda_powertools.utilities.data_classes.sqs_event import SQSRecord
+    from aws_lambda_powertools.utilities.typing import LambdaContext
 
 processor = SqsFifoPartialProcessor()
 tracer = Tracer()
@@ -23,6 +28,6 @@ def record_handler(record: SQSRecord):
 def lambda_handler(event, context: LambdaContext):
     batch = event["Records"]
     with processor(records=batch, handler=record_handler):
-        processor.process()  # kick off processing, return List[Tuple]
+        processor.process()  # kick off processing, return list[tuple]
 
     return processor.response()

--- a/examples/batch_processing/src/getting_started_sqs_fifo_decorator.py
+++ b/examples/batch_processing/src/getting_started_sqs_fifo_decorator.py
@@ -1,12 +1,17 @@
+from __future__ import annotations
+
 import json
+from typing import TYPE_CHECKING
 
 from aws_lambda_powertools import Logger, Tracer
 from aws_lambda_powertools.utilities.batch import (
     SqsFifoPartialProcessor,
     batch_processor,
 )
-from aws_lambda_powertools.utilities.data_classes.sqs_event import SQSRecord
-from aws_lambda_powertools.utilities.typing import LambdaContext
+
+if TYPE_CHECKING:
+    from aws_lambda_powertools.utilities.data_classes.sqs_event import SQSRecord
+    from aws_lambda_powertools.utilities.typing import LambdaContext
 
 processor = SqsFifoPartialProcessor()
 tracer = Tracer()

--- a/examples/batch_processing/src/getting_started_sqs_fifo_skip_on_error.py
+++ b/examples/batch_processing/src/getting_started_sqs_fifo_skip_on_error.py
@@ -1,10 +1,16 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 from aws_lambda_powertools import Logger, Tracer
 from aws_lambda_powertools.utilities.batch import (
     SqsFifoPartialProcessor,
     process_partial_response,
 )
-from aws_lambda_powertools.utilities.data_classes.sqs_event import SQSRecord
-from aws_lambda_powertools.utilities.typing import LambdaContext
+
+if TYPE_CHECKING:
+    from aws_lambda_powertools.utilities.data_classes.sqs_event import SQSRecord
+    from aws_lambda_powertools.utilities.typing import LambdaContext
 
 processor = SqsFifoPartialProcessor(skip_group_on_error=True)
 tracer = Tracer()

--- a/examples/batch_processing/src/getting_started_with_test.py
+++ b/examples/batch_processing/src/getting_started_with_test.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import json
 from dataclasses import dataclass
 from pathlib import Path

--- a/examples/batch_processing/src/getting_started_with_test_app.py
+++ b/examples/batch_processing/src/getting_started_with_test_app.py
@@ -1,4 +1,7 @@
+from __future__ import annotations
+
 import json
+from typing import TYPE_CHECKING
 
 from aws_lambda_powertools import Logger, Tracer
 from aws_lambda_powertools.utilities.batch import (
@@ -6,8 +9,10 @@ from aws_lambda_powertools.utilities.batch import (
     EventType,
     process_partial_response,
 )
-from aws_lambda_powertools.utilities.data_classes.sqs_event import SQSRecord
-from aws_lambda_powertools.utilities.typing import LambdaContext
+
+if TYPE_CHECKING:
+    from aws_lambda_powertools.utilities.data_classes.sqs_event import SQSRecord
+    from aws_lambda_powertools.utilities.typing import LambdaContext
 
 processor = BatchProcessor(event_type=EventType.SQS)
 tracer = Tracer()

--- a/examples/batch_processing/src/pydantic_dynamodb.py
+++ b/examples/batch_processing/src/pydantic_dynamodb.py
@@ -1,5 +1,7 @@
+from __future__ import annotations
+
 import json
-from typing import Dict, Optional
+from typing import TYPE_CHECKING
 
 from typing_extensions import Literal
 
@@ -14,7 +16,9 @@ from aws_lambda_powertools.utilities.parser.models import (
     DynamoDBStreamChangedRecordModel,
     DynamoDBStreamRecordModel,
 )
-from aws_lambda_powertools.utilities.typing import LambdaContext
+
+if TYPE_CHECKING:
+    from aws_lambda_powertools.utilities.typing import LambdaContext
 
 
 class Order(BaseModel):
@@ -27,13 +31,13 @@ class OrderDynamoDB(BaseModel):
     # auto transform json string
     # so Pydantic can auto-initialize nested Order model
     @field_validator("Message", mode="before")
-    def transform_message_to_dict(cls, value: Dict[Literal["S"], str]):
+    def transform_message_to_dict(cls, value: dict[Literal["S"], str]):
         return json.loads(value["S"])
 
 
 class OrderDynamoDBChangeRecord(DynamoDBStreamChangedRecordModel):
-    NewImage: Optional[OrderDynamoDB]
-    OldImage: Optional[OrderDynamoDB]
+    NewImage: OrderDynamoDB | None
+    OldImage: OrderDynamoDB | None
 
 
 class OrderDynamoDBRecord(DynamoDBStreamRecordModel):

--- a/examples/batch_processing/src/pydantic_kinesis.py
+++ b/examples/batch_processing/src/pydantic_kinesis.py
@@ -1,3 +1,7 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 from aws_lambda_powertools import Logger, Tracer
 from aws_lambda_powertools.utilities.batch import (
     BatchProcessor,
@@ -9,8 +13,10 @@ from aws_lambda_powertools.utilities.parser.models import (
     KinesisDataStreamRecord,
     KinesisDataStreamRecordPayload,
 )
-from aws_lambda_powertools.utilities.parser.types import Json
-from aws_lambda_powertools.utilities.typing import LambdaContext
+
+if TYPE_CHECKING:
+    from aws_lambda_powertools.utilities.parser.types import Json
+    from aws_lambda_powertools.utilities.typing import LambdaContext
 
 
 class Order(BaseModel):

--- a/examples/batch_processing/src/pydantic_sqs.py
+++ b/examples/batch_processing/src/pydantic_sqs.py
@@ -1,3 +1,7 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 from aws_lambda_powertools import Logger, Tracer
 from aws_lambda_powertools.utilities.batch import (
     BatchProcessor,
@@ -6,8 +10,10 @@ from aws_lambda_powertools.utilities.batch import (
 )
 from aws_lambda_powertools.utilities.parser import BaseModel
 from aws_lambda_powertools.utilities.parser.models import SqsRecordModel
-from aws_lambda_powertools.utilities.parser.types import Json
-from aws_lambda_powertools.utilities.typing import LambdaContext
+
+if TYPE_CHECKING:
+    from aws_lambda_powertools.utilities.parser.types import Json
+    from aws_lambda_powertools.utilities.typing import LambdaContext
 
 
 class Order(BaseModel):

--- a/examples/batch_processing/src/sentry_error_tracking.py
+++ b/examples/batch_processing/src/sentry_error_tracking.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from sentry_sdk import capture_exception
 
 from aws_lambda_powertools.utilities.batch import BatchProcessor, FailureResponse

--- a/examples/data_masking/src/advanced_custom_serializer.py
+++ b/examples/data_masking/src/advanced_custom_serializer.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import os
+from typing import TYPE_CHECKING
 
 import ujson
 
@@ -8,7 +9,9 @@ from aws_lambda_powertools.utilities.data_masking import DataMasking
 from aws_lambda_powertools.utilities.data_masking.provider.kms.aws_encryption_sdk import (
     AWSEncryptionSDKProvider,
 )
-from aws_lambda_powertools.utilities.typing import LambdaContext
+
+if TYPE_CHECKING:
+    from aws_lambda_powertools.utilities.typing import LambdaContext
 
 KMS_KEY_ARN = os.getenv("KMS_KEY_ARN", "")
 

--- a/examples/data_masking/src/aws_encryption_provider_example.py
+++ b/examples/data_masking/src/aws_encryption_provider_example.py
@@ -1,13 +1,16 @@
 from __future__ import annotations
 
 import os
+from typing import TYPE_CHECKING
 
 from aws_lambda_powertools import Logger
 from aws_lambda_powertools.utilities.data_masking import DataMasking
 from aws_lambda_powertools.utilities.data_masking.provider.kms.aws_encryption_sdk import (
     AWSEncryptionSDKProvider,
 )
-from aws_lambda_powertools.utilities.typing import LambdaContext
+
+if TYPE_CHECKING:
+    from aws_lambda_powertools.utilities.typing import LambdaContext
 
 KMS_KEY_ARN = os.getenv("KMS_KEY_ARN", "")
 
@@ -16,7 +19,8 @@ encryption_provider = AWSEncryptionSDKProvider(
     local_cache_capacity=200,
     max_cache_age_seconds=400,
     max_messages_encrypted=200,
-    max_bytes_encrypted=2000)
+    max_bytes_encrypted=2000,
+)
 
 data_masker = DataMasking(provider=encryption_provider)
 

--- a/examples/data_masking/src/changing_default_algorithm.py
+++ b/examples/data_masking/src/changing_default_algorithm.py
@@ -1,13 +1,16 @@
 from __future__ import annotations
 
 import os
+from typing import TYPE_CHECKING
 
 from aws_encryption_sdk.identifiers import Algorithm
 
 from aws_lambda_powertools import Logger
 from aws_lambda_powertools.utilities.data_masking import DataMasking
 from aws_lambda_powertools.utilities.data_masking.provider.kms.aws_encryption_sdk import AWSEncryptionSDKProvider
-from aws_lambda_powertools.utilities.typing import LambdaContext
+
+if TYPE_CHECKING:
+    from aws_lambda_powertools.utilities.typing import LambdaContext
 
 KMS_KEY_ARN = os.getenv("KMS_KEY_ARN", "")
 

--- a/examples/data_masking/src/data_masking_function_example.py
+++ b/examples/data_masking/src/data_masking_function_example.py
@@ -1,11 +1,14 @@
 from __future__ import annotations
 
 import os
+from typing import TYPE_CHECKING
 
 from aws_lambda_powertools import Logger, Tracer
 from aws_lambda_powertools.utilities.data_masking import DataMasking
 from aws_lambda_powertools.utilities.data_masking.provider.kms.aws_encryption_sdk import AWSEncryptionSDKProvider
-from aws_lambda_powertools.utilities.typing import LambdaContext
+
+if TYPE_CHECKING:
+    from aws_lambda_powertools.utilities.typing import LambdaContext
 
 KMS_KEY_ARN = os.getenv("KMS_KEY_ARN", "")
 

--- a/examples/data_masking/src/getting_started_decrypt_data.py
+++ b/examples/data_masking/src/getting_started_decrypt_data.py
@@ -1,11 +1,14 @@
 from __future__ import annotations
 
 import os
+from typing import TYPE_CHECKING
 
 from aws_lambda_powertools import Logger
 from aws_lambda_powertools.utilities.data_masking import DataMasking
 from aws_lambda_powertools.utilities.data_masking.provider.kms.aws_encryption_sdk import AWSEncryptionSDKProvider
-from aws_lambda_powertools.utilities.typing import LambdaContext
+
+if TYPE_CHECKING:
+    from aws_lambda_powertools.utilities.typing import LambdaContext
 
 KMS_KEY_ARN = os.getenv("KMS_KEY_ARN", "")  # (1)!
 

--- a/examples/data_masking/src/getting_started_decryption_context.py
+++ b/examples/data_masking/src/getting_started_decryption_context.py
@@ -1,11 +1,14 @@
 from __future__ import annotations
 
 import os
+from typing import TYPE_CHECKING
 
 from aws_lambda_powertools import Logger
 from aws_lambda_powertools.utilities.data_masking import DataMasking
 from aws_lambda_powertools.utilities.data_masking.provider.kms.aws_encryption_sdk import AWSEncryptionSDKProvider
-from aws_lambda_powertools.utilities.typing import LambdaContext
+
+if TYPE_CHECKING:
+    from aws_lambda_powertools.utilities.typing import LambdaContext
 
 KMS_KEY_ARN = os.getenv("KMS_KEY_ARN", "")
 

--- a/examples/data_masking/src/getting_started_encrypt_data.py
+++ b/examples/data_masking/src/getting_started_encrypt_data.py
@@ -1,13 +1,16 @@
 from __future__ import annotations
 
 import os
+from typing import TYPE_CHECKING
 
 from aws_lambda_powertools import Logger
 from aws_lambda_powertools.utilities.data_masking import DataMasking
 from aws_lambda_powertools.utilities.data_masking.provider.kms.aws_encryption_sdk import (
     AWSEncryptionSDKProvider,
 )
-from aws_lambda_powertools.utilities.typing import LambdaContext
+
+if TYPE_CHECKING:
+    from aws_lambda_powertools.utilities.typing import LambdaContext
 
 KMS_KEY_ARN = os.getenv("KMS_KEY_ARN", "")
 

--- a/examples/data_masking/src/getting_started_encryption_context.py
+++ b/examples/data_masking/src/getting_started_encryption_context.py
@@ -1,11 +1,14 @@
 from __future__ import annotations
 
 import os
+from typing import TYPE_CHECKING
 
 from aws_lambda_powertools import Logger
 from aws_lambda_powertools.utilities.data_masking import DataMasking
 from aws_lambda_powertools.utilities.data_masking.provider.kms.aws_encryption_sdk import AWSEncryptionSDKProvider
-from aws_lambda_powertools.utilities.typing import LambdaContext
+
+if TYPE_CHECKING:
+    from aws_lambda_powertools.utilities.typing import LambdaContext
 
 KMS_KEY_ARN = os.getenv("KMS_KEY_ARN", "")
 

--- a/examples/data_masking/src/getting_started_erase_data.py
+++ b/examples/data_masking/src/getting_started_erase_data.py
@@ -1,8 +1,12 @@
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 from aws_lambda_powertools import Logger
 from aws_lambda_powertools.utilities.data_masking import DataMasking
-from aws_lambda_powertools.utilities.typing import LambdaContext
+
+if TYPE_CHECKING:
+    from aws_lambda_powertools.utilities.typing import LambdaContext
 
 logger = Logger()
 data_masker = DataMasking()

--- a/examples/data_masking/src/using_multiple_keys.py
+++ b/examples/data_masking/src/using_multiple_keys.py
@@ -1,13 +1,16 @@
 from __future__ import annotations
 
 import os
+from typing import TYPE_CHECKING
 
 from aws_lambda_powertools import Logger
 from aws_lambda_powertools.utilities.data_masking import DataMasking
 from aws_lambda_powertools.utilities.data_masking.provider.kms.aws_encryption_sdk import (
     AWSEncryptionSDKProvider,
 )
-from aws_lambda_powertools.utilities.typing import LambdaContext
+
+if TYPE_CHECKING:
+    from aws_lambda_powertools.utilities.typing import LambdaContext
 
 KMS_KEY_ARN_1 = os.getenv("KMS_KEY_ARN_1", "")
 KMS_KEY_ARN_2 = os.getenv("KMS_KEY_ARN_2", "")

--- a/examples/data_masking/tests/lambda_mask.py
+++ b/examples/data_masking/tests/lambda_mask.py
@@ -1,7 +1,11 @@
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 from aws_lambda_powertools.utilities.data_masking import DataMasking
-from aws_lambda_powertools.utilities.typing import LambdaContext
+
+if TYPE_CHECKING:
+    from aws_lambda_powertools.utilities.typing import LambdaContext
 
 data_masker = DataMasking()
 

--- a/examples/data_masking/tests/test_lambda_mask.py
+++ b/examples/data_masking/tests/test_lambda_mask.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from dataclasses import dataclass
 
 import pytest

--- a/examples/event_handler_bedrock_agents/cdk/bedrock_agent_stack.py
+++ b/examples/event_handler_bedrock_agents/cdk/bedrock_agent_stack.py
@@ -1,3 +1,7 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 from aws_cdk import (
     Stack,
 )
@@ -10,7 +14,9 @@ from cdklabs.generative_ai_cdk_constructs.bedrock import (
     ApiSchema,
     BedrockFoundationModel,
 )
-from constructs import Construct
+
+if TYPE_CHECKING:
+    from constructs import Construct
 
 
 class AgentsCdkStack(Stack):

--- a/examples/event_handler_bedrock_agents/src/accessing_request_fields.py
+++ b/examples/event_handler_bedrock_agents/src/accessing_request_fields.py
@@ -1,8 +1,13 @@
+from __future__ import annotations
+
 from time import time
+from typing import TYPE_CHECKING
 
 from aws_lambda_powertools import Logger
 from aws_lambda_powertools.event_handler import BedrockAgentResolver
-from aws_lambda_powertools.utilities.typing import LambdaContext
+
+if TYPE_CHECKING:
+    from aws_lambda_powertools.utilities.typing import LambdaContext
 
 logger = Logger()
 app = BedrockAgentResolver()

--- a/examples/event_handler_bedrock_agents/src/assert_bedrock_agent_response.py
+++ b/examples/event_handler_bedrock_agents/src/assert_bedrock_agent_response.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from dataclasses import dataclass
 
 import assert_bedrock_agent_response_module

--- a/examples/event_handler_bedrock_agents/src/assert_bedrock_agent_response_module.py
+++ b/examples/event_handler_bedrock_agents/src/assert_bedrock_agent_response_module.py
@@ -1,11 +1,16 @@
+from __future__ import annotations
+
 import time
+from typing import TYPE_CHECKING
 
 from typing_extensions import Annotated
 
 from aws_lambda_powertools import Logger, Tracer
 from aws_lambda_powertools.event_handler import BedrockAgentResolver
-from aws_lambda_powertools.event_handler.openapi.params import Body
-from aws_lambda_powertools.utilities.typing import LambdaContext
+
+if TYPE_CHECKING:
+    from aws_lambda_powertools.event_handler.openapi.params import Body
+    from aws_lambda_powertools.utilities.typing import LambdaContext
 
 tracer = Tracer()
 logger = Logger()

--- a/examples/event_handler_bedrock_agents/src/customizing_bedrock_api_metadata.py
+++ b/examples/event_handler_bedrock_agents/src/customizing_bedrock_api_metadata.py
@@ -1,8 +1,14 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 import requests
 
 from aws_lambda_powertools.event_handler import BedrockAgentResolver
 from aws_lambda_powertools.event_handler.openapi.models import Contact, Server
-from aws_lambda_powertools.utilities.typing import LambdaContext
+
+if TYPE_CHECKING:
+    from aws_lambda_powertools.utilities.typing import LambdaContext
 
 app = BedrockAgentResolver()
 

--- a/examples/event_handler_bedrock_agents/src/customizing_bedrock_api_operations.py
+++ b/examples/event_handler_bedrock_agents/src/customizing_bedrock_api_operations.py
@@ -1,9 +1,15 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 import requests
 from typing_extensions import Annotated
 
 from aws_lambda_powertools.event_handler import BedrockAgentResolver
-from aws_lambda_powertools.event_handler.openapi.params import Body, Path
-from aws_lambda_powertools.utilities.typing import LambdaContext
+
+if TYPE_CHECKING:
+    from aws_lambda_powertools.event_handler.openapi.params import Body, Path
+    from aws_lambda_powertools.utilities.typing import LambdaContext
 
 app = BedrockAgentResolver()
 

--- a/examples/event_handler_bedrock_agents/src/customizing_bedrock_api_parameters.py
+++ b/examples/event_handler_bedrock_agents/src/customizing_bedrock_api_parameters.py
@@ -1,10 +1,16 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 import requests
 from typing_extensions import Annotated
 
 from aws_lambda_powertools import Logger
 from aws_lambda_powertools.event_handler import BedrockAgentResolver
-from aws_lambda_powertools.event_handler.openapi.params import Body, Query
-from aws_lambda_powertools.utilities.typing import LambdaContext
+
+if TYPE_CHECKING:
+    from aws_lambda_powertools.event_handler.openapi.params import Body, Query
+    from aws_lambda_powertools.utilities.typing import LambdaContext
 
 app = BedrockAgentResolver()
 

--- a/examples/event_handler_bedrock_agents/src/generating_openapi_schema.py
+++ b/examples/event_handler_bedrock_agents/src/generating_openapi_schema.py
@@ -1,8 +1,13 @@
+from __future__ import annotations
+
 from time import time
+from typing import TYPE_CHECKING
 
 from aws_lambda_powertools import Logger, Tracer
 from aws_lambda_powertools.event_handler import BedrockAgentResolver
-from aws_lambda_powertools.utilities.typing import LambdaContext
+
+if TYPE_CHECKING:
+    from aws_lambda_powertools.utilities.typing import LambdaContext
 
 tracer = Tracer()
 logger = Logger()

--- a/examples/event_handler_bedrock_agents/src/getting_started.py
+++ b/examples/event_handler_bedrock_agents/src/getting_started.py
@@ -1,8 +1,13 @@
+from __future__ import annotations
+
 from time import time
+from typing import TYPE_CHECKING
 
 from aws_lambda_powertools import Logger, Tracer
 from aws_lambda_powertools.event_handler import BedrockAgentResolver
-from aws_lambda_powertools.utilities.typing import LambdaContext
+
+if TYPE_CHECKING:
+    from aws_lambda_powertools.utilities.typing import LambdaContext
 
 tracer = Tracer()
 logger = Logger()

--- a/examples/event_handler_bedrock_agents/src/getting_started_with_validation.py
+++ b/examples/event_handler_bedrock_agents/src/getting_started_with_validation.py
@@ -1,10 +1,17 @@
-from pydantic import EmailStr
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 from typing_extensions import Annotated
 
 from aws_lambda_powertools import Logger, Tracer
 from aws_lambda_powertools.event_handler import BedrockAgentResolver
-from aws_lambda_powertools.event_handler.openapi.params import Body, Query
-from aws_lambda_powertools.utilities.typing import LambdaContext
+
+if TYPE_CHECKING:
+    from pydantic import EmailStr
+
+    from aws_lambda_powertools.event_handler.openapi.params import Body, Query
+    from aws_lambda_powertools.utilities.typing import LambdaContext
 
 tracer = Tracer()
 logger = Logger()

--- a/examples/event_handler_graphql/src/assert_async_graphql_response.py
+++ b/examples/event_handler_graphql/src/assert_async_graphql_response.py
@@ -1,7 +1,9 @@
+from __future__ import annotations
+
 import json
 from dataclasses import dataclass
 from pathlib import Path
-from typing import List
+from typing import list
 
 import pytest
 from assert_async_graphql_response_module import (  # instance of AppSyncResolver
@@ -28,7 +30,7 @@ async def test_async_direct_resolver(lambda_context):
     fake_event = json.loads(Path("assert_async_graphql_response.json").read_text())
 
     # WHEN
-    result: List[Todo] = await app(fake_event, lambda_context)
+    result: list[Todo] = await app(fake_event, lambda_context)
     # alternatively, you can also run a sync test against `lambda_handler`
     # since `lambda_handler` awaits the coroutine to complete
 

--- a/examples/event_handler_graphql/src/assert_async_graphql_response_module.py
+++ b/examples/event_handler_graphql/src/assert_async_graphql_response_module.py
@@ -1,5 +1,7 @@
+from __future__ import annotations
+
 import asyncio
-from typing import List, TypedDict
+from typing import TYPE_CHECKING, TypedDict
 
 import aiohttp
 
@@ -7,7 +9,9 @@ from aws_lambda_powertools import Logger, Tracer
 from aws_lambda_powertools.event_handler import AppSyncResolver
 from aws_lambda_powertools.logging import correlation_paths
 from aws_lambda_powertools.tracing import aiohttp_trace_config
-from aws_lambda_powertools.utilities.typing import LambdaContext
+
+if TYPE_CHECKING:
+    from aws_lambda_powertools.utilities.typing import LambdaContext
 
 tracer = Tracer()
 logger = Logger()
@@ -22,10 +26,10 @@ class Todo(TypedDict, total=False):
 
 
 @app.resolver(type_name="Query", field_name="listTodos")
-async def list_todos() -> List[Todo]:
+async def list_todos() -> list[Todo]:
     async with aiohttp.ClientSession(trace_configs=[aiohttp_trace_config()]) as session:
         async with session.get("https://jsonplaceholder.typicode.com/todos") as resp:
-            result: List[Todo] = await resp.json()
+            result: list[Todo] = await resp.json()
             return result[:2]  # first two results to demo assertion
 
 

--- a/examples/event_handler_graphql/src/assert_graphql_response_module.py
+++ b/examples/event_handler_graphql/src/assert_graphql_response_module.py
@@ -1,9 +1,13 @@
-from typing import List, TypedDict
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, TypedDict
 
 from aws_lambda_powertools import Logger, Tracer
 from aws_lambda_powertools.event_handler import AppSyncResolver
 from aws_lambda_powertools.logging import correlation_paths
-from aws_lambda_powertools.utilities.typing import LambdaContext
+
+if TYPE_CHECKING:
+    from aws_lambda_powertools.utilities.typing import LambdaContext
 
 tracer = Tracer()
 logger = Logger()
@@ -20,7 +24,7 @@ class Location(TypedDict, total=False):
 @app.resolver(field_name="listLocations")
 @app.resolver(field_name="locations")
 @tracer.capture_method
-def get_locations(name: str, description: str = "") -> List[Location]:  # match GraphQL Query arguments
+def get_locations(name: str, description: str = "") -> list[Location]:  # match GraphQL Query arguments
     return [{"name": name, "description": description}]
 
 

--- a/examples/event_handler_graphql/src/async_resolvers.py
+++ b/examples/event_handler_graphql/src/async_resolvers.py
@@ -1,5 +1,7 @@
+from __future__ import annotations
+
 import asyncio
-from typing import List, TypedDict
+from typing import TYPE_CHECKING, TypedDict
 
 import aiohttp
 
@@ -7,7 +9,9 @@ from aws_lambda_powertools import Logger, Tracer
 from aws_lambda_powertools.event_handler import AppSyncResolver
 from aws_lambda_powertools.logging import correlation_paths
 from aws_lambda_powertools.tracing import aiohttp_trace_config
-from aws_lambda_powertools.utilities.typing import LambdaContext
+
+if TYPE_CHECKING:
+    from aws_lambda_powertools.utilities.typing import LambdaContext
 
 tracer = Tracer()
 logger = Logger()
@@ -22,7 +26,7 @@ class Todo(TypedDict, total=False):
 
 
 @app.resolver(type_name="Query", field_name="listTodos")
-async def list_todos() -> List[Todo]:
+async def list_todos() -> list[Todo]:
     async with aiohttp.ClientSession(trace_configs=[aiohttp_trace_config()]) as session:
         async with session.get("https://jsonplaceholder.typicode.com/todos") as resp:
             return await resp.json()

--- a/examples/event_handler_graphql/src/custom_models.py
+++ b/examples/event_handler_graphql/src/custom_models.py
@@ -1,4 +1,6 @@
-from typing import List, TypedDict
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, TypedDict
 
 from aws_lambda_powertools import Logger, Tracer
 from aws_lambda_powertools.event_handler import AppSyncResolver
@@ -7,7 +9,9 @@ from aws_lambda_powertools.utilities.data_classes.appsync import scalar_types_ut
 from aws_lambda_powertools.utilities.data_classes.appsync_resolver_event import (
     AppSyncResolverEvent,
 )
-from aws_lambda_powertools.utilities.typing import LambdaContext
+
+if TYPE_CHECKING:
+    from aws_lambda_powertools.utilities.typing import LambdaContext
 
 tracer = Tracer()
 logger = Logger()
@@ -33,7 +37,7 @@ class MyCustomModel(AppSyncResolverEvent):
 
 
 @app.resolver(type_name="Query", field_name="listLocations")
-def list_locations(page: int = 0, size: int = 10) -> List[Location]:
+def list_locations(page: int = 0, size: int = 10) -> list[Location]:
     # additional properties/methods will now be available under current_event
     logger.debug(f"Request country origin: {app.current_event.country_viewer}")  # type: ignore[attr-defined]
     return [{"id": scalar_types_utils.make_id(), "name": "Perry, James and Carroll"}]

--- a/examples/event_handler_graphql/src/getting_started_graphql_api_resolver.py
+++ b/examples/event_handler_graphql/src/getting_started_graphql_api_resolver.py
@@ -1,4 +1,6 @@
-from typing import List, TypedDict
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, TypedDict
 
 import requests
 from requests import Response
@@ -7,7 +9,9 @@ from aws_lambda_powertools import Logger, Tracer
 from aws_lambda_powertools.event_handler import AppSyncResolver
 from aws_lambda_powertools.logging import correlation_paths
 from aws_lambda_powertools.utilities.data_classes.appsync import scalar_types_utils
-from aws_lambda_powertools.utilities.typing import LambdaContext
+
+if TYPE_CHECKING:
+    from aws_lambda_powertools.utilities.typing import LambdaContext
 
 tracer = Tracer()
 logger = Logger()
@@ -35,7 +39,7 @@ def get_todo(
 
 @app.resolver(type_name="Query", field_name="listTodos")
 @tracer.capture_method
-def list_todos() -> List[Todo]:
+def list_todos() -> list[Todo]:
     todos: Response = requests.get("https://jsonplaceholder.typicode.com/todos")
     todos.raise_for_status()
 

--- a/examples/event_handler_graphql/src/graphql_transformer_merchant_info.py
+++ b/examples/event_handler_graphql/src/graphql_transformer_merchant_info.py
@@ -1,10 +1,14 @@
-from typing import List, TypedDict
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, TypedDict
 
 from aws_lambda_powertools import Logger, Tracer
 from aws_lambda_powertools.event_handler import AppSyncResolver
 from aws_lambda_powertools.logging import correlation_paths
 from aws_lambda_powertools.utilities.data_classes.appsync import scalar_types_utils
-from aws_lambda_powertools.utilities.typing import LambdaContext
+
+if TYPE_CHECKING:
+    from aws_lambda_powertools.utilities.typing import LambdaContext
 
 tracer = Tracer()
 logger = Logger()
@@ -20,7 +24,7 @@ class Location(TypedDict, total=False):
 
 
 @app.resolver(type_name="Query", field_name="listLocations")
-def list_locations(page: int = 0, size: int = 10) -> List[Location]:
+def list_locations(page: int = 0, size: int = 10) -> list[Location]:
     return [{"id": scalar_types_utils.make_id(), "name": "Smooth Grooves"}]
 
 

--- a/examples/event_handler_graphql/src/graphql_transformer_search_merchant.py
+++ b/examples/event_handler_graphql/src/graphql_transformer_search_merchant.py
@@ -1,10 +1,14 @@
-from typing import List, TypedDict
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, TypedDict
 
 from aws_lambda_powertools import Logger, Tracer
 from aws_lambda_powertools.event_handler import AppSyncResolver
 from aws_lambda_powertools.logging import correlation_paths
 from aws_lambda_powertools.utilities.data_classes.appsync import scalar_types_utils
-from aws_lambda_powertools.utilities.typing import LambdaContext
+
+if TYPE_CHECKING:
+    from aws_lambda_powertools.utilities.typing import LambdaContext
 
 app = AppSyncResolver()
 tracer = Tracer()
@@ -19,8 +23,8 @@ class Merchant(TypedDict, total=False):
 
 
 @app.resolver(type_name="Query", field_name="findMerchant")
-def find_merchant(search: str) -> List[Merchant]:
-    merchants: List[Merchant] = [
+def find_merchant(search: str) -> list[Merchant]:
+    merchants: list[Merchant] = [
         {
             "id": scalar_types_utils.make_id(),
             "name": "Parry-Wood",

--- a/examples/event_handler_graphql/src/nested_mappings.py
+++ b/examples/event_handler_graphql/src/nested_mappings.py
@@ -1,9 +1,13 @@
-from typing import List, TypedDict
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, TypedDict
 
 from aws_lambda_powertools import Logger, Tracer
 from aws_lambda_powertools.event_handler import AppSyncResolver
 from aws_lambda_powertools.logging import correlation_paths
-from aws_lambda_powertools.utilities.typing import LambdaContext
+
+if TYPE_CHECKING:
+    from aws_lambda_powertools.utilities.typing import LambdaContext
 
 tracer = Tracer()
 logger = Logger()
@@ -20,7 +24,7 @@ class Location(TypedDict, total=False):
 @app.resolver(field_name="listLocations")
 @app.resolver(field_name="locations")
 @tracer.capture_method
-def get_locations(name: str, description: str = "") -> List[Location]:  # match GraphQL Query arguments
+def get_locations(name: str, description: str = "") -> list[Location]:  # match GraphQL Query arguments
     return [{"name": name, "description": description}]
 
 

--- a/examples/event_handler_graphql/src/scalar_functions.py
+++ b/examples/event_handler_graphql/src/scalar_functions.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from aws_lambda_powertools.utilities.data_classes.appsync.scalar_types_utils import (
     aws_date,
     aws_datetime,

--- a/examples/event_handler_graphql/src/split_operation.py
+++ b/examples/event_handler_graphql/src/split_operation.py
@@ -1,9 +1,15 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 import split_operation_module
 
 from aws_lambda_powertools import Logger, Tracer
 from aws_lambda_powertools.event_handler import AppSyncResolver
 from aws_lambda_powertools.logging import correlation_paths
-from aws_lambda_powertools.utilities.typing import LambdaContext
+
+if TYPE_CHECKING:
+    from aws_lambda_powertools.utilities.typing import LambdaContext
 
 tracer = Tracer()
 logger = Logger()

--- a/examples/event_handler_graphql/src/split_operation_append_context.py
+++ b/examples/event_handler_graphql/src/split_operation_append_context.py
@@ -1,9 +1,15 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 import split_operation_append_context_module
 
 from aws_lambda_powertools import Logger, Tracer
 from aws_lambda_powertools.event_handler import AppSyncResolver
 from aws_lambda_powertools.logging import correlation_paths
-from aws_lambda_powertools.utilities.typing import LambdaContext
+
+if TYPE_CHECKING:
+    from aws_lambda_powertools.utilities.typing import LambdaContext
 
 tracer = Tracer()
 logger = Logger()

--- a/examples/event_handler_graphql/src/split_operation_append_context_module.py
+++ b/examples/event_handler_graphql/src/split_operation_append_context_module.py
@@ -1,4 +1,6 @@
-from typing import List, TypedDict
+from __future__ import annotations
+
+from typing import TypedDict
 
 from aws_lambda_powertools import Logger, Tracer
 from aws_lambda_powertools.event_handler.appsync import Router
@@ -18,6 +20,6 @@ class Location(TypedDict, total=False):
 @router.resolver(field_name="listLocations")
 @router.resolver(field_name="locations")
 @tracer.capture_method
-def get_locations(name: str, description: str = "") -> List[Location]:  # match GraphQL Query arguments
+def get_locations(name: str, description: str = "") -> list[Location]:  # match GraphQL Query arguments
     is_admin: bool = router.context.get("is_admin", False)
     return [{"name": name, "description": description}] if is_admin else []

--- a/examples/event_handler_graphql/src/split_operation_module.py
+++ b/examples/event_handler_graphql/src/split_operation_module.py
@@ -1,4 +1,6 @@
-from typing import List, TypedDict
+from __future__ import annotations
+
+from typing import TypedDict
 
 from aws_lambda_powertools import Logger, Tracer
 from aws_lambda_powertools.event_handler.appsync import Router
@@ -18,5 +20,5 @@ class Location(TypedDict, total=False):
 @router.resolver(field_name="listLocations")
 @router.resolver(field_name="locations")
 @tracer.capture_method
-def get_locations(name: str, description: str = "") -> List[Location]:  # match GraphQL Query arguments
+def get_locations(name: str, description: str = "") -> list[Location]:  # match GraphQL Query arguments
     return [{"name": name, "description": description}]

--- a/examples/event_handler_lambda_function_url/src/getting_started_lambda_function_url_resolver.py
+++ b/examples/event_handler_lambda_function_url/src/getting_started_lambda_function_url_resolver.py
@@ -1,10 +1,16 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 import requests
 from requests import Response
 
 from aws_lambda_powertools import Logger, Tracer
 from aws_lambda_powertools.event_handler import LambdaFunctionUrlResolver
 from aws_lambda_powertools.logging import correlation_paths
-from aws_lambda_powertools.utilities.typing import LambdaContext
+
+if TYPE_CHECKING:
+    from aws_lambda_powertools.utilities.typing import LambdaContext
 
 tracer = Tracer()
 logger = Logger()

--- a/examples/event_handler_rest/src/accessing_request_details.py
+++ b/examples/event_handler_rest/src/accessing_request_details.py
@@ -1,4 +1,6 @@
-from typing import List, Optional
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
 
 import requests
 from requests import Response
@@ -6,7 +8,9 @@ from requests import Response
 from aws_lambda_powertools import Logger, Tracer
 from aws_lambda_powertools.event_handler import APIGatewayRestResolver
 from aws_lambda_powertools.logging import correlation_paths
-from aws_lambda_powertools.utilities.typing import LambdaContext
+
+if TYPE_CHECKING:
+    from aws_lambda_powertools.utilities.typing import LambdaContext
 
 tracer = Tracer()
 logger = Logger()
@@ -18,13 +22,13 @@ app = APIGatewayRestResolver()
 def get_todos():
     todo_id: str = app.current_event.query_string_parameters["id"]
     # alternatively
-    _: Optional[str] = app.current_event.query_string_parameters.get("id")
+    _: str | None = app.current_event.query_string_parameters.get("id")
 
     # or multi-value query string parameters; ?category="red"&?category="blue"
-    _: List[str] = app.current_event.multi_value_query_string_parameters["category"]
+    _: list[str] = app.current_event.multi_value_query_string_parameters["category"]
 
     # Payload
-    _: Optional[str] = app.current_event.body  # raw str | None
+    _: str | None = app.current_event.body  # raw str | None
 
     endpoint = "https://jsonplaceholder.typicode.com/todos"
     if todo_id:

--- a/examples/event_handler_rest/src/accessing_request_details_headers.py
+++ b/examples/event_handler_rest/src/accessing_request_details_headers.py
@@ -1,10 +1,16 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 import requests
 from requests import Response
 
 from aws_lambda_powertools import Logger, Tracer
 from aws_lambda_powertools.event_handler import APIGatewayRestResolver
 from aws_lambda_powertools.logging import correlation_paths
-from aws_lambda_powertools.utilities.typing import LambdaContext
+
+if TYPE_CHECKING:
+    from aws_lambda_powertools.utilities.typing import LambdaContext
 
 tracer = Tracer()
 logger = Logger()

--- a/examples/event_handler_rest/src/assert_alb_api_resolver_response.py
+++ b/examples/event_handler_rest/src/assert_alb_api_resolver_response.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from dataclasses import dataclass
 
 import assert_alb_api_response_module

--- a/examples/event_handler_rest/src/assert_alb_api_response_module.py
+++ b/examples/event_handler_rest/src/assert_alb_api_response_module.py
@@ -1,10 +1,16 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 import requests
 from requests import Response
 
 from aws_lambda_powertools import Logger, Tracer
 from aws_lambda_powertools.event_handler import ALBResolver
 from aws_lambda_powertools.logging import correlation_paths
-from aws_lambda_powertools.utilities.typing import LambdaContext
+
+if TYPE_CHECKING:
+    from aws_lambda_powertools.utilities.typing import LambdaContext
 
 tracer = Tracer()
 logger = Logger()

--- a/examples/event_handler_rest/src/assert_function_url_api_resolver_response.py
+++ b/examples/event_handler_rest/src/assert_function_url_api_resolver_response.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from dataclasses import dataclass
 
 import assert_function_url_api_response_module

--- a/examples/event_handler_rest/src/assert_function_url_api_response_module.py
+++ b/examples/event_handler_rest/src/assert_function_url_api_response_module.py
@@ -1,10 +1,16 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 import requests
 from requests import Response
 
 from aws_lambda_powertools import Logger, Tracer
 from aws_lambda_powertools.event_handler import LambdaFunctionUrlResolver
 from aws_lambda_powertools.logging import correlation_paths
-from aws_lambda_powertools.utilities.typing import LambdaContext
+
+if TYPE_CHECKING:
+    from aws_lambda_powertools.utilities.typing import LambdaContext
 
 tracer = Tracer()
 logger = Logger()

--- a/examples/event_handler_rest/src/assert_http_api_resolver_response.py
+++ b/examples/event_handler_rest/src/assert_http_api_resolver_response.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from dataclasses import dataclass
 
 import assert_http_api_response_module

--- a/examples/event_handler_rest/src/assert_http_api_response_module.py
+++ b/examples/event_handler_rest/src/assert_http_api_response_module.py
@@ -1,10 +1,16 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 import requests
 from requests import Response
 
 from aws_lambda_powertools import Logger, Tracer
 from aws_lambda_powertools.event_handler import APIGatewayHttpResolver
 from aws_lambda_powertools.logging import correlation_paths
-from aws_lambda_powertools.utilities.typing import LambdaContext
+
+if TYPE_CHECKING:
+    from aws_lambda_powertools.utilities.typing import LambdaContext
 
 tracer = Tracer()
 logger = Logger()

--- a/examples/event_handler_rest/src/assert_rest_api_resolver_response.py
+++ b/examples/event_handler_rest/src/assert_rest_api_resolver_response.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from dataclasses import dataclass
 
 import assert_rest_api_resolver_response

--- a/examples/event_handler_rest/src/assert_rest_api_response_module.py
+++ b/examples/event_handler_rest/src/assert_rest_api_response_module.py
@@ -1,10 +1,16 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 import requests
 from requests import Response
 
 from aws_lambda_powertools import Logger, Tracer
 from aws_lambda_powertools.event_handler import APIGatewayRestResolver
 from aws_lambda_powertools.logging import correlation_paths
-from aws_lambda_powertools.utilities.typing import LambdaContext
+
+if TYPE_CHECKING:
+    from aws_lambda_powertools.utilities.typing import LambdaContext
 
 tracer = Tracer()
 logger = Logger()

--- a/examples/event_handler_rest/src/binary_responses.py
+++ b/examples/event_handler_rest/src/binary_responses.py
@@ -1,5 +1,8 @@
+from __future__ import annotations
+
 import os
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 from aws_lambda_powertools import Logger, Tracer
 from aws_lambda_powertools.event_handler.api_gateway import (
@@ -7,7 +10,9 @@ from aws_lambda_powertools.event_handler.api_gateway import (
     Response,
 )
 from aws_lambda_powertools.logging import correlation_paths
-from aws_lambda_powertools.utilities.typing import LambdaContext
+
+if TYPE_CHECKING:
+    from aws_lambda_powertools.utilities.typing import LambdaContext
 
 tracer = Tracer()
 logger = Logger()

--- a/examples/event_handler_rest/src/compressing_responses_using_response.py
+++ b/examples/event_handler_rest/src/compressing_responses_using_response.py
@@ -1,3 +1,7 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 import requests
 
 from aws_lambda_powertools import Logger, Tracer
@@ -7,7 +11,9 @@ from aws_lambda_powertools.event_handler import (
     content_types,
 )
 from aws_lambda_powertools.logging import correlation_paths
-from aws_lambda_powertools.utilities.typing import LambdaContext
+
+if TYPE_CHECKING:
+    from aws_lambda_powertools.utilities.typing import LambdaContext
 
 tracer = Tracer()
 logger = Logger()

--- a/examples/event_handler_rest/src/compressing_responses_using_route.py
+++ b/examples/event_handler_rest/src/compressing_responses_using_route.py
@@ -1,3 +1,7 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 import requests
 
 from aws_lambda_powertools import Logger, Tracer
@@ -7,7 +11,9 @@ from aws_lambda_powertools.event_handler import (
     content_types,
 )
 from aws_lambda_powertools.logging import correlation_paths
-from aws_lambda_powertools.utilities.typing import LambdaContext
+
+if TYPE_CHECKING:
+    from aws_lambda_powertools.utilities.typing import LambdaContext
 
 tracer = Tracer()
 logger = Logger()

--- a/examples/event_handler_rest/src/custom_api_mapping.py
+++ b/examples/event_handler_rest/src/custom_api_mapping.py
@@ -1,7 +1,13 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 from aws_lambda_powertools import Logger, Tracer
 from aws_lambda_powertools.event_handler import APIGatewayRestResolver
 from aws_lambda_powertools.logging import correlation_paths
-from aws_lambda_powertools.utilities.typing import LambdaContext
+
+if TYPE_CHECKING:
+    from aws_lambda_powertools.utilities.typing import LambdaContext
 
 tracer = Tracer()
 logger = Logger()

--- a/examples/event_handler_rest/src/custom_serializer.py
+++ b/examples/event_handler_rest/src/custom_serializer.py
@@ -1,6 +1,9 @@
+from __future__ import annotations
+
 import json
 from dataclasses import asdict, dataclass, is_dataclass
 from json import JSONEncoder
+from typing import TYPE_CHECKING
 
 import requests
 from requests import Response
@@ -8,7 +11,9 @@ from requests import Response
 from aws_lambda_powertools import Logger, Tracer
 from aws_lambda_powertools.event_handler import APIGatewayRestResolver
 from aws_lambda_powertools.logging import correlation_paths
-from aws_lambda_powertools.utilities.typing import LambdaContext
+
+if TYPE_CHECKING:
+    from aws_lambda_powertools.utilities.typing import LambdaContext
 
 tracer = Tracer()
 logger = Logger()

--- a/examples/event_handler_rest/src/customizing_api_metadata.py
+++ b/examples/event_handler_rest/src/customizing_api_metadata.py
@@ -1,8 +1,14 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 import requests
 
 from aws_lambda_powertools.event_handler import APIGatewayRestResolver
 from aws_lambda_powertools.event_handler.openapi.models import Contact, Server
-from aws_lambda_powertools.utilities.typing import LambdaContext
+
+if TYPE_CHECKING:
+    from aws_lambda_powertools.utilities.typing import LambdaContext
 
 app = APIGatewayRestResolver(enable_validation=True)
 

--- a/examples/event_handler_rest/src/customizing_api_operations.py
+++ b/examples/event_handler_rest/src/customizing_api_operations.py
@@ -1,7 +1,13 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 import requests
 
 from aws_lambda_powertools.event_handler import APIGatewayRestResolver
-from aws_lambda_powertools.utilities.typing import LambdaContext
+
+if TYPE_CHECKING:
+    from aws_lambda_powertools.utilities.typing import LambdaContext
 
 app = APIGatewayRestResolver(enable_validation=True)
 

--- a/examples/event_handler_rest/src/customizing_swagger.py
+++ b/examples/event_handler_rest/src/customizing_swagger.py
@@ -1,10 +1,14 @@
-from typing import List
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
 
 import requests
 from pydantic import BaseModel, EmailStr, Field
 
 from aws_lambda_powertools.event_handler import APIGatewayRestResolver
-from aws_lambda_powertools.utilities.typing import LambdaContext
+
+if TYPE_CHECKING:
+    from aws_lambda_powertools.utilities.typing import LambdaContext
 
 app = APIGatewayRestResolver(enable_validation=True)
 app.enable_swagger(path="/_swagger", swagger_base_url="https://cdn.example.com/path/to/assets/")
@@ -18,7 +22,7 @@ class Todo(BaseModel):
 
 
 @app.get("/todos")
-def get_todos_by_email(email: EmailStr) -> List[Todo]:
+def get_todos_by_email(email: EmailStr) -> list[Todo]:
     todos = requests.get(f"https://jsonplaceholder.typicode.com/todos?email={email}")
     todos.raise_for_status()
 

--- a/examples/event_handler_rest/src/customizing_swagger_middlewares.py
+++ b/examples/event_handler_rest/src/customizing_swagger_middlewares.py
@@ -1,11 +1,15 @@
-from typing import List
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
 
 import requests
 from pydantic import BaseModel, EmailStr, Field
 
 from aws_lambda_powertools.event_handler import APIGatewayRestResolver, Response
-from aws_lambda_powertools.event_handler.middlewares import NextMiddleware
-from aws_lambda_powertools.utilities.typing import LambdaContext
+
+if TYPE_CHECKING:
+    from aws_lambda_powertools.event_handler.middlewares import NextMiddleware
+    from aws_lambda_powertools.utilities.typing import LambdaContext
 
 app = APIGatewayRestResolver(enable_validation=True)
 
@@ -29,7 +33,7 @@ class Todo(BaseModel):
 
 
 @app.get("/todos")
-def get_todos_by_email(email: EmailStr) -> List[Todo]:
+def get_todos_by_email(email: EmailStr) -> list[Todo]:
     todos = requests.get(f"https://jsonplaceholder.typicode.com/todos?email={email}")
     todos.raise_for_status()
 

--- a/examples/event_handler_rest/src/data_validation.py
+++ b/examples/event_handler_rest/src/data_validation.py
@@ -1,4 +1,6 @@
-from typing import Optional
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
 
 import requests
 from pydantic import BaseModel, Field
@@ -6,7 +8,9 @@ from pydantic import BaseModel, Field
 from aws_lambda_powertools import Logger, Tracer
 from aws_lambda_powertools.event_handler import APIGatewayRestResolver
 from aws_lambda_powertools.logging import correlation_paths
-from aws_lambda_powertools.utilities.typing import LambdaContext
+
+if TYPE_CHECKING:
+    from aws_lambda_powertools.utilities.typing import LambdaContext
 
 tracer = Tracer()
 logger = Logger()
@@ -15,7 +19,7 @@ app = APIGatewayRestResolver(enable_validation=True)  # (1)!
 
 class Todo(BaseModel):  # (2)!
     userId: int
-    id_: Optional[int] = Field(alias="id", default=None)
+    id_: int | None = Field(alias="id", default=None)
     title: str
     completed: bool
 

--- a/examples/event_handler_rest/src/data_validation_fine_grained_response.py
+++ b/examples/event_handler_rest/src/data_validation_fine_grained_response.py
@@ -1,5 +1,7 @@
+from __future__ import annotations
+
 from http import HTTPStatus
-from typing import Optional
+from typing import TYPE_CHECKING
 
 import requests
 from pydantic import BaseModel, Field
@@ -7,7 +9,9 @@ from pydantic import BaseModel, Field
 from aws_lambda_powertools import Logger, Tracer
 from aws_lambda_powertools.event_handler import APIGatewayRestResolver, Response, content_types
 from aws_lambda_powertools.logging import correlation_paths
-from aws_lambda_powertools.utilities.typing import LambdaContext
+
+if TYPE_CHECKING:
+    from aws_lambda_powertools.utilities.typing import LambdaContext
 
 tracer = Tracer()
 logger = Logger()
@@ -16,7 +20,7 @@ app = APIGatewayRestResolver(enable_validation=True)
 
 class Todo(BaseModel):
     userId: int
-    id_: Optional[int] = Field(alias="id", default=None)
+    id_: int | None = Field(alias="id", default=None)
     title: str
     completed: bool
 

--- a/examples/event_handler_rest/src/data_validation_sanitized_error.py
+++ b/examples/event_handler_rest/src/data_validation_sanitized_error.py
@@ -1,4 +1,6 @@
-from typing import Optional
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
 
 import requests
 from pydantic import BaseModel, Field
@@ -7,7 +9,9 @@ from aws_lambda_powertools import Logger, Tracer
 from aws_lambda_powertools.event_handler import APIGatewayRestResolver, Response, content_types
 from aws_lambda_powertools.event_handler.openapi.exceptions import RequestValidationError
 from aws_lambda_powertools.logging import correlation_paths
-from aws_lambda_powertools.utilities.typing import LambdaContext
+
+if TYPE_CHECKING:
+    from aws_lambda_powertools.utilities.typing import LambdaContext
 
 tracer = Tracer()
 logger = Logger()
@@ -16,7 +20,7 @@ app = APIGatewayRestResolver(enable_validation=True)
 
 class Todo(BaseModel):
     userId: int
-    id_: Optional[int] = Field(alias="id", default=None)
+    id_: int | None = Field(alias="id", default=None)
     title: str
     completed: bool
 

--- a/examples/event_handler_rest/src/debug_mode.py
+++ b/examples/event_handler_rest/src/debug_mode.py
@@ -1,10 +1,16 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 import requests
 from requests import Response
 
 from aws_lambda_powertools import Logger, Tracer
 from aws_lambda_powertools.event_handler import APIGatewayRestResolver
 from aws_lambda_powertools.logging import correlation_paths
-from aws_lambda_powertools.utilities.typing import LambdaContext
+
+if TYPE_CHECKING:
+    from aws_lambda_powertools.utilities.typing import LambdaContext
 
 tracer = Tracer()
 logger = Logger()

--- a/examples/event_handler_rest/src/dynamic_routes.py
+++ b/examples/event_handler_rest/src/dynamic_routes.py
@@ -1,10 +1,16 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 import requests
 from requests import Response
 
 from aws_lambda_powertools import Logger, Tracer
 from aws_lambda_powertools.event_handler import APIGatewayRestResolver
 from aws_lambda_powertools.logging import correlation_paths
-from aws_lambda_powertools.utilities.typing import LambdaContext
+
+if TYPE_CHECKING:
+    from aws_lambda_powertools.utilities.typing import LambdaContext
 
 tracer = Tracer()
 logger = Logger()

--- a/examples/event_handler_rest/src/dynamic_routes_catch_all.py
+++ b/examples/event_handler_rest/src/dynamic_routes_catch_all.py
@@ -1,7 +1,13 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 from aws_lambda_powertools import Logger, Tracer
 from aws_lambda_powertools.event_handler import APIGatewayRestResolver
 from aws_lambda_powertools.logging import correlation_paths
-from aws_lambda_powertools.utilities.typing import LambdaContext
+
+if TYPE_CHECKING:
+    from aws_lambda_powertools.utilities.typing import LambdaContext
 
 tracer = Tracer()
 logger = Logger()

--- a/examples/event_handler_rest/src/enabling_swagger.py
+++ b/examples/event_handler_rest/src/enabling_swagger.py
@@ -1,11 +1,15 @@
-from typing import List
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
 
 import requests
 from pydantic import BaseModel, Field
 
 from aws_lambda_powertools import Logger, Tracer
 from aws_lambda_powertools.event_handler import APIGatewayRestResolver
-from aws_lambda_powertools.utilities.typing import LambdaContext
+
+if TYPE_CHECKING:
+    from aws_lambda_powertools.utilities.typing import LambdaContext
 
 tracer = Tracer()
 logger = Logger()
@@ -29,7 +33,7 @@ def create_todo(todo: Todo) -> str:
 
 
 @app.get("/todos")
-def get_todos() -> List[Todo]:
+def get_todos() -> list[Todo]:
     todo = requests.get("https://jsonplaceholder.typicode.com/todos")
     todo.raise_for_status()
 

--- a/examples/event_handler_rest/src/exception_handling.py
+++ b/examples/event_handler_rest/src/exception_handling.py
@@ -1,3 +1,7 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 import requests
 
 from aws_lambda_powertools import Logger, Tracer
@@ -7,7 +11,9 @@ from aws_lambda_powertools.event_handler import (
     content_types,
 )
 from aws_lambda_powertools.logging import correlation_paths
-from aws_lambda_powertools.utilities.typing import LambdaContext
+
+if TYPE_CHECKING:
+    from aws_lambda_powertools.utilities.typing import LambdaContext
 
 tracer = Tracer()
 logger = Logger()

--- a/examples/event_handler_rest/src/fine_grained_responses.py
+++ b/examples/event_handler_rest/src/fine_grained_responses.py
@@ -1,4 +1,7 @@
+from __future__ import annotations
+
 from http import HTTPStatus
+from typing import TYPE_CHECKING
 from uuid import uuid4
 
 import requests
@@ -11,7 +14,9 @@ from aws_lambda_powertools.event_handler import (
 )
 from aws_lambda_powertools.logging import correlation_paths
 from aws_lambda_powertools.shared.cookies import Cookie
-from aws_lambda_powertools.utilities.typing import LambdaContext
+
+if TYPE_CHECKING:
+    from aws_lambda_powertools.utilities.typing import LambdaContext
 
 tracer = Tracer()
 logger = Logger()

--- a/examples/event_handler_rest/src/getting_started_alb_api_resolver.py
+++ b/examples/event_handler_rest/src/getting_started_alb_api_resolver.py
@@ -1,10 +1,16 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 import requests
 from requests import Response
 
 from aws_lambda_powertools import Logger, Tracer
 from aws_lambda_powertools.event_handler import ALBResolver
 from aws_lambda_powertools.logging import correlation_paths
-from aws_lambda_powertools.utilities.typing import LambdaContext
+
+if TYPE_CHECKING:
+    from aws_lambda_powertools.utilities.typing import LambdaContext
 
 tracer = Tracer()
 logger = Logger()

--- a/examples/event_handler_rest/src/getting_started_http_api_resolver.py
+++ b/examples/event_handler_rest/src/getting_started_http_api_resolver.py
@@ -1,10 +1,16 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 import requests
 from requests import Response
 
 from aws_lambda_powertools import Logger, Tracer
 from aws_lambda_powertools.event_handler import APIGatewayHttpResolver
 from aws_lambda_powertools.logging import correlation_paths
-from aws_lambda_powertools.utilities.typing import LambdaContext
+
+if TYPE_CHECKING:
+    from aws_lambda_powertools.utilities.typing import LambdaContext
 
 tracer = Tracer()
 logger = Logger()

--- a/examples/event_handler_rest/src/getting_started_rest_api_resolver.py
+++ b/examples/event_handler_rest/src/getting_started_rest_api_resolver.py
@@ -1,10 +1,16 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 import requests
 from requests import Response
 
 from aws_lambda_powertools import Logger, Tracer
 from aws_lambda_powertools.event_handler import APIGatewayRestResolver
 from aws_lambda_powertools.logging import correlation_paths
-from aws_lambda_powertools.utilities.typing import LambdaContext
+
+if TYPE_CHECKING:
+    from aws_lambda_powertools.utilities.typing import LambdaContext
 
 tracer = Tracer()
 logger = Logger()

--- a/examples/event_handler_rest/src/getting_started_return_tuple.py
+++ b/examples/event_handler_rest/src/getting_started_return_tuple.py
@@ -1,8 +1,14 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 import requests
 from requests import Response
 
 from aws_lambda_powertools.event_handler import ALBResolver
-from aws_lambda_powertools.utilities.typing import LambdaContext
+
+if TYPE_CHECKING:
+    from aws_lambda_powertools.utilities.typing import LambdaContext
 
 app = ALBResolver()
 

--- a/examples/event_handler_rest/src/getting_started_vpclattice_resolver.py
+++ b/examples/event_handler_rest/src/getting_started_vpclattice_resolver.py
@@ -1,10 +1,16 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 import requests
 from requests import Response
 
 from aws_lambda_powertools import Logger, Tracer
 from aws_lambda_powertools.event_handler import VPCLatticeResolver
 from aws_lambda_powertools.logging import correlation_paths
-from aws_lambda_powertools.utilities.typing import LambdaContext
+
+if TYPE_CHECKING:
+    from aws_lambda_powertools.utilities.typing import LambdaContext
 
 tracer = Tracer()
 logger = Logger()

--- a/examples/event_handler_rest/src/getting_started_vpclatticev2_resolver.py
+++ b/examples/event_handler_rest/src/getting_started_vpclatticev2_resolver.py
@@ -1,10 +1,16 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 import requests
 from requests import Response
 
 from aws_lambda_powertools import Logger, Tracer
 from aws_lambda_powertools.event_handler import VPCLatticeV2Resolver
 from aws_lambda_powertools.logging import correlation_paths
-from aws_lambda_powertools.utilities.typing import LambdaContext
+
+if TYPE_CHECKING:
+    from aws_lambda_powertools.utilities.typing import LambdaContext
 
 tracer = Tracer()
 logger = Logger()

--- a/examples/event_handler_rest/src/http_methods.py
+++ b/examples/event_handler_rest/src/http_methods.py
@@ -1,10 +1,16 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 import requests
 from requests import Response
 
 from aws_lambda_powertools import Logger, Tracer
 from aws_lambda_powertools.event_handler import APIGatewayRestResolver
 from aws_lambda_powertools.logging import correlation_paths
-from aws_lambda_powertools.utilities.typing import LambdaContext
+
+if TYPE_CHECKING:
+    from aws_lambda_powertools.utilities.typing import LambdaContext
 
 tracer = Tracer()
 logger = Logger()

--- a/examples/event_handler_rest/src/http_methods_multiple.py
+++ b/examples/event_handler_rest/src/http_methods_multiple.py
@@ -1,10 +1,16 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 import requests
 from requests import Response
 
 from aws_lambda_powertools import Logger, Tracer
 from aws_lambda_powertools.event_handler import APIGatewayRestResolver
 from aws_lambda_powertools.logging import correlation_paths
-from aws_lambda_powertools.utilities.typing import LambdaContext
+
+if TYPE_CHECKING:
+    from aws_lambda_powertools.utilities.typing import LambdaContext
 
 tracer = Tracer()
 logger = Logger()

--- a/examples/event_handler_rest/src/micro_function_all_users_route.py
+++ b/examples/event_handler_rest/src/micro_function_all_users_route.py
@@ -1,10 +1,15 @@
+from __future__ import annotations
+
 import json
 from dataclasses import dataclass
 from http import HTTPStatus
+from typing import TYPE_CHECKING
 
 from aws_lambda_powertools import Logger
 from aws_lambda_powertools.event_handler import APIGatewayRestResolver, Response
-from aws_lambda_powertools.utilities.typing import LambdaContext
+
+if TYPE_CHECKING:
+    from aws_lambda_powertools.utilities.typing import LambdaContext
 
 logger = Logger()
 

--- a/examples/event_handler_rest/src/micro_function_user_by_id_route.py
+++ b/examples/event_handler_rest/src/micro_function_user_by_id_route.py
@@ -1,11 +1,15 @@
+from __future__ import annotations
+
 import json
 from dataclasses import dataclass
 from http import HTTPStatus
-from typing import Union
+from typing import TYPE_CHECKING
 
 from aws_lambda_powertools import Logger
 from aws_lambda_powertools.event_handler import APIGatewayRestResolver, Response
-from aws_lambda_powertools.utilities.typing import LambdaContext
+
+if TYPE_CHECKING:
+    from aws_lambda_powertools.utilities.typing import LambdaContext
 
 logger = Logger()
 
@@ -36,7 +40,7 @@ class User:
     active: bool
 
 
-def get_user_by_id(user_id: str) -> Union[User, None]:
+def get_user_by_id(user_id: str) -> User | None:
     for user_data in users:
         if user_data["user_id"] == user_id:
             return User(

--- a/examples/event_handler_rest/src/middleware_early_return.py
+++ b/examples/event_handler_rest/src/middleware_early_return.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import middleware_global_middlewares_module
 import requests
 

--- a/examples/event_handler_rest/src/middleware_extending_middlewares.py
+++ b/examples/event_handler_rest/src/middleware_extending_middlewares.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import requests
 
 from aws_lambda_powertools import Logger

--- a/examples/event_handler_rest/src/middleware_getting_started.py
+++ b/examples/event_handler_rest/src/middleware_getting_started.py
@@ -1,8 +1,14 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 import requests
 
 from aws_lambda_powertools import Logger
 from aws_lambda_powertools.event_handler import APIGatewayRestResolver, Response
-from aws_lambda_powertools.event_handler.middlewares import NextMiddleware
+
+if TYPE_CHECKING:
+    from aws_lambda_powertools.event_handler.middlewares import NextMiddleware
 
 app = APIGatewayRestResolver()
 logger = Logger()

--- a/examples/event_handler_rest/src/middleware_global_middlewares.py
+++ b/examples/event_handler_rest/src/middleware_global_middlewares.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import middleware_global_middlewares_module  # (1)!
 import requests
 

--- a/examples/event_handler_rest/src/middleware_global_middlewares_module.py
+++ b/examples/event_handler_rest/src/middleware_global_middlewares_module.py
@@ -1,6 +1,12 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 from aws_lambda_powertools import Logger
 from aws_lambda_powertools.event_handler import APIGatewayRestResolver, Response
-from aws_lambda_powertools.event_handler.middlewares import NextMiddleware
+
+if TYPE_CHECKING:
+    from aws_lambda_powertools.event_handler.middlewares import NextMiddleware
 
 logger = Logger()
 

--- a/examples/event_handler_rest/src/not_found_routes.py
+++ b/examples/event_handler_rest/src/not_found_routes.py
@@ -1,3 +1,7 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 import requests
 
 from aws_lambda_powertools import Logger, Tracer
@@ -6,9 +10,11 @@ from aws_lambda_powertools.event_handler import (
     Response,
     content_types,
 )
-from aws_lambda_powertools.event_handler.exceptions import NotFoundError
 from aws_lambda_powertools.logging import correlation_paths
-from aws_lambda_powertools.utilities.typing import LambdaContext
+
+if TYPE_CHECKING:
+    from aws_lambda_powertools.event_handler.exceptions import NotFoundError
+    from aws_lambda_powertools.utilities.typing import LambdaContext
 
 tracer = Tracer()
 logger = Logger()

--- a/examples/event_handler_rest/src/raising_http_errors.py
+++ b/examples/event_handler_rest/src/raising_http_errors.py
@@ -1,3 +1,7 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 import requests
 from requests import Response
 
@@ -11,7 +15,9 @@ from aws_lambda_powertools.event_handler.exceptions import (
     UnauthorizedError,
 )
 from aws_lambda_powertools.logging import correlation_paths
-from aws_lambda_powertools.utilities.typing import LambdaContext
+
+if TYPE_CHECKING:
+    from aws_lambda_powertools.utilities.typing import LambdaContext
 
 tracer = Tracer()
 logger = Logger()

--- a/examples/event_handler_rest/src/security_schemes_global.py
+++ b/examples/event_handler_rest/src/security_schemes_global.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from aws_lambda_powertools import Logger, Tracer
 from aws_lambda_powertools.event_handler import (
     APIGatewayRestResolver,

--- a/examples/event_handler_rest/src/security_schemes_per_operation.py
+++ b/examples/event_handler_rest/src/security_schemes_per_operation.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from aws_lambda_powertools import Logger, Tracer
 from aws_lambda_powertools.event_handler import (
     APIGatewayRestResolver,

--- a/examples/event_handler_rest/src/setting_cors.py
+++ b/examples/event_handler_rest/src/setting_cors.py
@@ -1,10 +1,16 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 import requests
 from requests import Response
 
 from aws_lambda_powertools import Logger, Tracer
 from aws_lambda_powertools.event_handler import APIGatewayRestResolver, CORSConfig
 from aws_lambda_powertools.logging import correlation_paths
-from aws_lambda_powertools.utilities.typing import LambdaContext
+
+if TYPE_CHECKING:
+    from aws_lambda_powertools.utilities.typing import LambdaContext
 
 tracer = Tracer()
 logger = Logger()

--- a/examples/event_handler_rest/src/setting_cors_extra_origins.py
+++ b/examples/event_handler_rest/src/setting_cors_extra_origins.py
@@ -1,10 +1,16 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 import requests
 from requests import Response
 
 from aws_lambda_powertools import Logger, Tracer
 from aws_lambda_powertools.event_handler import APIGatewayRestResolver, CORSConfig
 from aws_lambda_powertools.logging import correlation_paths
-from aws_lambda_powertools.utilities.typing import LambdaContext
+
+if TYPE_CHECKING:
+    from aws_lambda_powertools.utilities.typing import LambdaContext
 
 tracer = Tracer()
 logger = Logger()

--- a/examples/event_handler_rest/src/skip_validating_query_strings.py
+++ b/examples/event_handler_rest/src/skip_validating_query_strings.py
@@ -1,4 +1,6 @@
-from typing import List, Optional
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
 
 import requests
 from pydantic import BaseModel, Field
@@ -6,7 +8,9 @@ from pydantic import BaseModel, Field
 from aws_lambda_powertools import Logger, Tracer
 from aws_lambda_powertools.event_handler import APIGatewayRestResolver
 from aws_lambda_powertools.logging import correlation_paths
-from aws_lambda_powertools.utilities.typing import LambdaContext
+
+if TYPE_CHECKING:
+    from aws_lambda_powertools.utilities.typing import LambdaContext
 
 tracer = Tracer()
 logger = Logger()
@@ -15,14 +19,14 @@ app = APIGatewayRestResolver(enable_validation=True)
 
 class Todo(BaseModel):
     userId: int
-    id_: Optional[int] = Field(alias="id", default=None)
+    id_: int | None = Field(alias="id", default=None)
     title: str
     completed: bool
 
 
 @app.get("/todos")
 @tracer.capture_method
-def get_todos(completed: Optional[str] = None) -> List[Todo]:  # (1)!
+def get_todos(completed: str | None = None) -> list[Todo]:  # (1)!
     url = "https://jsonplaceholder.typicode.com/todos"
 
     if completed is not None:

--- a/examples/event_handler_rest/src/split_route.py
+++ b/examples/event_handler_rest/src/split_route.py
@@ -1,9 +1,15 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 import split_route_module
 
 from aws_lambda_powertools import Logger, Tracer
 from aws_lambda_powertools.event_handler import APIGatewayRestResolver
 from aws_lambda_powertools.logging import correlation_paths
-from aws_lambda_powertools.utilities.typing import LambdaContext
+
+if TYPE_CHECKING:
+    from aws_lambda_powertools.utilities.typing import LambdaContext
 
 tracer = Tracer()
 logger = Logger()

--- a/examples/event_handler_rest/src/split_route_append_context.py
+++ b/examples/event_handler_rest/src/split_route_append_context.py
@@ -1,9 +1,15 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 import split_route_append_context_module
 
 from aws_lambda_powertools import Logger, Tracer
 from aws_lambda_powertools.event_handler import APIGatewayRestResolver
 from aws_lambda_powertools.logging import correlation_paths
-from aws_lambda_powertools.utilities.typing import LambdaContext
+
+if TYPE_CHECKING:
+    from aws_lambda_powertools.utilities.typing import LambdaContext
 
 tracer = Tracer()
 logger = Logger()

--- a/examples/event_handler_rest/src/split_route_append_context_module.py
+++ b/examples/event_handler_rest/src/split_route_append_context_module.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import requests
 from requests import Response
 

--- a/examples/event_handler_rest/src/split_route_module.py
+++ b/examples/event_handler_rest/src/split_route_module.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import requests
 from requests import Response
 

--- a/examples/event_handler_rest/src/split_route_prefix.py
+++ b/examples/event_handler_rest/src/split_route_prefix.py
@@ -1,9 +1,15 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 import split_route_module
 
 from aws_lambda_powertools import Logger, Tracer
 from aws_lambda_powertools.event_handler import APIGatewayRestResolver
 from aws_lambda_powertools.logging import correlation_paths
-from aws_lambda_powertools.utilities.typing import LambdaContext
+
+if TYPE_CHECKING:
+    from aws_lambda_powertools.utilities.typing import LambdaContext
 
 tracer = Tracer()
 logger = Logger()

--- a/examples/event_handler_rest/src/split_route_prefix_module.py
+++ b/examples/event_handler_rest/src/split_route_prefix_module.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import requests
 from requests import Response
 

--- a/examples/event_handler_rest/src/split_route_specialized_router.py
+++ b/examples/event_handler_rest/src/split_route_specialized_router.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from aws_lambda_powertools.event_handler import APIGatewayRestResolver
 from aws_lambda_powertools.event_handler.router import APIGatewayRouter
 

--- a/examples/event_handler_rest/src/strip_route_prefix_regex.py
+++ b/examples/event_handler_rest/src/strip_route_prefix_regex.py
@@ -1,7 +1,12 @@
+from __future__ import annotations
+
 import re
+from typing import TYPE_CHECKING
 
 from aws_lambda_powertools.event_handler import APIGatewayRestResolver
-from aws_lambda_powertools.utilities.typing import LambdaContext
+
+if TYPE_CHECKING:
+    from aws_lambda_powertools.utilities.typing import LambdaContext
 
 # This will support:
 # /v1/dev/subscriptions/<subscription>

--- a/examples/event_handler_rest/src/swagger_ui_oauth2.py
+++ b/examples/event_handler_rest/src/swagger_ui_oauth2.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import os
 
 from aws_lambda_powertools import Logger, Tracer

--- a/examples/event_handler_rest/src/swagger_with_oauth2.py
+++ b/examples/event_handler_rest/src/swagger_with_oauth2.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from aws_lambda_powertools import Logger, Tracer
 from aws_lambda_powertools.event_handler import (
     APIGatewayRestResolver,

--- a/examples/event_handler_rest/src/validating_headers.py
+++ b/examples/event_handler_rest/src/validating_headers.py
@@ -1,4 +1,6 @@
-from typing import List, Optional
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
 
 import requests
 from pydantic import BaseModel, Field
@@ -6,9 +8,11 @@ from typing_extensions import Annotated  # (1)!
 
 from aws_lambda_powertools import Logger, Tracer
 from aws_lambda_powertools.event_handler import APIGatewayRestResolver
-from aws_lambda_powertools.event_handler.openapi.params import Header  # (2)!
 from aws_lambda_powertools.logging import correlation_paths
-from aws_lambda_powertools.utilities.typing import LambdaContext
+
+if TYPE_CHECKING:
+    from aws_lambda_powertools.event_handler.openapi.params import Header  # (2)!
+    from aws_lambda_powertools.utilities.typing import LambdaContext
 
 tracer = Tracer()
 logger = Logger()
@@ -17,14 +21,14 @@ app = APIGatewayRestResolver(enable_validation=True)
 
 class Todo(BaseModel):
     userId: int
-    id_: Optional[int] = Field(alias="id", default=None)
+    id_: int | None = Field(alias="id", default=None)
     title: str
     completed: bool
 
 
 @app.get("/todos")
 @tracer.capture_method
-def get_todos(correlation_id: Annotated[str, Header(min_length=16, max_length=16)]) -> List[Todo]:  # (3)!
+def get_todos(correlation_id: Annotated[str, Header(min_length=16, max_length=16)]) -> list[Todo]:  # (3)!
     url = "https://jsonplaceholder.typicode.com/todos"
 
     todo = requests.get(url, headers={"correlation_id": correlation_id})

--- a/examples/event_handler_rest/src/validating_path.py
+++ b/examples/event_handler_rest/src/validating_path.py
@@ -1,4 +1,6 @@
-from typing import Optional
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
 
 import requests
 from pydantic import BaseModel, Field
@@ -6,9 +8,11 @@ from typing_extensions import Annotated
 
 from aws_lambda_powertools import Logger, Tracer
 from aws_lambda_powertools.event_handler import APIGatewayRestResolver
-from aws_lambda_powertools.event_handler.openapi.params import Path
 from aws_lambda_powertools.logging import correlation_paths
-from aws_lambda_powertools.utilities.typing import LambdaContext
+
+if TYPE_CHECKING:
+    from aws_lambda_powertools.event_handler.openapi.params import Path
+    from aws_lambda_powertools.utilities.typing import LambdaContext
 
 tracer = Tracer()
 logger = Logger()
@@ -17,7 +21,7 @@ app = APIGatewayRestResolver(enable_validation=True)
 
 class Todo(BaseModel):
     userId: int
-    id_: Optional[int] = Field(alias="id", default=None)
+    id_: int | None = Field(alias="id", default=None)
     title: str
     completed: bool
 

--- a/examples/event_handler_rest/src/validating_payload_subset.py
+++ b/examples/event_handler_rest/src/validating_payload_subset.py
@@ -1,19 +1,23 @@
-from typing import Optional
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
 
 import requests
 from pydantic import BaseModel, Field
 from typing_extensions import Annotated
 
 from aws_lambda_powertools.event_handler import APIGatewayRestResolver
-from aws_lambda_powertools.event_handler.openapi.params import Body  # (1)!
-from aws_lambda_powertools.utilities.typing import LambdaContext
+
+if TYPE_CHECKING:
+    from aws_lambda_powertools.event_handler.openapi.params import Body  # (1)!
+    from aws_lambda_powertools.utilities.typing import LambdaContext
 
 app = APIGatewayRestResolver(enable_validation=True)
 
 
 class Todo(BaseModel):
     userId: int
-    id_: Optional[int] = Field(alias="id", default=None)
+    id_: int | None = Field(alias="id", default=None)
     title: str
     completed: bool
 

--- a/examples/event_handler_rest/src/validating_payloads.py
+++ b/examples/event_handler_rest/src/validating_payloads.py
@@ -1,4 +1,6 @@
-from typing import List, Optional
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
 
 import requests
 from pydantic import BaseModel, Field
@@ -6,7 +8,9 @@ from pydantic import BaseModel, Field
 from aws_lambda_powertools import Logger, Tracer
 from aws_lambda_powertools.event_handler import APIGatewayRestResolver
 from aws_lambda_powertools.logging import correlation_paths
-from aws_lambda_powertools.utilities.typing import LambdaContext
+
+if TYPE_CHECKING:
+    from aws_lambda_powertools.utilities.typing import LambdaContext
 
 tracer = Tracer()
 logger = Logger()
@@ -15,7 +19,7 @@ app = APIGatewayRestResolver(enable_validation=True)  # (1)!
 
 class Todo(BaseModel):  # (2)!
     userId: int
-    id_: Optional[int] = Field(alias="id", default=None)
+    id_: int | None = Field(alias="id", default=None)
     title: str
     completed: bool
 
@@ -30,7 +34,7 @@ def create_todo(todo: Todo) -> str:  # (3)!
 
 @app.get("/todos")
 @tracer.capture_method
-def get_todos() -> List[Todo]:
+def get_todos() -> list[Todo]:
     todo = requests.get("https://jsonplaceholder.typicode.com/todos")
     todo.raise_for_status()
 

--- a/examples/event_handler_rest/src/validating_query_strings.py
+++ b/examples/event_handler_rest/src/validating_query_strings.py
@@ -1,4 +1,6 @@
-from typing import List, Optional
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
 
 import requests
 from pydantic import BaseModel, Field
@@ -6,9 +8,11 @@ from typing_extensions import Annotated  # (1)!
 
 from aws_lambda_powertools import Logger, Tracer
 from aws_lambda_powertools.event_handler import APIGatewayRestResolver
-from aws_lambda_powertools.event_handler.openapi.params import Query  # (2)!
 from aws_lambda_powertools.logging import correlation_paths
-from aws_lambda_powertools.utilities.typing import LambdaContext
+
+if TYPE_CHECKING:
+    from aws_lambda_powertools.event_handler.openapi.params import Query  # (2)!
+    from aws_lambda_powertools.utilities.typing import LambdaContext
 
 tracer = Tracer()
 logger = Logger()
@@ -17,14 +21,14 @@ app = APIGatewayRestResolver(enable_validation=True)
 
 class Todo(BaseModel):
     userId: int
-    id_: Optional[int] = Field(alias="id", default=None)
+    id_: int | None = Field(alias="id", default=None)
     title: str
     completed: bool
 
 
 @app.get("/todos")
 @tracer.capture_method
-def get_todos(completed: Annotated[Optional[str], Query(min_length=4)] = None) -> List[Todo]:  # (3)!
+def get_todos(completed: Annotated[str | None, Query(min_length=4)] = None) -> list[Todo]:  # (3)!
     url = "https://jsonplaceholder.typicode.com/todos"
 
     if completed is not None:

--- a/examples/event_handler_rest/src/working_with_headers_multi_value.py
+++ b/examples/event_handler_rest/src/working_with_headers_multi_value.py
@@ -1,11 +1,15 @@
+from __future__ import annotations
+
 from enum import Enum
-from typing import List
+from typing import TYPE_CHECKING
 
 from typing_extensions import Annotated
 
 from aws_lambda_powertools.event_handler import APIGatewayRestResolver
-from aws_lambda_powertools.event_handler.openapi.params import Header
-from aws_lambda_powertools.utilities.typing import LambdaContext
+
+if TYPE_CHECKING:
+    from aws_lambda_powertools.event_handler.openapi.params import Header
+    from aws_lambda_powertools.utilities.typing import LambdaContext
 
 app = APIGatewayRestResolver(enable_validation=True)
 
@@ -21,7 +25,7 @@ class CountriesAllowed(Enum):
 @app.get("/hello")
 def get(
     cloudfront_viewer_country: Annotated[
-        List[CountriesAllowed],  # (1)!
+        list[CountriesAllowed],  # (1)!
         Header(
             description="This is multi value header parameter.",
         ),

--- a/examples/event_handler_rest/src/working_with_multi_query_values.py
+++ b/examples/event_handler_rest/src/working_with_multi_query_values.py
@@ -1,11 +1,15 @@
+from __future__ import annotations
+
 from enum import Enum
-from typing import List
+from typing import TYPE_CHECKING
 
 from typing_extensions import Annotated
 
 from aws_lambda_powertools.event_handler import APIGatewayRestResolver
-from aws_lambda_powertools.event_handler.openapi.params import Query
-from aws_lambda_powertools.utilities.typing import LambdaContext
+
+if TYPE_CHECKING:
+    from aws_lambda_powertools.event_handler.openapi.params import Query
+    from aws_lambda_powertools.utilities.typing import LambdaContext
 
 app = APIGatewayRestResolver(enable_validation=True)
 
@@ -21,7 +25,7 @@ class ExampleEnum(Enum):
 @app.get("/todos")
 def get(
     example_multi_value_param: Annotated[
-        List[ExampleEnum],  # (1)!
+        list[ExampleEnum],  # (1)!
         Query(
             description="This is multi value query parameter.",
         ),

--- a/examples/event_sources/src/aws_config_rule.py
+++ b/examples/event_sources/src/aws_config_rule.py
@@ -1,9 +1,15 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 from aws_lambda_powertools import Logger
 from aws_lambda_powertools.utilities.data_classes import (
     AWSConfigRuleEvent,
     event_source,
 )
-from aws_lambda_powertools.utilities.typing import LambdaContext
+
+if TYPE_CHECKING:
+    from aws_lambda_powertools.utilities.typing import LambdaContext
 
 logger = Logger()
 

--- a/examples/event_sources/src/bedrock_agent_event.py
+++ b/examples/event_sources/src/bedrock_agent_event.py
@@ -1,6 +1,12 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 from aws_lambda_powertools import Logger
 from aws_lambda_powertools.utilities.data_classes import BedrockAgentEvent, event_source
-from aws_lambda_powertools.utilities.typing import LambdaContext
+
+if TYPE_CHECKING:
+    from aws_lambda_powertools.utilities.typing import LambdaContext
 
 logger = Logger()
 

--- a/examples/event_sources/src/cloudformation_custom_resource_handler.py
+++ b/examples/event_sources/src/cloudformation_custom_resource_handler.py
@@ -1,9 +1,15 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 from aws_lambda_powertools import Logger
 from aws_lambda_powertools.utilities.data_classes import (
     CloudFormationCustomResourceEvent,
     event_source,
 )
-from aws_lambda_powertools.utilities.typing import LambdaContext
+
+if TYPE_CHECKING:
+    from aws_lambda_powertools.utilities.typing import LambdaContext
 
 logger = Logger()
 

--- a/examples/event_sources/src/cloudwatch_alarm_event.py
+++ b/examples/event_sources/src/cloudwatch_alarm_event.py
@@ -1,6 +1,12 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 from aws_lambda_powertools import Logger
 from aws_lambda_powertools.utilities.data_classes import CloudWatchAlarmEvent, event_source
-from aws_lambda_powertools.utilities.typing import LambdaContext
+
+if TYPE_CHECKING:
+    from aws_lambda_powertools.utilities.typing import LambdaContext
 
 logger = Logger()
 

--- a/examples/event_sources/src/debugging.py
+++ b/examples/event_sources/src/debugging.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from aws_lambda_powertools.utilities.data_classes import (
     CodePipelineJobEvent,
     event_source,

--- a/examples/event_sources/src/kinesis_firehose_delivery_stream.py
+++ b/examples/event_sources/src/kinesis_firehose_delivery_stream.py
@@ -1,10 +1,16 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 from aws_lambda_powertools.utilities.data_classes import (
     KinesisFirehoseDataTransformationResponse,
     KinesisFirehoseEvent,
     event_source,
 )
 from aws_lambda_powertools.utilities.serialization import base64_from_json
-from aws_lambda_powertools.utilities.typing import LambdaContext
+
+if TYPE_CHECKING:
+    from aws_lambda_powertools.utilities.typing import LambdaContext
 
 
 @event_source(data_class=KinesisFirehoseEvent)

--- a/examples/event_sources/src/kinesis_firehose_response_drop.py
+++ b/examples/event_sources/src/kinesis_firehose_response_drop.py
@@ -1,5 +1,7 @@
+from __future__ import annotations
+
 from json import JSONDecodeError
-from typing import Dict
+from typing import TYPE_CHECKING
 
 from aws_lambda_powertools.utilities.data_classes import (
     KinesisFirehoseDataTransformationRecord,
@@ -8,7 +10,9 @@ from aws_lambda_powertools.utilities.data_classes import (
     event_source,
 )
 from aws_lambda_powertools.utilities.serialization import base64_from_json
-from aws_lambda_powertools.utilities.typing import LambdaContext
+
+if TYPE_CHECKING:
+    from aws_lambda_powertools.utilities.typing import LambdaContext
 
 
 @event_source(data_class=KinesisFirehoseEvent)
@@ -17,7 +21,7 @@ def lambda_handler(event: KinesisFirehoseEvent, context: LambdaContext):
 
     for record in event.records:
         try:
-            payload: Dict = record.data_as_json  # decodes and deserialize base64 JSON string
+            payload: dict = record.data_as_json  # decodes and deserialize base64 JSON string
 
             ## generate data to return
             transformed_data = {"tool_used": "powertools_dataclass", "original_payload": payload}

--- a/examples/event_sources/src/kinesis_firehose_response_exception.py
+++ b/examples/event_sources/src/kinesis_firehose_response_exception.py
@@ -1,3 +1,7 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 from aws_lambda_powertools.utilities.data_classes import (
     KinesisFirehoseDataTransformationRecord,
     KinesisFirehoseDataTransformationResponse,
@@ -5,7 +9,9 @@ from aws_lambda_powertools.utilities.data_classes import (
     event_source,
 )
 from aws_lambda_powertools.utilities.serialization import base64_from_json
-from aws_lambda_powertools.utilities.typing import LambdaContext
+
+if TYPE_CHECKING:
+    from aws_lambda_powertools.utilities.typing import LambdaContext
 
 
 @event_source(data_class=KinesisFirehoseEvent)

--- a/examples/event_sources/src/s3_batch_operation.py
+++ b/examples/event_sources/src/s3_batch_operation.py
@@ -1,8 +1,14 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 import boto3
 from botocore.exceptions import ClientError
 
 from aws_lambda_powertools.utilities.data_classes import S3BatchOperationEvent, S3BatchOperationResponse, event_source
-from aws_lambda_powertools.utilities.typing import LambdaContext
+
+if TYPE_CHECKING:
+    from aws_lambda_powertools.utilities.typing import LambdaContext
 
 
 @event_source(data_class=S3BatchOperationEvent)
@@ -33,5 +39,4 @@ def lambda_handler(event: S3BatchOperationEvent, context: LambdaContext):
     return response.asdict()
 
 
-def do_some_work(s3_client, src_bucket: str, src_key: str):
-    ...
+def do_some_work(s3_client, src_bucket: str, src_key: str): ...

--- a/examples/event_sources/src/secrets_manager.py
+++ b/examples/event_sources/src/secrets_manager.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from aws_lambda_powertools.utilities import parameters
 from aws_lambda_powertools.utilities.data_classes import SecretsManagerEvent, event_source
 

--- a/examples/event_sources/src/vpc_lattice.py
+++ b/examples/event_sources/src/vpc_lattice.py
@@ -1,6 +1,12 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 from aws_lambda_powertools import Logger
 from aws_lambda_powertools.utilities.data_classes import VPCLatticeEvent, event_source
-from aws_lambda_powertools.utilities.typing import LambdaContext
+
+if TYPE_CHECKING:
+    from aws_lambda_powertools.utilities.typing import LambdaContext
 
 logger = Logger()
 

--- a/examples/event_sources/src/vpc_lattice_v2.py
+++ b/examples/event_sources/src/vpc_lattice_v2.py
@@ -1,6 +1,12 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 from aws_lambda_powertools import Logger
 from aws_lambda_powertools.utilities.data_classes import VPCLatticeEventV2, event_source
-from aws_lambda_powertools.utilities.typing import LambdaContext
+
+if TYPE_CHECKING:
+    from aws_lambda_powertools.utilities.typing import LambdaContext
 
 logger = Logger()
 

--- a/examples/feature_flags/src/appconfig_provider_options.py
+++ b/examples/feature_flags/src/appconfig_provider_options.py
@@ -1,10 +1,14 @@
-from typing import Any
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
 
 from botocore.config import Config
 from jmespath.functions import Functions, signature
 
 from aws_lambda_powertools.utilities.feature_flags import AppConfigStore, FeatureFlags
-from aws_lambda_powertools.utilities.typing import LambdaContext
+
+if TYPE_CHECKING:
+    from aws_lambda_powertools.utilities.typing import LambdaContext
 
 boto_config = Config(read_timeout=10, retries={"total_max_attempts": 2})
 

--- a/examples/feature_flags/src/beyond_boolean.py
+++ b/examples/feature_flags/src/beyond_boolean.py
@@ -1,7 +1,11 @@
-from typing import Any
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
 
 from aws_lambda_powertools.utilities.feature_flags import AppConfigStore, FeatureFlags
-from aws_lambda_powertools.utilities.typing import LambdaContext
+
+if TYPE_CHECKING:
+    from aws_lambda_powertools.utilities.typing import LambdaContext
 
 app_config = AppConfigStore(environment="dev", application="comments", name="config")
 

--- a/examples/feature_flags/src/custom_s3_store_provider.py
+++ b/examples/feature_flags/src/custom_s3_store_provider.py
@@ -1,5 +1,7 @@
+from __future__ import annotations
+
 import json
-from typing import Any, Dict
+from typing import Any
 
 import boto3
 from botocore.exceptions import ClientError
@@ -20,7 +22,7 @@ class S3StoreProvider(StoreProvider):
         self.object_key = object_key
         self.client = boto3.client("s3")
 
-    def _get_s3_object(self) -> Dict[str, Any]:
+    def _get_s3_object(self) -> dict[str, Any]:
         # Retrieve the object content
         try:
             response = self.client.get_object(Bucket=self.bucket_name, Key=self.object_key)
@@ -28,9 +30,9 @@ class S3StoreProvider(StoreProvider):
         except ClientError as exc:
             raise ConfigurationStoreError("Unable to get S3 Store Provider configuration file") from exc
 
-    def get_configuration(self) -> Dict[str, Any]:
+    def get_configuration(self) -> dict[str, Any]:
         return self._get_s3_object()
 
     @property
-    def get_raw_configuration(self) -> Dict[str, Any]:
+    def get_raw_configuration(self) -> dict[str, Any]:
         return self._get_s3_object()

--- a/examples/feature_flags/src/datetime_feature.py
+++ b/examples/feature_flags/src/datetime_feature.py
@@ -1,5 +1,11 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 from aws_lambda_powertools.utilities.feature_flags import AppConfigStore, FeatureFlags
-from aws_lambda_powertools.utilities.typing import LambdaContext
+
+if TYPE_CHECKING:
+    from aws_lambda_powertools.utilities.typing import LambdaContext
 
 app_config = AppConfigStore(environment="dev", application="product-catalogue", name="features")
 

--- a/examples/feature_flags/src/extracting_envelope.py
+++ b/examples/feature_flags/src/extracting_envelope.py
@@ -1,7 +1,11 @@
-from typing import Any
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
 
 from aws_lambda_powertools.utilities.feature_flags import AppConfigStore, FeatureFlags
-from aws_lambda_powertools.utilities.typing import LambdaContext
+
+if TYPE_CHECKING:
+    from aws_lambda_powertools.utilities.typing import LambdaContext
 
 app_config = AppConfigStore(
     environment="dev",

--- a/examples/feature_flags/src/getting_all_enabled_features.py
+++ b/examples/feature_flags/src/getting_all_enabled_features.py
@@ -1,8 +1,12 @@
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 from aws_lambda_powertools.event_handler import APIGatewayRestResolver
 from aws_lambda_powertools.utilities.feature_flags import AppConfigStore, FeatureFlags
-from aws_lambda_powertools.utilities.typing import LambdaContext
+
+if TYPE_CHECKING:
+    from aws_lambda_powertools.utilities.typing import LambdaContext
 
 app = APIGatewayRestResolver()
 

--- a/examples/feature_flags/src/getting_started_single_feature_flag.py
+++ b/examples/feature_flags/src/getting_started_single_feature_flag.py
@@ -1,7 +1,11 @@
-from typing import Any
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
 
 from aws_lambda_powertools.utilities.feature_flags import AppConfigStore, FeatureFlags
-from aws_lambda_powertools.utilities.typing import LambdaContext
+
+if TYPE_CHECKING:
+    from aws_lambda_powertools.utilities.typing import LambdaContext
 
 app_config = AppConfigStore(environment="dev", application="product-catalogue", name="features")
 

--- a/examples/feature_flags/src/getting_started_static_flag.py
+++ b/examples/feature_flags/src/getting_started_static_flag.py
@@ -1,7 +1,11 @@
-from typing import Any
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
 
 from aws_lambda_powertools.utilities.feature_flags import AppConfigStore, FeatureFlags
-from aws_lambda_powertools.utilities.typing import LambdaContext
+
+if TYPE_CHECKING:
+    from aws_lambda_powertools.utilities.typing import LambdaContext
 
 app_config = AppConfigStore(environment="dev", application="product-catalogue", name="features")
 

--- a/examples/feature_flags/src/getting_started_with_cache.py
+++ b/examples/feature_flags/src/getting_started_with_cache.py
@@ -1,7 +1,11 @@
-from typing import Any
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
 
 from aws_lambda_powertools.utilities.feature_flags import AppConfigStore, FeatureFlags
-from aws_lambda_powertools.utilities.typing import LambdaContext
+
+if TYPE_CHECKING:
+    from aws_lambda_powertools.utilities.typing import LambdaContext
 
 app_config = AppConfigStore(environment="dev", application="product-catalogue", name="features", max_age=300)
 

--- a/examples/feature_flags/src/getting_started_with_tests.py
+++ b/examples/feature_flags/src/getting_started_with_tests.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from aws_lambda_powertools.utilities.feature_flags import (
     AppConfigStore,
     FeatureFlags,

--- a/examples/feature_flags/src/getting_stored_features.py
+++ b/examples/feature_flags/src/getting_stored_features.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from aws_lambda_powertools.utilities.feature_flags import AppConfigStore, FeatureFlags
 
 app_config = AppConfigStore(

--- a/examples/feature_flags/src/modulo_range_feature.py
+++ b/examples/feature_flags/src/modulo_range_feature.py
@@ -1,5 +1,11 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 from aws_lambda_powertools.utilities.feature_flags import AppConfigStore, FeatureFlags
-from aws_lambda_powertools.utilities.typing import LambdaContext
+
+if TYPE_CHECKING:
+    from aws_lambda_powertools.utilities.typing import LambdaContext
 
 app_config = AppConfigStore(environment="dev", application="product-catalogue", name="features")
 

--- a/examples/feature_flags/src/modulo_range_multiple_feature.py
+++ b/examples/feature_flags/src/modulo_range_multiple_feature.py
@@ -1,5 +1,11 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 from aws_lambda_powertools.utilities.feature_flags import AppConfigStore, FeatureFlags
-from aws_lambda_powertools.utilities.typing import LambdaContext
+
+if TYPE_CHECKING:
+    from aws_lambda_powertools.utilities.typing import LambdaContext
 
 app_config = AppConfigStore(environment="dev", application="product-catalogue", name="features")
 

--- a/examples/feature_flags/src/timebased_feature.py
+++ b/examples/feature_flags/src/timebased_feature.py
@@ -1,5 +1,11 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 from aws_lambda_powertools.utilities.feature_flags import AppConfigStore, FeatureFlags
-from aws_lambda_powertools.utilities.typing import LambdaContext
+
+if TYPE_CHECKING:
+    from aws_lambda_powertools.utilities.typing import LambdaContext
 
 app_config = AppConfigStore(environment="dev", application="product-catalogue", name="features")
 

--- a/examples/feature_flags/src/timebased_happyhour_feature.py
+++ b/examples/feature_flags/src/timebased_happyhour_feature.py
@@ -1,5 +1,11 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 from aws_lambda_powertools.utilities.feature_flags import AppConfigStore, FeatureFlags
-from aws_lambda_powertools.utilities.typing import LambdaContext
+
+if TYPE_CHECKING:
+    from aws_lambda_powertools.utilities.typing import LambdaContext
 
 app_config = AppConfigStore(environment="dev", application="product-catalogue", name="features")
 

--- a/examples/feature_flags/src/working_with_own_s3_store_provider.py
+++ b/examples/feature_flags/src/working_with_own_s3_store_provider.py
@@ -1,9 +1,13 @@
-from typing import Any
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
 
 from custom_s3_store_provider import S3StoreProvider
 
 from aws_lambda_powertools.utilities.feature_flags import FeatureFlags
-from aws_lambda_powertools.utilities.typing import LambdaContext
+
+if TYPE_CHECKING:
+    from aws_lambda_powertools.utilities.typing import LambdaContext
 
 s3_config_store = S3StoreProvider("your-bucket-name", "working_with_own_s3_store_provider_features.json")
 

--- a/examples/homepage/install/arm64/cdk_arm64.py
+++ b/examples/homepage/install/arm64/cdk_arm64.py
@@ -1,5 +1,11 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 from aws_cdk import Aws, Stack, aws_lambda
-from constructs import Construct
+
+if TYPE_CHECKING:
+    from constructs import Construct
 
 
 class SampleApp(Stack):

--- a/examples/homepage/install/arm64/pulumi_arm64.py
+++ b/examples/homepage/install/arm64/pulumi_arm64.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import json
 
 import pulumi

--- a/examples/homepage/install/sar/cdk_sar.py
+++ b/examples/homepage/install/sar/cdk_sar.py
@@ -1,5 +1,11 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 from aws_cdk import Stack, aws_lambda, aws_sam
-from constructs import Construct
+
+if TYPE_CHECKING:
+    from constructs import Construct
 
 POWERTOOLS_BASE_NAME = "AWSLambdaPowertools"
 # Find latest from github.com/aws-powertools/powertools-lambda-python/releases

--- a/examples/homepage/install/x86_64/cdk_x86.py
+++ b/examples/homepage/install/x86_64/cdk_x86.py
@@ -1,5 +1,11 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 from aws_cdk import Aws, Stack, aws_lambda
-from constructs import Construct
+
+if TYPE_CHECKING:
+    from constructs import Construct
 
 
 class SampleApp(Stack):

--- a/examples/homepage/install/x86_64/pulumi_x86.py
+++ b/examples/homepage/install/x86_64/pulumi_x86.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import json
 
 import pulumi

--- a/examples/idempotency/src/bring_your_own_persistent_store.py
+++ b/examples/idempotency/src/bring_your_own_persistent_store.py
@@ -1,9 +1,10 @@
+from __future__ import annotations
+
 import datetime
 import logging
-from typing import Any, Dict, Optional
+from typing import TYPE_CHECKING, Any
 
 import boto3
-from botocore.config import Config
 
 from aws_lambda_powertools.utilities.idempotency import BasePersistenceLayer
 from aws_lambda_powertools.utilities.idempotency.exceptions import (
@@ -11,6 +12,9 @@ from aws_lambda_powertools.utilities.idempotency.exceptions import (
     IdempotencyItemNotFoundError,
 )
 from aws_lambda_powertools.utilities.idempotency.persistence.base import DataRecord
+
+if TYPE_CHECKING:
+    from botocore.config import Config
 
 logger = logging.getLogger(__name__)
 
@@ -24,8 +28,8 @@ class MyOwnPersistenceLayer(BasePersistenceLayer):
         status_attr: str = "status",
         data_attr: str = "data",
         validation_key_attr: str = "validation",
-        boto_config: Optional[Config] = None,
-        boto3_session: Optional[boto3.session.Session] = None,
+        boto_config: Config | None = None,
+        boto3_session: boto3.session.Session | None = None,
     ):
         boto3_session = boto3_session or boto3.session.Session()
         self._ddb_resource = boto3_session.resource("dynamodb", config=boto_config)
@@ -38,13 +42,13 @@ class MyOwnPersistenceLayer(BasePersistenceLayer):
         self.validation_key_attr = validation_key_attr
         super(MyOwnPersistenceLayer, self).__init__()
 
-    def _item_to_data_record(self, item: Dict[str, Any]) -> DataRecord:
+    def _item_to_data_record(self, item: dict[str, Any]) -> DataRecord:
         """
         Translate raw item records from DynamoDB to DataRecord
 
         Parameters
         ----------
-        item: Dict[str, Union[str, int]]
+        item: dict[str, str | int]
                 Item format from dynamodb response
 
         Returns

--- a/examples/idempotency/src/customize_persistence_layer.py
+++ b/examples/idempotency/src/customize_persistence_layer.py
@@ -1,8 +1,14 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 from aws_lambda_powertools.utilities.idempotency import (
     DynamoDBPersistenceLayer,
     idempotent,
 )
-from aws_lambda_powertools.utilities.typing import LambdaContext
+
+if TYPE_CHECKING:
+    from aws_lambda_powertools.utilities.typing import LambdaContext
 
 persistence_layer = DynamoDBPersistenceLayer(
     table_name="IdempotencyTable",

--- a/examples/idempotency/src/customize_persistence_layer_redis.py
+++ b/examples/idempotency/src/customize_persistence_layer_redis.py
@@ -1,10 +1,16 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 from aws_lambda_powertools.utilities.idempotency import (
     idempotent,
 )
 from aws_lambda_powertools.utilities.idempotency.persistence.redis import (
     RedisCachePersistenceLayer,
 )
-from aws_lambda_powertools.utilities.typing import LambdaContext
+
+if TYPE_CHECKING:
+    from aws_lambda_powertools.utilities.typing import LambdaContext
 
 persistence_layer = RedisCachePersistenceLayer(
     host="localhost",

--- a/examples/idempotency/src/getting_started_with_idempotency.py
+++ b/examples/idempotency/src/getting_started_with_idempotency.py
@@ -1,11 +1,16 @@
+from __future__ import annotations
+
 from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
 from uuid import uuid4
 
 from aws_lambda_powertools.utilities.idempotency import (
     DynamoDBPersistenceLayer,
     idempotent,
 )
-from aws_lambda_powertools.utilities.typing import LambdaContext
+
+if TYPE_CHECKING:
+    from aws_lambda_powertools.utilities.typing import LambdaContext
 
 persistence_layer = DynamoDBPersistenceLayer(table_name="IdempotencyTable")
 
@@ -17,8 +22,7 @@ class Payment:
     payment_id: str = field(default_factory=lambda: f"{uuid4()}")
 
 
-class PaymentError(Exception):
-    ...
+class PaymentError(Exception): ...
 
 
 @idempotent(persistence_store=persistence_layer)

--- a/examples/idempotency/src/getting_started_with_idempotency_redis_client.py
+++ b/examples/idempotency/src/getting_started_with_idempotency_redis_client.py
@@ -1,4 +1,7 @@
+from __future__ import annotations
+
 from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
 from uuid import uuid4
 
 from redis import Redis
@@ -9,7 +12,9 @@ from aws_lambda_powertools.utilities.idempotency import (
 from aws_lambda_powertools.utilities.idempotency.persistence.redis import (
     RedisCachePersistenceLayer,
 )
-from aws_lambda_powertools.utilities.typing import LambdaContext
+
+if TYPE_CHECKING:
+    from aws_lambda_powertools.utilities.typing import LambdaContext
 
 client = Redis(
     host="localhost",
@@ -29,8 +34,7 @@ class Payment:
     payment_id: str = field(default_factory=lambda: f"{uuid4()}")
 
 
-class PaymentError(Exception):
-    ...
+class PaymentError(Exception): ...
 
 
 @idempotent(persistence_store=persistence_layer)

--- a/examples/idempotency/src/getting_started_with_idempotency_redis_config.py
+++ b/examples/idempotency/src/getting_started_with_idempotency_redis_config.py
@@ -1,4 +1,7 @@
+from __future__ import annotations
+
 from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
 from uuid import uuid4
 
 from aws_lambda_powertools.utilities.idempotency import (
@@ -7,7 +10,9 @@ from aws_lambda_powertools.utilities.idempotency import (
 from aws_lambda_powertools.utilities.idempotency.persistence.redis import (
     RedisCachePersistenceLayer,
 )
-from aws_lambda_powertools.utilities.typing import LambdaContext
+
+if TYPE_CHECKING:
+    from aws_lambda_powertools.utilities.typing import LambdaContext
 
 persistence_layer = RedisCachePersistenceLayer(host="localhost", port=6379)
 
@@ -19,8 +24,7 @@ class Payment:
     payment_id: str = field(default_factory=lambda: f"{uuid4()}")
 
 
-class PaymentError(Exception):
-    ...
+class PaymentError(Exception): ...
 
 
 @idempotent(persistence_store=persistence_layer)

--- a/examples/idempotency/src/integrate_idempotency_with_batch_processor.py
+++ b/examples/idempotency/src/integrate_idempotency_with_batch_processor.py
@@ -1,12 +1,18 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 from aws_lambda_powertools import Logger
 from aws_lambda_powertools.utilities.batch import BatchProcessor, EventType
-from aws_lambda_powertools.utilities.data_classes.sqs_event import SQSRecord
 from aws_lambda_powertools.utilities.idempotency import (
     DynamoDBPersistenceLayer,
     IdempotencyConfig,
     idempotent_function,
 )
-from aws_lambda_powertools.utilities.typing import LambdaContext
+
+if TYPE_CHECKING:
+    from aws_lambda_powertools.utilities.data_classes.sqs_event import SQSRecord
+    from aws_lambda_powertools.utilities.typing import LambdaContext
 
 logger = Logger()
 processor = BatchProcessor(event_type=EventType.SQS)

--- a/examples/idempotency/src/integrate_idempotency_with_validator.py
+++ b/examples/idempotency/src/integrate_idempotency_with_validator.py
@@ -1,10 +1,16 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 from aws_lambda_powertools.utilities.idempotency import (
     DynamoDBPersistenceLayer,
     IdempotencyConfig,
     idempotent,
 )
-from aws_lambda_powertools.utilities.typing import LambdaContext
 from aws_lambda_powertools.utilities.validation import envelopes, validator
+
+if TYPE_CHECKING:
+    from aws_lambda_powertools.utilities.typing import LambdaContext
 
 config = IdempotencyConfig(event_key_jmespath='["message", "username"]')
 persistence_layer = DynamoDBPersistenceLayer(table_name="IdempotencyTable")

--- a/examples/idempotency/src/using_redis_client_with_aws_secrets.py
+++ b/examples/idempotency/src/using_redis_client_with_aws_secrets.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import Any
 
 from redis import Redis

--- a/examples/idempotency/src/using_redis_client_with_local_certs.py
+++ b/examples/idempotency/src/using_redis_client_with_local_certs.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import Any
 
 from redis import Redis

--- a/examples/idempotency/src/working_with_composite_key.py
+++ b/examples/idempotency/src/working_with_composite_key.py
@@ -1,8 +1,14 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 from aws_lambda_powertools.utilities.idempotency import (
     DynamoDBPersistenceLayer,
     idempotent,
 )
-from aws_lambda_powertools.utilities.typing import LambdaContext
+
+if TYPE_CHECKING:
+    from aws_lambda_powertools.utilities.typing import LambdaContext
 
 persistence_layer = DynamoDBPersistenceLayer(table_name="IdempotencyTable", sort_key_attr="sort_key")
 

--- a/examples/idempotency/src/working_with_custom_config.py
+++ b/examples/idempotency/src/working_with_custom_config.py
@@ -1,3 +1,7 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 from botocore.config import Config
 
 from aws_lambda_powertools.utilities.idempotency import (
@@ -5,7 +9,9 @@ from aws_lambda_powertools.utilities.idempotency import (
     IdempotencyConfig,
     idempotent,
 )
-from aws_lambda_powertools.utilities.typing import LambdaContext
+
+if TYPE_CHECKING:
+    from aws_lambda_powertools.utilities.typing import LambdaContext
 
 # See: https://botocore.amazonaws.com/v1/documentation/api/latest/reference/config.html#botocore-config
 boto_config = Config()

--- a/examples/idempotency/src/working_with_custom_session.py
+++ b/examples/idempotency/src/working_with_custom_session.py
@@ -1,3 +1,7 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 import boto3
 
 from aws_lambda_powertools.utilities.idempotency import (
@@ -5,7 +9,9 @@ from aws_lambda_powertools.utilities.idempotency import (
     IdempotencyConfig,
     idempotent,
 )
-from aws_lambda_powertools.utilities.typing import LambdaContext
+
+if TYPE_CHECKING:
+    from aws_lambda_powertools.utilities.typing import LambdaContext
 
 # See: https://boto3.amazonaws.com/v1/documentation/api/latest/reference/core/session.html#module-boto3.session
 boto3_session = boto3.session.Session()

--- a/examples/idempotency/src/working_with_dataclass_deduced_output_serializer.py
+++ b/examples/idempotency/src/working_with_dataclass_deduced_output_serializer.py
@@ -1,4 +1,7 @@
+from __future__ import annotations
+
 from dataclasses import dataclass
+from typing import TYPE_CHECKING
 
 from aws_lambda_powertools.utilities.idempotency import (
     DynamoDBPersistenceLayer,
@@ -6,7 +9,9 @@ from aws_lambda_powertools.utilities.idempotency import (
     idempotent_function,
 )
 from aws_lambda_powertools.utilities.idempotency.serialization.dataclass import DataclassSerializer
-from aws_lambda_powertools.utilities.typing import LambdaContext
+
+if TYPE_CHECKING:
+    from aws_lambda_powertools.utilities.typing import LambdaContext
 
 dynamodb = DynamoDBPersistenceLayer(table_name="IdempotencyTable")
 config = IdempotencyConfig(event_key_jmespath="order_id")  # see Choosing a payload subset section

--- a/examples/idempotency/src/working_with_dataclass_explicitly_output_serializer.py
+++ b/examples/idempotency/src/working_with_dataclass_explicitly_output_serializer.py
@@ -1,4 +1,7 @@
+from __future__ import annotations
+
 from dataclasses import dataclass
+from typing import TYPE_CHECKING
 
 from aws_lambda_powertools.utilities.idempotency import (
     DynamoDBPersistenceLayer,
@@ -6,7 +9,9 @@ from aws_lambda_powertools.utilities.idempotency import (
     idempotent_function,
 )
 from aws_lambda_powertools.utilities.idempotency.serialization.dataclass import DataclassSerializer
-from aws_lambda_powertools.utilities.typing import LambdaContext
+
+if TYPE_CHECKING:
+    from aws_lambda_powertools.utilities.typing import LambdaContext
 
 dynamodb = DynamoDBPersistenceLayer(table_name="IdempotencyTable")
 config = IdempotencyConfig(event_key_jmespath="order_id")  # see Choosing a payload subset section

--- a/examples/idempotency/src/working_with_exceptions.py
+++ b/examples/idempotency/src/working_with_exceptions.py
@@ -1,3 +1,7 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 import requests
 
 from aws_lambda_powertools.utilities.idempotency import (
@@ -5,7 +9,9 @@ from aws_lambda_powertools.utilities.idempotency import (
     IdempotencyConfig,
     idempotent_function,
 )
-from aws_lambda_powertools.utilities.typing import LambdaContext
+
+if TYPE_CHECKING:
+    from aws_lambda_powertools.utilities.typing import LambdaContext
 
 persistence_layer = DynamoDBPersistenceLayer(table_name="IdempotencyTable")
 

--- a/examples/idempotency/src/working_with_idempotency_key_required.py
+++ b/examples/idempotency/src/working_with_idempotency_key_required.py
@@ -1,9 +1,15 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 from aws_lambda_powertools.utilities.idempotency import (
     DynamoDBPersistenceLayer,
     IdempotencyConfig,
     idempotent,
 )
-from aws_lambda_powertools.utilities.typing import LambdaContext
+
+if TYPE_CHECKING:
+    from aws_lambda_powertools.utilities.typing import LambdaContext
 
 persistence_layer = DynamoDBPersistenceLayer(table_name="IdempotencyTable")
 config = IdempotencyConfig(

--- a/examples/idempotency/src/working_with_idempotent_function_custom_output_serializer.py
+++ b/examples/idempotency/src/working_with_idempotent_function_custom_output_serializer.py
@@ -1,4 +1,6 @@
-from typing import Dict, Type
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
 
 from aws_lambda_powertools.utilities.idempotency import (
     DynamoDBPersistenceLayer,
@@ -6,7 +8,9 @@ from aws_lambda_powertools.utilities.idempotency import (
     idempotent_function,
 )
 from aws_lambda_powertools.utilities.idempotency.serialization.custom_dict import CustomDictSerializer
-from aws_lambda_powertools.utilities.typing import LambdaContext
+
+if TYPE_CHECKING:
+    from aws_lambda_powertools.utilities.typing import LambdaContext
 
 dynamodb = DynamoDBPersistenceLayer(table_name="IdempotencyTable")
 config = IdempotencyConfig(event_key_jmespath="order_id")  # see Choosing a payload subset section
@@ -29,11 +33,11 @@ class OrderOutput:
         self.order_id = order_id
 
 
-def order_to_dict(x: Type[OrderOutput]) -> Dict:  # (1)!
+def order_to_dict(x: type[OrderOutput]) -> dict:  # (1)!
     return dict(x.__dict__)
 
 
-def dict_to_order(x: Dict) -> OrderOutput:  # (2)!
+def dict_to_order(x: dict) -> OrderOutput:  # (2)!
     return OrderOutput(**x)
 
 

--- a/examples/idempotency/src/working_with_idempotent_function_dataclass.py
+++ b/examples/idempotency/src/working_with_idempotent_function_dataclass.py
@@ -1,11 +1,16 @@
+from __future__ import annotations
+
 from dataclasses import dataclass
+from typing import TYPE_CHECKING
 
 from aws_lambda_powertools.utilities.idempotency import (
     DynamoDBPersistenceLayer,
     IdempotencyConfig,
     idempotent_function,
 )
-from aws_lambda_powertools.utilities.typing import LambdaContext
+
+if TYPE_CHECKING:
+    from aws_lambda_powertools.utilities.typing import LambdaContext
 
 dynamodb = DynamoDBPersistenceLayer(table_name="IdempotencyTable")
 config = IdempotencyConfig(event_key_jmespath="order_id")  # see Choosing a payload subset section

--- a/examples/idempotency/src/working_with_idempotent_function_pydantic.py
+++ b/examples/idempotency/src/working_with_idempotent_function_pydantic.py
@@ -1,10 +1,16 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 from aws_lambda_powertools.utilities.idempotency import (
     DynamoDBPersistenceLayer,
     IdempotencyConfig,
     idempotent_function,
 )
 from aws_lambda_powertools.utilities.parser import BaseModel
-from aws_lambda_powertools.utilities.typing import LambdaContext
+
+if TYPE_CHECKING:
+    from aws_lambda_powertools.utilities.typing import LambdaContext
 
 dynamodb = DynamoDBPersistenceLayer(table_name="IdempotencyTable")
 config = IdempotencyConfig(event_key_jmespath="order_id")  # see Choosing a payload subset section

--- a/examples/idempotency/src/working_with_lambda_timeout.py
+++ b/examples/idempotency/src/working_with_lambda_timeout.py
@@ -1,10 +1,16 @@
-from aws_lambda_powertools.utilities.data_classes.sqs_event import SQSRecord
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 from aws_lambda_powertools.utilities.idempotency import (
     DynamoDBPersistenceLayer,
     IdempotencyConfig,
     idempotent_function,
 )
-from aws_lambda_powertools.utilities.typing import LambdaContext
+
+if TYPE_CHECKING:
+    from aws_lambda_powertools.utilities.data_classes.sqs_event import SQSRecord
+    from aws_lambda_powertools.utilities.typing import LambdaContext
 
 persistence_layer = DynamoDBPersistenceLayer(table_name="IdempotencyTable")
 

--- a/examples/idempotency/src/working_with_local_cache.py
+++ b/examples/idempotency/src/working_with_local_cache.py
@@ -1,9 +1,15 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 from aws_lambda_powertools.utilities.idempotency import (
     DynamoDBPersistenceLayer,
     IdempotencyConfig,
     idempotent,
 )
-from aws_lambda_powertools.utilities.typing import LambdaContext
+
+if TYPE_CHECKING:
+    from aws_lambda_powertools.utilities.typing import LambdaContext
 
 persistence_layer = DynamoDBPersistenceLayer(table_name="IdempotencyTable")
 config = IdempotencyConfig(

--- a/examples/idempotency/src/working_with_payload_subset.py
+++ b/examples/idempotency/src/working_with_payload_subset.py
@@ -1,5 +1,8 @@
+from __future__ import annotations
+
 import json
 from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
 from uuid import uuid4
 
 from aws_lambda_powertools.utilities.idempotency import (
@@ -7,7 +10,9 @@ from aws_lambda_powertools.utilities.idempotency import (
     IdempotencyConfig,
     idempotent,
 )
-from aws_lambda_powertools.utilities.typing import LambdaContext
+
+if TYPE_CHECKING:
+    from aws_lambda_powertools.utilities.typing import LambdaContext
 
 persistence_layer = DynamoDBPersistenceLayer(table_name="IdempotencyTable")
 
@@ -23,8 +28,7 @@ class Payment:
     payment_id: str = field(default_factory=lambda: f"{uuid4()}")
 
 
-class PaymentError(Exception):
-    ...
+class PaymentError(Exception): ...
 
 
 @idempotent(config=config, persistence_store=persistence_layer)

--- a/examples/idempotency/src/working_with_pydantic_deduced_output_serializer.py
+++ b/examples/idempotency/src/working_with_pydantic_deduced_output_serializer.py
@@ -1,3 +1,7 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 from aws_lambda_powertools.utilities.idempotency import (
     DynamoDBPersistenceLayer,
     IdempotencyConfig,
@@ -5,7 +9,9 @@ from aws_lambda_powertools.utilities.idempotency import (
 )
 from aws_lambda_powertools.utilities.idempotency.serialization.pydantic import PydanticSerializer
 from aws_lambda_powertools.utilities.parser import BaseModel
-from aws_lambda_powertools.utilities.typing import LambdaContext
+
+if TYPE_CHECKING:
+    from aws_lambda_powertools.utilities.typing import LambdaContext
 
 dynamodb = DynamoDBPersistenceLayer(table_name="IdempotencyTable")
 config = IdempotencyConfig(event_key_jmespath="order_id")  # see Choosing a payload subset section

--- a/examples/idempotency/src/working_with_pydantic_explicitly_output_serializer.py
+++ b/examples/idempotency/src/working_with_pydantic_explicitly_output_serializer.py
@@ -1,3 +1,7 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 from aws_lambda_powertools.utilities.idempotency import (
     DynamoDBPersistenceLayer,
     IdempotencyConfig,
@@ -5,7 +9,9 @@ from aws_lambda_powertools.utilities.idempotency import (
 )
 from aws_lambda_powertools.utilities.idempotency.serialization.pydantic import PydanticSerializer
 from aws_lambda_powertools.utilities.parser import BaseModel
-from aws_lambda_powertools.utilities.typing import LambdaContext
+
+if TYPE_CHECKING:
+    from aws_lambda_powertools.utilities.typing import LambdaContext
 
 dynamodb = DynamoDBPersistenceLayer(table_name="IdempotencyTable")
 config = IdempotencyConfig(event_key_jmespath="order_id")  # see Choosing a payload subset section

--- a/examples/idempotency/src/working_with_record_expiration.py
+++ b/examples/idempotency/src/working_with_record_expiration.py
@@ -1,9 +1,15 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 from aws_lambda_powertools.utilities.idempotency import (
     DynamoDBPersistenceLayer,
     IdempotencyConfig,
     idempotent,
 )
-from aws_lambda_powertools.utilities.typing import LambdaContext
+
+if TYPE_CHECKING:
+    from aws_lambda_powertools.utilities.typing import LambdaContext
 
 persistence_layer = DynamoDBPersistenceLayer(table_name="IdempotencyTable")
 config = IdempotencyConfig(

--- a/examples/idempotency/src/working_with_response_hook.py
+++ b/examples/idempotency/src/working_with_response_hook.py
@@ -1,6 +1,8 @@
+from __future__ import annotations
+
 import datetime
 import uuid
-from typing import Dict
+from typing import TYPE_CHECKING
 
 from aws_lambda_powertools import Logger
 from aws_lambda_powertools.utilities.idempotency import (
@@ -8,15 +10,17 @@ from aws_lambda_powertools.utilities.idempotency import (
     IdempotencyConfig,
     idempotent_function,
 )
-from aws_lambda_powertools.utilities.idempotency.persistence.datarecord import (
-    DataRecord,
-)
-from aws_lambda_powertools.utilities.typing import LambdaContext
+
+if TYPE_CHECKING:
+    from aws_lambda_powertools.utilities.idempotency.persistence.datarecord import (
+        DataRecord,
+    )
+    from aws_lambda_powertools.utilities.typing import LambdaContext
 
 logger = Logger()
 
 
-def my_response_hook(response: Dict, idempotent_data: DataRecord) -> Dict:
+def my_response_hook(response: dict, idempotent_data: DataRecord) -> dict:
     # Return inserted Header data into the Idempotent Response
     response["x-idempotent-key"] = idempotent_data.idempotency_key
 

--- a/examples/idempotency/src/working_with_validation_payload.py
+++ b/examples/idempotency/src/working_with_validation_payload.py
@@ -1,4 +1,7 @@
+from __future__ import annotations
+
 from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
 from uuid import uuid4
 
 from aws_lambda_powertools.utilities.idempotency import (
@@ -6,7 +9,9 @@ from aws_lambda_powertools.utilities.idempotency import (
     IdempotencyConfig,
     idempotent,
 )
-from aws_lambda_powertools.utilities.typing import LambdaContext
+
+if TYPE_CHECKING:
+    from aws_lambda_powertools.utilities.typing import LambdaContext
 
 persistence_layer = DynamoDBPersistenceLayer(table_name="IdempotencyTable")
 config = IdempotencyConfig(event_key_jmespath='["user_id", "product_id"]', payload_validation_jmespath="amount")
@@ -21,8 +26,7 @@ class Payment:
     payment_id: str = field(default_factory=lambda: f"{uuid4()}")
 
 
-class PaymentError(Exception):
-    ...
+class PaymentError(Exception): ...
 
 
 @idempotent(config=config, persistence_store=persistence_layer)

--- a/examples/idempotency/templates/cdk.py
+++ b/examples/idempotency/templates/cdk.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from aws_cdk import RemovalPolicy
 from aws_cdk import aws_dynamodb as dynamodb
 from aws_cdk import aws_iam as iam

--- a/examples/idempotency/tests/app_test_disabling_idempotency_utility.py
+++ b/examples/idempotency/tests/app_test_disabling_idempotency_utility.py
@@ -1,8 +1,14 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 from aws_lambda_powertools.utilities.idempotency import (
     DynamoDBPersistenceLayer,
     idempotent,
 )
-from aws_lambda_powertools.utilities.typing import LambdaContext
+
+if TYPE_CHECKING:
+    from aws_lambda_powertools.utilities.typing import LambdaContext
 
 persistence_layer = DynamoDBPersistenceLayer(table_name="IdempotencyTable")
 

--- a/examples/idempotency/tests/app_test_dynamodb_local.py
+++ b/examples/idempotency/tests/app_test_dynamodb_local.py
@@ -1,8 +1,14 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 from aws_lambda_powertools.utilities.idempotency import (
     DynamoDBPersistenceLayer,
     idempotent,
 )
-from aws_lambda_powertools.utilities.typing import LambdaContext
+
+if TYPE_CHECKING:
+    from aws_lambda_powertools.utilities.typing import LambdaContext
 
 persistence_layer = DynamoDBPersistenceLayer(table_name="IdempotencyTable")
 

--- a/examples/idempotency/tests/app_test_io_operations.py
+++ b/examples/idempotency/tests/app_test_io_operations.py
@@ -1,8 +1,14 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 from aws_lambda_powertools.utilities.idempotency import (
     DynamoDBPersistenceLayer,
     idempotent,
 )
-from aws_lambda_powertools.utilities.typing import LambdaContext
+
+if TYPE_CHECKING:
+    from aws_lambda_powertools.utilities.typing import LambdaContext
 
 persistence_layer = DynamoDBPersistenceLayer(table_name="IdempotencyTable")
 

--- a/examples/idempotency/tests/mock_redis.py
+++ b/examples/idempotency/tests/mock_redis.py
@@ -1,14 +1,16 @@
+from __future__ import annotations
+
 import time as t
-from typing import Dict
+from typing import dict
 
 
 # Mock redis class that includes all operations we used in Idempotency
 class MockRedis:
-    def __init__(self, decode_responses, cache: Dict, **kwargs):
+    def __init__(self, decode_responses, cache: dict, **kwargs):
         self.cache = cache or {}
-        self.expire_dict: Dict = {}
+        self.expire_dict: dict = {}
         self.decode_responses = decode_responses
-        self.acl: Dict = {}
+        self.acl: dict = {}
         self.username = ""
 
     def hset(self, name, mapping):

--- a/examples/idempotency/tests/test_disabling_idempotency_utility.py
+++ b/examples/idempotency/tests/test_disabling_idempotency_utility.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from dataclasses import dataclass
 
 import app_test_disabling_idempotency_utility
@@ -20,7 +22,7 @@ def lambda_context():
 
 
 def test_idempotent_lambda_handler(monkeypatch, lambda_context):
-    # Set POWERTOOLS_IDEMPOTENCY_DISABLED before calling decorated functions
+    # set POWERTOOLS_IDEMPOTENCY_DISABLED before calling decorated functions
     monkeypatch.setenv("POWERTOOLS_IDEMPOTENCY_DISABLED", 1)
 
     result = app_test_disabling_idempotency_utility.lambda_handler({}, lambda_context)

--- a/examples/idempotency/tests/test_with_dynamodb_local.py
+++ b/examples/idempotency/tests/test_with_dynamodb_local.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from dataclasses import dataclass
 
 import app_test_dynamodb_local

--- a/examples/idempotency/tests/test_with_io_operations.py
+++ b/examples/idempotency/tests/test_with_io_operations.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from dataclasses import dataclass
 from unittest.mock import MagicMock
 

--- a/examples/idempotency/tests/test_with_mock_redis.py
+++ b/examples/idempotency/tests/test_with_mock_redis.py
@@ -1,4 +1,7 @@
+from __future__ import annotations
+
 from dataclasses import dataclass
+from typing import TYPE_CHECKING
 
 import pytest
 from mock_redis import MockRedis
@@ -9,7 +12,9 @@ from aws_lambda_powertools.utilities.idempotency import (
 from aws_lambda_powertools.utilities.idempotency.persistence.redis import (
     RedisCachePersistenceLayer,
 )
-from aws_lambda_powertools.utilities.typing import LambdaContext
+
+if TYPE_CHECKING:
+    from aws_lambda_powertools.utilities.typing import LambdaContext
 
 
 @pytest.fixture

--- a/examples/idempotency/tests/test_with_real_redis.py
+++ b/examples/idempotency/tests/test_with_real_redis.py
@@ -1,4 +1,7 @@
+from __future__ import annotations
+
 from dataclasses import dataclass
+from typing import TYPE_CHECKING
 
 import pytest
 import redis
@@ -9,7 +12,9 @@ from aws_lambda_powertools.utilities.idempotency import (
 from aws_lambda_powertools.utilities.idempotency.persistence.redis import (
     RedisCachePersistenceLayer,
 )
-from aws_lambda_powertools.utilities.typing import LambdaContext
+
+if TYPE_CHECKING:
+    from aws_lambda_powertools.utilities.typing import LambdaContext
 
 
 @pytest.fixture

--- a/examples/jmespath_functions/src/extract_data_from_builtin_envelope.py
+++ b/examples/jmespath_functions/src/extract_data_from_builtin_envelope.py
@@ -1,11 +1,15 @@
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 from aws_lambda_powertools import Logger
 from aws_lambda_powertools.utilities.jmespath_utils import (
     envelopes,
     query,
 )
-from aws_lambda_powertools.utilities.typing import LambdaContext
+
+if TYPE_CHECKING:
+    from aws_lambda_powertools.utilities.typing import LambdaContext
 
 logger = Logger()
 

--- a/examples/jmespath_functions/src/powertools_base64_gzip_jmespath_function.py
+++ b/examples/jmespath_functions/src/powertools_base64_gzip_jmespath_function.py
@@ -1,13 +1,18 @@
+from __future__ import annotations
+
 import base64
 import binascii
 import gzip
 import json
+from typing import TYPE_CHECKING
 
 import powertools_base64_gzip_jmespath_schema as schemas
 from jmespath.exceptions import JMESPathTypeError
 
-from aws_lambda_powertools.utilities.typing import LambdaContext
 from aws_lambda_powertools.utilities.validation import SchemaValidationError, validate
+
+if TYPE_CHECKING:
+    from aws_lambda_powertools.utilities.typing import LambdaContext
 
 
 def lambda_handler(event, context: LambdaContext) -> dict:

--- a/examples/jmespath_functions/src/powertools_base64_gzip_jmespath_schema.py
+++ b/examples/jmespath_functions/src/powertools_base64_gzip_jmespath_schema.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 INPUT = {
     "$schema": "http://json-schema.org/draft-07/schema",
     "$id": "http://example.com/example.json",

--- a/examples/jmespath_functions/src/powertools_base64_jmespath_function.py
+++ b/examples/jmespath_functions/src/powertools_base64_jmespath_function.py
@@ -1,14 +1,19 @@
+from __future__ import annotations
+
 import base64
 import binascii
 import json
 from dataclasses import asdict, dataclass, field, is_dataclass
+from typing import TYPE_CHECKING
 from uuid import uuid4
 
 import powertools_base64_jmespath_schema as schemas
 from jmespath.exceptions import JMESPathTypeError
 
-from aws_lambda_powertools.utilities.typing import LambdaContext
 from aws_lambda_powertools.utilities.validation import SchemaValidationError, validate
+
+if TYPE_CHECKING:
+    from aws_lambda_powertools.utilities.typing import LambdaContext
 
 
 @dataclass

--- a/examples/jmespath_functions/src/powertools_base64_jmespath_schema.py
+++ b/examples/jmespath_functions/src/powertools_base64_jmespath_schema.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 INPUT = {
     "$schema": "http://json-schema.org/draft-07/schema",
     "$id": "http://example.com/example.json",

--- a/examples/jmespath_functions/src/powertools_custom_jmespath_function.py
+++ b/examples/jmespath_functions/src/powertools_custom_jmespath_function.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import base64
 import binascii
 import zlib

--- a/examples/jmespath_functions/src/powertools_json_idempotency_jmespath.py
+++ b/examples/jmespath_functions/src/powertools_json_idempotency_jmespath.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import json
 from uuid import uuid4
 
@@ -16,8 +18,7 @@ persistence_layer = DynamoDBPersistenceLayer(table_name="IdempotencyTable")
 config = IdempotencyConfig(event_key_jmespath="powertools_json(body)")
 
 
-class PaymentError(Exception):
-    ...
+class PaymentError(Exception): ...
 
 
 @idempotent(config=config, persistence_store=persistence_layer)

--- a/examples/jmespath_functions/src/powertools_json_jmespath_function.py
+++ b/examples/jmespath_functions/src/powertools_json_jmespath_function.py
@@ -1,12 +1,17 @@
+from __future__ import annotations
+
 import json
 from dataclasses import asdict, dataclass, field, is_dataclass
+from typing import TYPE_CHECKING
 from uuid import uuid4
 
 import powertools_json_jmespath_schema as schemas
 from jmespath.exceptions import JMESPathTypeError
 
-from aws_lambda_powertools.utilities.typing import LambdaContext
 from aws_lambda_powertools.utilities.validation import SchemaValidationError, validate
+
+if TYPE_CHECKING:
+    from aws_lambda_powertools.utilities.typing import LambdaContext
 
 
 @dataclass

--- a/examples/jmespath_functions/src/powertools_json_jmespath_schema.py
+++ b/examples/jmespath_functions/src/powertools_json_jmespath_schema.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 INPUT = {
     "$schema": "http://json-schema.org/draft-07/schema",
     "$id": "http://example.com/example.json",

--- a/examples/jmespath_functions/src/query.py
+++ b/examples/jmespath_functions/src/query.py
@@ -1,5 +1,12 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 from aws_lambda_powertools.utilities.jmespath_utils import query
 from aws_lambda_powertools.utilities.typing import LambdaContext
+
+if TYPE_CHECKING:
+    from aws_lambda_powertools.utilities.typing import LambdaContext
 
 
 def handler(event: dict, context: LambdaContext) -> dict:

--- a/examples/logger/src/append_and_remove_keys.py
+++ b/examples/logger/src/append_and_remove_keys.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from aws_lambda_powertools import Logger
 
 logger = Logger(service="payment", name="%(name)s")

--- a/examples/logger/src/append_keys.py
+++ b/examples/logger/src/append_keys.py
@@ -1,5 +1,11 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 from aws_lambda_powertools import Logger
-from aws_lambda_powertools.utilities.typing import LambdaContext
+
+if TYPE_CHECKING:
+    from aws_lambda_powertools.utilities.typing import LambdaContext
 
 logger = Logger()
 

--- a/examples/logger/src/append_keys_extra.py
+++ b/examples/logger/src/append_keys_extra.py
@@ -1,5 +1,11 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 from aws_lambda_powertools import Logger
-from aws_lambda_powertools.utilities.typing import LambdaContext
+
+if TYPE_CHECKING:
+    from aws_lambda_powertools.utilities.typing import LambdaContext
 
 logger = Logger()
 

--- a/examples/logger/src/append_keys_kwargs.py
+++ b/examples/logger/src/append_keys_kwargs.py
@@ -1,5 +1,11 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 from aws_lambda_powertools import Logger
-from aws_lambda_powertools.utilities.typing import LambdaContext
+
+if TYPE_CHECKING:
+    from aws_lambda_powertools.utilities.typing import LambdaContext
 
 logger = Logger()
 

--- a/examples/logger/src/append_keys_vs_extra.py
+++ b/examples/logger/src/append_keys_vs_extra.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import os
 
 import requests
@@ -8,8 +10,7 @@ ENDPOINT = os.getenv("PAYMENT_API", "")
 logger = Logger(service="payment")
 
 
-class PaymentError(Exception):
-    ...
+class PaymentError(Exception): ...
 
 
 def lambda_handler(event, context):

--- a/examples/logger/src/bring_your_own_formatter.py
+++ b/examples/logger/src/bring_your_own_formatter.py
@@ -1,6 +1,12 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 from aws_lambda_powertools import Logger
 from aws_lambda_powertools.logging.formatter import LambdaPowertoolsFormatter
-from aws_lambda_powertools.logging.types import LogRecord
+
+if TYPE_CHECKING:
+    from aws_lambda_powertools.logging.types import LogRecord
 
 
 class CustomFormatter(LambdaPowertoolsFormatter):

--- a/examples/logger/src/bring_your_own_formatter_from_scratch.py
+++ b/examples/logger/src/bring_your_own_formatter_from_scratch.py
@@ -1,13 +1,17 @@
+from __future__ import annotations
+
 import json
-import logging
-from typing import Any, Dict, Iterable, List, Optional
+from typing import TYPE_CHECKING, Any, Iterable
 
 from aws_lambda_powertools import Logger
 from aws_lambda_powertools.logging.formatter import BasePowertoolsFormatter
 
+if TYPE_CHECKING:
+    import logging
+
 
 class CustomFormatter(BasePowertoolsFormatter):
-    def __init__(self, log_record_order: Optional[List[str]] = None, *args, **kwargs):
+    def __init__(self, log_record_order: list[str] | None = None, *args, **kwargs):
         self.log_record_order = log_record_order or ["level", "location", "message", "timestamp"]
         self.log_format = dict.fromkeys(self.log_record_order)
         super().__init__(*args, **kwargs)
@@ -16,7 +20,7 @@ class CustomFormatter(BasePowertoolsFormatter):
         # also used by `inject_lambda_context` decorator
         self.log_format.update(additional_keys)
 
-    def current_keys(self) -> Dict[str, Any]:
+    def current_keys(self) -> dict[str, Any]:
         return self.log_format
 
     def remove_keys(self, keys: Iterable[str]):

--- a/examples/logger/src/bring_your_own_handler.py
+++ b/examples/logger/src/bring_your_own_handler.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import logging
 from pathlib import Path
 

--- a/examples/logger/src/bring_your_own_json_serializer.py
+++ b/examples/logger/src/bring_your_own_json_serializer.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import functools
 
 import orjson

--- a/examples/logger/src/clear_state.py
+++ b/examples/logger/src/clear_state.py
@@ -1,5 +1,11 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 from aws_lambda_powertools import Logger
-from aws_lambda_powertools.utilities.typing import LambdaContext
+
+if TYPE_CHECKING:
+    from aws_lambda_powertools.utilities.typing import LambdaContext
 
 logger = Logger()
 

--- a/examples/logger/src/cloning_logger_config.py
+++ b/examples/logger/src/cloning_logger_config.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import logging
 
 from aws_lambda_powertools import Logger

--- a/examples/logger/src/date_formatting.py
+++ b/examples/logger/src/date_formatting.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from aws_lambda_powertools import Logger
 
 date_format = "%m/%d/%Y %I:%M:%S %p"

--- a/examples/logger/src/enabling_boto_logging.py
+++ b/examples/logger/src/enabling_boto_logging.py
@@ -1,9 +1,13 @@
-from typing import Dict, List
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
 
 import boto3
 
 from aws_lambda_powertools import Logger
-from aws_lambda_powertools.utilities.typing import LambdaContext
+
+if TYPE_CHECKING:
+    from aws_lambda_powertools.utilities.typing import LambdaContext
 
 boto3.set_stream_logger()
 boto3.set_stream_logger("botocore")
@@ -12,7 +16,7 @@ logger = Logger()
 client = boto3.client("s3")
 
 
-def lambda_handler(event: Dict, context: LambdaContext) -> List:
+def lambda_handler(event: dict, context: LambdaContext) -> list:
     response = client.list_buckets()
 
     return response.get("Buckets", [])

--- a/examples/logger/src/fake_lambda_context_for_logger.py
+++ b/examples/logger/src/fake_lambda_context_for_logger.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from dataclasses import dataclass
 
 import fake_lambda_context_for_logger_module  # sample module for completeness

--- a/examples/logger/src/fake_lambda_context_for_logger_module.py
+++ b/examples/logger/src/fake_lambda_context_for_logger_module.py
@@ -1,5 +1,11 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 from aws_lambda_powertools import Logger
-from aws_lambda_powertools.utilities.typing import LambdaContext
+
+if TYPE_CHECKING:
+    from aws_lambda_powertools.utilities.typing import LambdaContext
 
 logger = Logger()
 

--- a/examples/logger/src/get_current_keys.py
+++ b/examples/logger/src/get_current_keys.py
@@ -1,5 +1,11 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 from aws_lambda_powertools import Logger
-from aws_lambda_powertools.utilities.typing import LambdaContext
+
+if TYPE_CHECKING:
+    from aws_lambda_powertools.utilities.typing import LambdaContext
 
 logger = Logger()
 

--- a/examples/logger/src/inject_lambda_context.py
+++ b/examples/logger/src/inject_lambda_context.py
@@ -1,5 +1,11 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 from aws_lambda_powertools import Logger
-from aws_lambda_powertools.utilities.typing import LambdaContext
+
+if TYPE_CHECKING:
+    from aws_lambda_powertools.utilities.typing import LambdaContext
 
 logger = Logger()
 

--- a/examples/logger/src/log_incoming_event.py
+++ b/examples/logger/src/log_incoming_event.py
@@ -1,5 +1,11 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 from aws_lambda_powertools import Logger
-from aws_lambda_powertools.utilities.typing import LambdaContext
+
+if TYPE_CHECKING:
+    from aws_lambda_powertools.utilities.typing import LambdaContext
 
 logger = Logger()
 

--- a/examples/logger/src/logger_reuse.py
+++ b/examples/logger/src/logger_reuse.py
@@ -1,7 +1,13 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 from logger_reuse_payment import inject_payment_id
 
 from aws_lambda_powertools import Logger
-from aws_lambda_powertools.utilities.typing import LambdaContext
+
+if TYPE_CHECKING:
+    from aws_lambda_powertools.utilities.typing import LambdaContext
 
 logger = Logger()
 

--- a/examples/logger/src/logger_reuse_payment.py
+++ b/examples/logger/src/logger_reuse_payment.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from aws_lambda_powertools import Logger
 
 logger = Logger()

--- a/examples/logger/src/logging_exceptions.py
+++ b/examples/logger/src/logging_exceptions.py
@@ -1,7 +1,13 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 import requests
 
 from aws_lambda_powertools import Logger
-from aws_lambda_powertools.utilities.typing import LambdaContext
+
+if TYPE_CHECKING:
+    from aws_lambda_powertools.utilities.typing import LambdaContext
 
 ENDPOINT = "http://httpbin.org/status/500"
 logger = Logger()

--- a/examples/logger/src/logging_inheritance_bad.py
+++ b/examples/logger/src/logging_inheritance_bad.py
@@ -1,7 +1,13 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 from logging_inheritance_module import inject_payment_id
 
 from aws_lambda_powertools import Logger
-from aws_lambda_powertools.utilities.typing import LambdaContext
+
+if TYPE_CHECKING:
+    from aws_lambda_powertools.utilities.typing import LambdaContext
 
 # NOTE: explicit service name differs from Child
 # meaning we will have two Logger instances with different state

--- a/examples/logger/src/logging_inheritance_good.py
+++ b/examples/logger/src/logging_inheritance_good.py
@@ -1,7 +1,13 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 from logging_inheritance_module import inject_payment_id
 
 from aws_lambda_powertools import Logger
-from aws_lambda_powertools.utilities.typing import LambdaContext
+
+if TYPE_CHECKING:
+    from aws_lambda_powertools.utilities.typing import LambdaContext
 
 # NOTE: explicit service name matches any new Logger
 # because we're using POWERTOOLS_SERVICE_NAME env var

--- a/examples/logger/src/logging_inheritance_module.py
+++ b/examples/logger/src/logging_inheritance_module.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from aws_lambda_powertools import Logger
 
 logger = Logger(child=True)

--- a/examples/logger/src/logging_stacktrace.py
+++ b/examples/logger/src/logging_stacktrace.py
@@ -1,7 +1,13 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 import requests
 
 from aws_lambda_powertools import Logger
-from aws_lambda_powertools.utilities.typing import LambdaContext
+
+if TYPE_CHECKING:
+    from aws_lambda_powertools.utilities.typing import LambdaContext
 
 ENDPOINT = "http://httpbin.org/status/500"
 logger = Logger(serialize_stacktrace=True)

--- a/examples/logger/src/logging_uncaught_exceptions.py
+++ b/examples/logger/src/logging_uncaught_exceptions.py
@@ -1,7 +1,13 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 import requests
 
 from aws_lambda_powertools import Logger
-from aws_lambda_powertools.utilities.typing import LambdaContext
+
+if TYPE_CHECKING:
+    from aws_lambda_powertools.utilities.typing import LambdaContext
 
 ENDPOINT = "http://httpbin.org/status/500"
 logger = Logger(log_uncaught_exceptions=True)

--- a/examples/logger/src/observability_provider_builtin_formatters.py
+++ b/examples/logger/src/observability_provider_builtin_formatters.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from aws_lambda_powertools import Logger
 from aws_lambda_powertools.logging.formatters.datadog import DatadogLogFormatter
 

--- a/examples/logger/src/overriding_log_records.py
+++ b/examples/logger/src/overriding_log_records.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from aws_lambda_powertools import Logger
 
 location_format = "[%(funcName)s] %(module)s"

--- a/examples/logger/src/powertools_formatter_setup.py
+++ b/examples/logger/src/powertools_formatter_setup.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from aws_lambda_powertools import Logger
 from aws_lambda_powertools.logging.formatter import LambdaPowertoolsFormatter
 

--- a/examples/logger/src/remove_keys.py
+++ b/examples/logger/src/remove_keys.py
@@ -1,5 +1,11 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 from aws_lambda_powertools import Logger
-from aws_lambda_powertools.utilities.typing import LambdaContext
+
+if TYPE_CHECKING:
+    from aws_lambda_powertools.utilities.typing import LambdaContext
 
 logger = Logger()
 

--- a/examples/logger/src/reordering_log_keys.py
+++ b/examples/logger/src/reordering_log_keys.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from aws_lambda_powertools import Logger
 
 # make message as the first key

--- a/examples/logger/src/sampling_debug_logs.py
+++ b/examples/logger/src/sampling_debug_logs.py
@@ -1,5 +1,11 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 from aws_lambda_powertools import Logger
-from aws_lambda_powertools.utilities.typing import LambdaContext
+
+if TYPE_CHECKING:
+    from aws_lambda_powertools.utilities.typing import LambdaContext
 
 # Sample 10% of debug logs e.g. 0.1
 # NOTE: this evaluation will only occur at cold start

--- a/examples/logger/src/set_correlation_id.py
+++ b/examples/logger/src/set_correlation_id.py
@@ -1,5 +1,11 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 from aws_lambda_powertools import Logger
-from aws_lambda_powertools.utilities.typing import LambdaContext
+
+if TYPE_CHECKING:
+    from aws_lambda_powertools.utilities.typing import LambdaContext
 
 logger = Logger()
 

--- a/examples/logger/src/set_correlation_id_jmespath.py
+++ b/examples/logger/src/set_correlation_id_jmespath.py
@@ -1,6 +1,12 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 from aws_lambda_powertools import Logger
 from aws_lambda_powertools.logging import correlation_paths
-from aws_lambda_powertools.utilities.typing import LambdaContext
+
+if TYPE_CHECKING:
+    from aws_lambda_powertools.utilities.typing import LambdaContext
 
 logger = Logger()
 

--- a/examples/logger/src/set_correlation_id_method.py
+++ b/examples/logger/src/set_correlation_id_method.py
@@ -1,6 +1,12 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 from aws_lambda_powertools import Logger
 from aws_lambda_powertools.utilities.data_classes import APIGatewayProxyEvent
-from aws_lambda_powertools.utilities.typing import LambdaContext
+
+if TYPE_CHECKING:
+    from aws_lambda_powertools.utilities.typing import LambdaContext
 
 logger = Logger()
 

--- a/examples/logger/src/setting_log_level_programmatically.py
+++ b/examples/logger/src/setting_log_level_programmatically.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from aws_lambda_powertools import Logger
 
 logger = Logger()

--- a/examples/logger/src/setting_log_level_via_constructor.py
+++ b/examples/logger/src/setting_log_level_via_constructor.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from aws_lambda_powertools import Logger
 
 logger = Logger(level="ERROR")

--- a/examples/logger/src/setting_utc_timestamp.py
+++ b/examples/logger/src/setting_utc_timestamp.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import os
 import time
 

--- a/examples/logger/src/unserializable_values.py
+++ b/examples/logger/src/unserializable_values.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from datetime import date, datetime
 
 from aws_lambda_powertools import Logger

--- a/examples/metrics/src/add_dimension.py
+++ b/examples/metrics/src/add_dimension.py
@@ -1,8 +1,13 @@
+from __future__ import annotations
+
 import os
+from typing import TYPE_CHECKING
 
 from aws_lambda_powertools import Metrics
 from aws_lambda_powertools.metrics import MetricUnit
-from aws_lambda_powertools.utilities.typing import LambdaContext
+
+if TYPE_CHECKING:
+    from aws_lambda_powertools.utilities.typing import LambdaContext
 
 STAGE = os.getenv("STAGE", "dev")
 metrics = Metrics()

--- a/examples/metrics/src/add_high_resolution_metric.py
+++ b/examples/metrics/src/add_high_resolution_metric.py
@@ -1,6 +1,12 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 from aws_lambda_powertools import Metrics
 from aws_lambda_powertools.metrics import MetricResolution, MetricUnit
-from aws_lambda_powertools.utilities.typing import LambdaContext
+
+if TYPE_CHECKING:
+    from aws_lambda_powertools.utilities.typing import LambdaContext
 
 metrics = Metrics()
 

--- a/examples/metrics/src/add_metadata.py
+++ b/examples/metrics/src/add_metadata.py
@@ -1,8 +1,13 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
 from uuid import uuid4
 
 from aws_lambda_powertools import Metrics
 from aws_lambda_powertools.metrics import MetricUnit
-from aws_lambda_powertools.utilities.typing import LambdaContext
+
+if TYPE_CHECKING:
+    from aws_lambda_powertools.utilities.typing import LambdaContext
 
 metrics = Metrics()
 

--- a/examples/metrics/src/add_metrics.py
+++ b/examples/metrics/src/add_metrics.py
@@ -1,6 +1,12 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 from aws_lambda_powertools import Metrics
 from aws_lambda_powertools.metrics import MetricUnit
-from aws_lambda_powertools.utilities.typing import LambdaContext
+
+if TYPE_CHECKING:
+    from aws_lambda_powertools.utilities.typing import LambdaContext
 
 metrics = Metrics()
 

--- a/examples/metrics/src/add_multi_value_metrics.py
+++ b/examples/metrics/src/add_multi_value_metrics.py
@@ -1,8 +1,13 @@
+from __future__ import annotations
+
 import os
+from typing import TYPE_CHECKING
 
 from aws_lambda_powertools import Metrics
 from aws_lambda_powertools.metrics import MetricUnit
-from aws_lambda_powertools.utilities.typing import LambdaContext
+
+if TYPE_CHECKING:
+    from aws_lambda_powertools.utilities.typing import LambdaContext
 
 STAGE = os.getenv("STAGE", "dev")
 metrics = Metrics()

--- a/examples/metrics/src/assert_multiple_emf_blobs.py
+++ b/examples/metrics/src/assert_multiple_emf_blobs.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import json
 from dataclasses import dataclass
 

--- a/examples/metrics/src/assert_multiple_emf_blobs_module.py
+++ b/examples/metrics/src/assert_multiple_emf_blobs_module.py
@@ -1,6 +1,12 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 from aws_lambda_powertools import Metrics
 from aws_lambda_powertools.metrics import MetricUnit
-from aws_lambda_powertools.utilities.typing import LambdaContext
+
+if TYPE_CHECKING:
+    from aws_lambda_powertools.utilities.typing import LambdaContext
 
 metrics = Metrics()
 

--- a/examples/metrics/src/assert_single_emf_blob.py
+++ b/examples/metrics/src/assert_single_emf_blob.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import json
 
 import add_metrics

--- a/examples/metrics/src/capture_cold_start_metric.py
+++ b/examples/metrics/src/capture_cold_start_metric.py
@@ -1,9 +1,14 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 from aws_lambda_powertools import Metrics
-from aws_lambda_powertools.utilities.typing import LambdaContext
+
+if TYPE_CHECKING:
+    from aws_lambda_powertools.utilities.typing import LambdaContext
 
 metrics = Metrics()
 
 
 @metrics.log_metrics(capture_cold_start_metric=True)
-def lambda_handler(event: dict, context: LambdaContext):
-    ...
+def lambda_handler(event: dict, context: LambdaContext): ...

--- a/examples/metrics/src/clear_metrics_in_tests.py
+++ b/examples/metrics/src/clear_metrics_in_tests.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pytest
 
 from aws_lambda_powertools import Metrics

--- a/examples/metrics/src/ephemeral_metrics.py
+++ b/examples/metrics/src/ephemeral_metrics.py
@@ -1,5 +1,11 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 from aws_lambda_powertools.metrics import EphemeralMetrics, MetricUnit
-from aws_lambda_powertools.utilities.typing import LambdaContext
+
+if TYPE_CHECKING:
+    from aws_lambda_powertools.utilities.typing import LambdaContext
 
 metrics = EphemeralMetrics()
 

--- a/examples/metrics/src/flush_metrics.py
+++ b/examples/metrics/src/flush_metrics.py
@@ -1,11 +1,17 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 from aws_lambda_powertools import Metrics
 from aws_lambda_powertools.metrics import MetricUnit
-from aws_lambda_powertools.utilities.typing import LambdaContext
+
+if TYPE_CHECKING:
+    from aws_lambda_powertools.utilities.typing import LambdaContext
 
 metrics = Metrics()
 
 
-def book_flight(flight_id: str, **kwargs): 
+def book_flight(flight_id: str, **kwargs):
     # logic to book flight
     ...
     metrics.add_metric(name="SuccessfulBooking", unit=MetricUnit.Count, value=1)

--- a/examples/metrics/src/raise_on_empty_metrics.py
+++ b/examples/metrics/src/raise_on_empty_metrics.py
@@ -1,5 +1,11 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 from aws_lambda_powertools.metrics import Metrics
-from aws_lambda_powertools.utilities.typing import LambdaContext
+
+if TYPE_CHECKING:
+    from aws_lambda_powertools.utilities.typing import LambdaContext
 
 metrics = Metrics()
 

--- a/examples/metrics/src/set_custom_timestamp_log_metrics.py
+++ b/examples/metrics/src/set_custom_timestamp_log_metrics.py
@@ -1,8 +1,13 @@
+from __future__ import annotations
+
 import datetime
+from typing import TYPE_CHECKING
 
 from aws_lambda_powertools import Metrics
 from aws_lambda_powertools.metrics import MetricUnit
-from aws_lambda_powertools.utilities.typing import LambdaContext
+
+if TYPE_CHECKING:
+    from aws_lambda_powertools.utilities.typing import LambdaContext
 
 metrics = Metrics()
 

--- a/examples/metrics/src/set_default_dimensions.py
+++ b/examples/metrics/src/set_default_dimensions.py
@@ -1,8 +1,13 @@
+from __future__ import annotations
+
 import os
+from typing import TYPE_CHECKING
 
 from aws_lambda_powertools import Metrics
 from aws_lambda_powertools.metrics import MetricUnit
-from aws_lambda_powertools.utilities.typing import LambdaContext
+
+if TYPE_CHECKING:
+    from aws_lambda_powertools.utilities.typing import LambdaContext
 
 STAGE = os.getenv("STAGE", "dev")
 metrics = Metrics()

--- a/examples/metrics/src/set_default_dimensions_log_metrics.py
+++ b/examples/metrics/src/set_default_dimensions_log_metrics.py
@@ -1,8 +1,13 @@
+from __future__ import annotations
+
 import os
+from typing import TYPE_CHECKING
 
 from aws_lambda_powertools import Metrics
 from aws_lambda_powertools.metrics import MetricUnit
-from aws_lambda_powertools.utilities.typing import LambdaContext
+
+if TYPE_CHECKING:
+    from aws_lambda_powertools.utilities.typing import LambdaContext
 
 STAGE = os.getenv("STAGE", "dev")
 metrics = Metrics()

--- a/examples/metrics/src/single_metric.py
+++ b/examples/metrics/src/single_metric.py
@@ -1,8 +1,13 @@
+from __future__ import annotations
+
 import os
+from typing import TYPE_CHECKING
 
 from aws_lambda_powertools import single_metric
 from aws_lambda_powertools.metrics import MetricUnit
-from aws_lambda_powertools.utilities.typing import LambdaContext
+
+if TYPE_CHECKING:
+    from aws_lambda_powertools.utilities.typing import LambdaContext
 
 STAGE = os.getenv("STAGE", "dev")
 

--- a/examples/metrics/src/single_metric_default_dimensions.py
+++ b/examples/metrics/src/single_metric_default_dimensions.py
@@ -1,8 +1,13 @@
+from __future__ import annotations
+
 import os
+from typing import TYPE_CHECKING
 
 from aws_lambda_powertools import single_metric
 from aws_lambda_powertools.metrics import MetricUnit
-from aws_lambda_powertools.utilities.typing import LambdaContext
+
+if TYPE_CHECKING:
+    from aws_lambda_powertools.utilities.typing import LambdaContext
 
 STAGE = os.getenv("STAGE", "dev")
 

--- a/examples/metrics/src/single_metric_default_dimensions_inherit.py
+++ b/examples/metrics/src/single_metric_default_dimensions_inherit.py
@@ -1,8 +1,13 @@
+from __future__ import annotations
+
 import os
+from typing import TYPE_CHECKING
 
 from aws_lambda_powertools import single_metric
 from aws_lambda_powertools.metrics import Metrics, MetricUnit
-from aws_lambda_powertools.utilities.typing import LambdaContext
+
+if TYPE_CHECKING:
+    from aws_lambda_powertools.utilities.typing import LambdaContext
 
 STAGE = os.getenv("STAGE", "dev")
 

--- a/examples/metrics/src/single_metric_with_different_timestamp.py
+++ b/examples/metrics/src/single_metric_with_different_timestamp.py
@@ -1,6 +1,12 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 from aws_lambda_powertools import Logger, single_metric
 from aws_lambda_powertools.metrics import MetricUnit
-from aws_lambda_powertools.utilities.typing import LambdaContext
+
+if TYPE_CHECKING:
+    from aws_lambda_powertools.utilities.typing import LambdaContext
 
 logger = Logger()
 

--- a/examples/metrics_datadog/src/add_datadog_metrics.py
+++ b/examples/metrics_datadog/src/add_datadog_metrics.py
@@ -1,5 +1,11 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 from aws_lambda_powertools.metrics.provider.datadog import DatadogMetrics
-from aws_lambda_powertools.utilities.typing import LambdaContext
+
+if TYPE_CHECKING:
+    from aws_lambda_powertools.utilities.typing import LambdaContext
 
 metrics = DatadogMetrics()
 

--- a/examples/metrics_datadog/src/add_metrics_with_tags.py
+++ b/examples/metrics_datadog/src/add_metrics_with_tags.py
@@ -1,5 +1,11 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 from aws_lambda_powertools.metrics.provider.datadog import DatadogMetrics
-from aws_lambda_powertools.utilities.typing import LambdaContext
+
+if TYPE_CHECKING:
+    from aws_lambda_powertools.utilities.typing import LambdaContext
 
 metrics = DatadogMetrics()
 

--- a/examples/metrics_datadog/src/add_metrics_with_timestamp.py
+++ b/examples/metrics_datadog/src/add_metrics_with_timestamp.py
@@ -1,7 +1,12 @@
+from __future__ import annotations
+
 import time
+from typing import TYPE_CHECKING
 
 from aws_lambda_powertools.metrics.provider.datadog import DatadogMetrics
-from aws_lambda_powertools.utilities.typing import LambdaContext
+
+if TYPE_CHECKING:
+    from aws_lambda_powertools.utilities.typing import LambdaContext
 
 metrics = DatadogMetrics()
 

--- a/examples/metrics_datadog/src/assert_single_datadog_metric.py
+++ b/examples/metrics_datadog/src/assert_single_datadog_metric.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import add_datadog_metrics
 
 

--- a/examples/metrics_datadog/src/capture_cold_start_datadog_metric.py
+++ b/examples/metrics_datadog/src/capture_cold_start_datadog_metric.py
@@ -1,5 +1,11 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 from aws_lambda_powertools.metrics.provider.datadog import DatadogMetrics
-from aws_lambda_powertools.utilities.typing import LambdaContext
+
+if TYPE_CHECKING:
+    from aws_lambda_powertools.utilities.typing import LambdaContext
 
 metrics = DatadogMetrics()
 

--- a/examples/metrics_datadog/src/clear_datadog_metrics_in_tests.py
+++ b/examples/metrics_datadog/src/clear_datadog_metrics_in_tests.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pytest
 
 from aws_lambda_powertools.metrics.provider import cold_start

--- a/examples/metrics_datadog/src/flush_datadog_metrics.py
+++ b/examples/metrics_datadog/src/flush_datadog_metrics.py
@@ -1,5 +1,11 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 from aws_lambda_powertools.metrics.provider.datadog import DatadogMetrics
-from aws_lambda_powertools.utilities.typing import LambdaContext
+
+if TYPE_CHECKING:
+    from aws_lambda_powertools.utilities.typing import LambdaContext
 
 metrics = DatadogMetrics()
 

--- a/examples/metrics_datadog/src/flush_metrics_to_standard_output.py
+++ b/examples/metrics_datadog/src/flush_metrics_to_standard_output.py
@@ -1,5 +1,11 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 from aws_lambda_powertools.metrics.provider.datadog import DatadogMetrics
-from aws_lambda_powertools.utilities.typing import LambdaContext
+
+if TYPE_CHECKING:
+    from aws_lambda_powertools.utilities.typing import LambdaContext
 
 metrics = DatadogMetrics(flush_to_log=True)
 

--- a/examples/metrics_datadog/src/raise_on_empty_datadog_metrics.py
+++ b/examples/metrics_datadog/src/raise_on_empty_datadog_metrics.py
@@ -1,5 +1,11 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 from aws_lambda_powertools.metrics.provider.datadog import DatadogMetrics
-from aws_lambda_powertools.utilities.typing import LambdaContext
+
+if TYPE_CHECKING:
+    from aws_lambda_powertools.utilities.typing import LambdaContext
 
 metrics = DatadogMetrics()
 

--- a/examples/metrics_datadog/src/set_default_tags.py
+++ b/examples/metrics_datadog/src/set_default_tags.py
@@ -1,5 +1,11 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 from aws_lambda_powertools.metrics.provider.datadog import DatadogMetrics
-from aws_lambda_powertools.utilities.typing import LambdaContext
+
+if TYPE_CHECKING:
+    from aws_lambda_powertools.utilities.typing import LambdaContext
 
 metrics = DatadogMetrics()
 metrics.set_default_tags(tag1="powertools", tag2="python")

--- a/examples/metrics_datadog/src/set_default_tags_log_metrics.py
+++ b/examples/metrics_datadog/src/set_default_tags_log_metrics.py
@@ -1,5 +1,11 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 from aws_lambda_powertools.metrics.provider.datadog import DatadogMetrics
-from aws_lambda_powertools.utilities.typing import LambdaContext
+
+if TYPE_CHECKING:
+    from aws_lambda_powertools.utilities.typing import LambdaContext
 
 metrics = DatadogMetrics()
 

--- a/examples/middleware_factory/src/advanced_middleware_tracer_function.py
+++ b/examples/middleware_factory/src/advanced_middleware_tracer_function.py
@@ -1,5 +1,7 @@
+from __future__ import annotations
+
 import time
-from typing import Callable
+from typing import TYPE_CHECKING, Callable
 
 import requests
 from requests import Response
@@ -7,7 +9,9 @@ from requests import Response
 from aws_lambda_powertools import Tracer
 from aws_lambda_powertools.event_handler import APIGatewayRestResolver
 from aws_lambda_powertools.middleware_factory import lambda_handler_decorator
-from aws_lambda_powertools.utilities.typing import LambdaContext
+
+if TYPE_CHECKING:
+    from aws_lambda_powertools.utilities.typing import LambdaContext
 
 tracer = Tracer()
 app = APIGatewayRestResolver()

--- a/examples/middleware_factory/src/combining_powertools_utilities_function.py
+++ b/examples/middleware_factory/src/combining_powertools_utilities_function.py
@@ -1,5 +1,7 @@
+from __future__ import annotations
+
 import json
-from typing import Callable
+from typing import TYPE_CHECKING, Callable
 
 import boto3
 import combining_powertools_utilities_schema as schemas
@@ -14,6 +16,10 @@ from aws_lambda_powertools.utilities.feature_flags.types import JSONType
 from aws_lambda_powertools.utilities.jmespath_utils import query
 from aws_lambda_powertools.utilities.typing import LambdaContext
 from aws_lambda_powertools.utilities.validation import SchemaValidationError, validate
+
+if TYPE_CHECKING:
+    from aws_lambda_powertools.utilities.feature_flags.types import JSONType
+    from aws_lambda_powertools.utilities.typing import LambdaContext
 
 app = APIGatewayRestResolver()
 tracer = Tracer()

--- a/examples/middleware_factory/src/combining_powertools_utilities_schema.py
+++ b/examples/middleware_factory/src/combining_powertools_utilities_schema.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 INPUT = {
     "$schema": "http://json-schema.org/draft-07/schema#",
     "$id": "https://example.com/object1661012141.json",

--- a/examples/middleware_factory/src/getting_started_middleware_after_logic_function.py
+++ b/examples/middleware_factory/src/getting_started_middleware_after_logic_function.py
@@ -1,12 +1,16 @@
+from __future__ import annotations
+
 import time
-from typing import Callable
+from typing import TYPE_CHECKING, Callable
 
 import requests
 from requests import Response
 
 from aws_lambda_powertools.event_handler import APIGatewayRestResolver
 from aws_lambda_powertools.middleware_factory import lambda_handler_decorator
-from aws_lambda_powertools.utilities.typing import LambdaContext
+
+if TYPE_CHECKING:
+    from aws_lambda_powertools.utilities.typing import LambdaContext
 
 app = APIGatewayRestResolver()
 

--- a/examples/middleware_factory/src/getting_started_middleware_before_logic_function.py
+++ b/examples/middleware_factory/src/getting_started_middleware_before_logic_function.py
@@ -1,5 +1,7 @@
+from __future__ import annotations
+
 from dataclasses import dataclass, field
-from typing import Callable
+from typing import TYPE_CHECKING, Callable
 from uuid import uuid4
 
 from aws_lambda_powertools.middleware_factory import lambda_handler_decorator
@@ -7,7 +9,9 @@ from aws_lambda_powertools.utilities.jmespath_utils import (
     envelopes,
     query,
 )
-from aws_lambda_powertools.utilities.typing import LambdaContext
+
+if TYPE_CHECKING:
+    from aws_lambda_powertools.utilities.typing import LambdaContext
 
 
 @dataclass

--- a/examples/middleware_factory/src/getting_started_middleware_tracer_function.py
+++ b/examples/middleware_factory/src/getting_started_middleware_tracer_function.py
@@ -1,12 +1,16 @@
+from __future__ import annotations
+
 import time
-from typing import Callable
+from typing import TYPE_CHECKING, Callable
 
 import requests
 from requests import Response
 
 from aws_lambda_powertools.event_handler import APIGatewayRestResolver
 from aws_lambda_powertools.middleware_factory import lambda_handler_decorator
-from aws_lambda_powertools.utilities.typing import LambdaContext
+
+if TYPE_CHECKING:
+    from aws_lambda_powertools.utilities.typing import LambdaContext
 
 app = APIGatewayRestResolver()
 

--- a/examples/middleware_factory/src/getting_started_middleware_with_params_function.py
+++ b/examples/middleware_factory/src/getting_started_middleware_with_params_function.py
@@ -1,6 +1,8 @@
+from __future__ import annotations
+
 import base64
 from dataclasses import dataclass, field
-from typing import Any, Callable, List
+from typing import TYPE_CHECKING, Any, Callable
 from uuid import uuid4
 
 from aws_lambda_powertools.middleware_factory import lambda_handler_decorator
@@ -8,7 +10,9 @@ from aws_lambda_powertools.utilities.jmespath_utils import (
     envelopes,
     query,
 )
-from aws_lambda_powertools.utilities.typing import LambdaContext
+
+if TYPE_CHECKING:
+    from aws_lambda_powertools.utilities.typing import LambdaContext
 
 
 @dataclass
@@ -31,7 +35,7 @@ def obfuscate_sensitive_data(
     handler: Callable[[dict, LambdaContext], dict],
     event: dict,
     context: LambdaContext,
-    fields: List,
+    fields: list,
 ) -> dict:
     # extracting payload from a EventBridge event
     detail: dict = query(data=event, envelope=envelopes.EVENTBRIDGE)

--- a/examples/parameters/src/appconfig_force_fetch.py
+++ b/examples/parameters/src/appconfig_force_fetch.py
@@ -1,9 +1,13 @@
-from typing import Any
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
 
 import requests
 
 from aws_lambda_powertools.utilities import parameters
-from aws_lambda_powertools.utilities.typing import LambdaContext
+
+if TYPE_CHECKING:
+    from aws_lambda_powertools.utilities.typing import LambdaContext
 
 
 def lambda_handler(event: dict, context: LambdaContext):

--- a/examples/parameters/src/appconfig_with_cache.py
+++ b/examples/parameters/src/appconfig_with_cache.py
@@ -1,9 +1,13 @@
-from typing import Any
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
 
 import requests
 
 from aws_lambda_powertools.utilities import parameters
-from aws_lambda_powertools.utilities.typing import LambdaContext
+
+if TYPE_CHECKING:
+    from aws_lambda_powertools.utilities.typing import LambdaContext
 
 
 def lambda_handler(event: dict, context: LambdaContext):

--- a/examples/parameters/src/builtin_provider_appconfig.py
+++ b/examples/parameters/src/builtin_provider_appconfig.py
@@ -1,10 +1,14 @@
-from typing import Any
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
 
 import requests
 from botocore.config import Config
 
 from aws_lambda_powertools.utilities import parameters
-from aws_lambda_powertools.utilities.typing import LambdaContext
+
+if TYPE_CHECKING:
+    from aws_lambda_powertools.utilities.typing import LambdaContext
 
 config = Config(region_name="sa-east-1")
 appconf_provider = parameters.AppConfigProvider(environment="dev", application="comments", config=config)

--- a/examples/parameters/src/builtin_provider_dynamodb_custom_endpoint.py
+++ b/examples/parameters/src/builtin_provider_dynamodb_custom_endpoint.py
@@ -1,9 +1,13 @@
-from typing import Any
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
 
 import requests
 
 from aws_lambda_powertools.utilities import parameters
-from aws_lambda_powertools.utilities.typing import LambdaContext
+
+if TYPE_CHECKING:
+    from aws_lambda_powertools.utilities.typing import LambdaContext
 
 dynamodb_provider = parameters.DynamoDBProvider(table_name="ParameterTable", endpoint_url="http://localhost:8000")
 

--- a/examples/parameters/src/builtin_provider_dynamodb_custom_fields.py
+++ b/examples/parameters/src/builtin_provider_dynamodb_custom_fields.py
@@ -1,9 +1,13 @@
-from typing import Any
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
 
 import requests
 
 from aws_lambda_powertools.utilities import parameters
-from aws_lambda_powertools.utilities.typing import LambdaContext
+
+if TYPE_CHECKING:
+    from aws_lambda_powertools.utilities.typing import LambdaContext
 
 dynamodb_provider = parameters.DynamoDBProvider(
     table_name="ParameterTable",

--- a/examples/parameters/src/builtin_provider_dynamodb_recursive_parameter.py
+++ b/examples/parameters/src/builtin_provider_dynamodb_recursive_parameter.py
@@ -1,9 +1,13 @@
-from typing import Any
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
 
 import requests
 
 from aws_lambda_powertools.utilities import parameters
-from aws_lambda_powertools.utilities.typing import LambdaContext
+
+if TYPE_CHECKING:
+    from aws_lambda_powertools.utilities.typing import LambdaContext
 
 dynamodb_provider = parameters.DynamoDBProvider(table_name="ParameterTable")
 

--- a/examples/parameters/src/builtin_provider_dynamodb_single_parameter.py
+++ b/examples/parameters/src/builtin_provider_dynamodb_single_parameter.py
@@ -1,9 +1,13 @@
-from typing import Any
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
 
 import requests
 
 from aws_lambda_powertools.utilities import parameters
-from aws_lambda_powertools.utilities.typing import LambdaContext
+
+if TYPE_CHECKING:
+    from aws_lambda_powertools.utilities.typing import LambdaContext
 
 dynamodb_provider = parameters.DynamoDBProvider(table_name="ParameterTable")
 

--- a/examples/parameters/src/builtin_provider_secret.py
+++ b/examples/parameters/src/builtin_provider_secret.py
@@ -1,10 +1,14 @@
-from typing import Any
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
 
 import requests
 from botocore.config import Config
 
 from aws_lambda_powertools.utilities import parameters
-from aws_lambda_powertools.utilities.typing import LambdaContext
+
+if TYPE_CHECKING:
+    from aws_lambda_powertools.utilities.typing import LambdaContext
 
 config = Config(region_name="sa-east-1", connect_timeout=1, retries={"total_max_attempts": 2, "max_attempts": 5})
 ssm_provider = parameters.SecretsProvider(config=config)

--- a/examples/parameters/src/builtin_provider_ssm_recursive_parameter.py
+++ b/examples/parameters/src/builtin_provider_ssm_recursive_parameter.py
@@ -1,10 +1,14 @@
-from typing import Any
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
 
 import boto3
 import requests
 
 from aws_lambda_powertools.utilities import parameters
-from aws_lambda_powertools.utilities.typing import LambdaContext
+
+if TYPE_CHECKING:
+    from aws_lambda_powertools.utilities.typing import LambdaContext
 
 # assuming role from another account to get parameter there
 # see: https://docs.aws.amazon.com/STS/latest/APIReference/API_AssumeRole.html

--- a/examples/parameters/src/builtin_provider_ssm_single_parameter.py
+++ b/examples/parameters/src/builtin_provider_ssm_single_parameter.py
@@ -1,10 +1,14 @@
-from typing import Any
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
 
 import requests
 from botocore.config import Config
 
 from aws_lambda_powertools.utilities import parameters
-from aws_lambda_powertools.utilities.typing import LambdaContext
+
+if TYPE_CHECKING:
+    from aws_lambda_powertools.utilities.typing import LambdaContext
 
 # changing region_name, connect_timeout and retrie configurations
 # see: https://botocore.amazonaws.com/v1/documentation/api/latest/reference/config.html

--- a/examples/parameters/src/builtin_provider_ssm_with_decrypt.py
+++ b/examples/parameters/src/builtin_provider_ssm_with_decrypt.py
@@ -1,10 +1,14 @@
-from typing import Any
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
 from uuid import uuid4
 
 import boto3
 
 from aws_lambda_powertools.utilities import parameters
-from aws_lambda_powertools.utilities.typing import LambdaContext
+
+if TYPE_CHECKING:
+    from aws_lambda_powertools.utilities.typing import LambdaContext
 
 ec2 = boto3.resource("ec2")
 ssm_provider = parameters.SSMProvider()

--- a/examples/parameters/src/builtin_provider_ssm_with_no_recursive.py
+++ b/examples/parameters/src/builtin_provider_ssm_with_no_recursive.py
@@ -1,15 +1,18 @@
-from typing import Any
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
 
 import requests
 
 from aws_lambda_powertools.utilities import parameters
-from aws_lambda_powertools.utilities.typing import LambdaContext
+
+if TYPE_CHECKING:
+    from aws_lambda_powertools.utilities.typing import LambdaContext
 
 ssm_provider = parameters.SSMProvider()
 
 
-class ConfigNotFound(Exception):
-    ...
+class ConfigNotFound(Exception): ...
 
 
 def lambda_handler(event: dict, context: LambdaContext):

--- a/examples/parameters/src/custom_boto3_all_providers.py
+++ b/examples/parameters/src/custom_boto3_all_providers.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import boto3
 from botocore.config import Config
 

--- a/examples/parameters/src/custom_boto_client.py
+++ b/examples/parameters/src/custom_boto_client.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import boto3
 
 from aws_lambda_powertools.utilities import parameters

--- a/examples/parameters/src/custom_boto_config.py
+++ b/examples/parameters/src/custom_boto_config.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from botocore.config import Config
 
 from aws_lambda_powertools.utilities import parameters

--- a/examples/parameters/src/custom_boto_session.py
+++ b/examples/parameters/src/custom_boto_session.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import boto3
 
 from aws_lambda_powertools.utilities import parameters

--- a/examples/parameters/src/custom_provider_s3.py
+++ b/examples/parameters/src/custom_provider_s3.py
@@ -1,5 +1,7 @@
+from __future__ import annotations
+
 import copy
-from typing import Dict
+from typing import dict
 
 import boto3
 
@@ -26,7 +28,7 @@ class S3Provider(BaseProvider):
         response = self.client.get_object(**sdk_options)
         return response["Body"].read().decode()
 
-    def _get_multiple(self, path: str, **sdk_options) -> Dict[str, str]:
+    def _get_multiple(self, path: str, **sdk_options) -> dict[str, str]:
         # Retrieve multiple values
         # E.g.:
 

--- a/examples/parameters/src/custom_provider_vault.py
+++ b/examples/parameters/src/custom_provider_vault.py
@@ -1,4 +1,6 @@
-from typing import Any, Dict
+from __future__ import annotations
+
+from typing import Any
 
 from hvac import Client
 
@@ -12,13 +14,13 @@ class VaultProvider(BaseProvider):
         self.vault_client = Client(url=vault_url, verify=False, timeout=10)
         self.vault_client.token = vault_token
 
-    def _get(self, name: str, **sdk_options) -> Dict[str, Any]:
+    def _get(self, name: str, **sdk_options) -> dict[str, Any]:
         # for example proposal, the mountpoint is always /secret
         kv_configuration = self.vault_client.secrets.kv.v2.read_secret(path=name)
 
         return kv_configuration["data"]["data"]
 
-    def _get_multiple(self, path: str, **sdk_options) -> Dict[str, str]:
+    def _get_multiple(self, path: str, **sdk_options) -> dict[str, str]:
         list_secrets = {}
         all_secrets = self.vault_client.secrets.kv.v2.list_secrets(path=path)
 

--- a/examples/parameters/src/getting_started_appconfig.py
+++ b/examples/parameters/src/getting_started_appconfig.py
@@ -1,9 +1,13 @@
-from typing import Any
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
 
 import requests
 
 from aws_lambda_powertools.utilities import parameters
-from aws_lambda_powertools.utilities.typing import LambdaContext
+
+if TYPE_CHECKING:
+    from aws_lambda_powertools.utilities.typing import LambdaContext
 
 
 def lambda_handler(event: dict, context: LambdaContext):

--- a/examples/parameters/src/getting_started_recursive_ssm_parameter.py
+++ b/examples/parameters/src/getting_started_recursive_ssm_parameter.py
@@ -1,7 +1,13 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 import requests
 
 from aws_lambda_powertools.utilities import parameters
-from aws_lambda_powertools.utilities.typing import LambdaContext
+
+if TYPE_CHECKING:
+    from aws_lambda_powertools.utilities.typing import LambdaContext
 
 
 def lambda_handler(event: dict, context: LambdaContext):

--- a/examples/parameters/src/getting_started_secret.py
+++ b/examples/parameters/src/getting_started_secret.py
@@ -1,9 +1,13 @@
-from typing import Any
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
 
 import requests
 
 from aws_lambda_powertools.utilities import parameters
-from aws_lambda_powertools.utilities.typing import LambdaContext
+
+if TYPE_CHECKING:
+    from aws_lambda_powertools.utilities.typing import LambdaContext
 
 
 def lambda_handler(event: dict, context: LambdaContext):

--- a/examples/parameters/src/getting_started_set_single_ssm_parameter.py
+++ b/examples/parameters/src/getting_started_set_single_ssm_parameter.py
@@ -1,10 +1,16 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 from aws_lambda_powertools.utilities import parameters
-from aws_lambda_powertools.utilities.typing import LambdaContext
+
+if TYPE_CHECKING:
+    from aws_lambda_powertools.utilities.typing import LambdaContext
 
 
 def lambda_handler(event: dict, context: LambdaContext) -> dict:
     try:
-        # Set a single parameter, returns the version ID of the parameter
+        # set a single parameter, returns the version ID of the parameter
         parameter_version = parameters.set_parameter(name="/mySuper/Parameter", value="PowerToolsIsAwesome")
 
         return {"mySuperParameterVersion": parameter_version, "statusCode": 200}

--- a/examples/parameters/src/getting_started_set_ssm_parameter_overwrite.py
+++ b/examples/parameters/src/getting_started_set_ssm_parameter_overwrite.py
@@ -1,10 +1,16 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 from aws_lambda_powertools.utilities import parameters
-from aws_lambda_powertools.utilities.typing import LambdaContext
+
+if TYPE_CHECKING:
+    from aws_lambda_powertools.utilities.typing import LambdaContext
 
 
 def lambda_handler(event: dict, context: LambdaContext) -> dict:
     try:
-        # Set a single parameter, but overwrite if it already exists.
+        # set a single parameter, but overwrite if it already exists.
         # Overwrite is False by default, so we explicitly set it to True
         updating_parameter = parameters.set_parameter(
             name="/mySuper/Parameter",

--- a/examples/parameters/src/getting_started_setting_secret.py
+++ b/examples/parameters/src/getting_started_setting_secret.py
@@ -1,8 +1,12 @@
-from typing import Any
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
 
 from aws_lambda_powertools import Logger
 from aws_lambda_powertools.utilities import parameters
-from aws_lambda_powertools.utilities.typing import LambdaContext
+
+if TYPE_CHECKING:
+    from aws_lambda_powertools.utilities.typing import LambdaContext
 
 logger = Logger(serialize_stacktrace=True)
 

--- a/examples/parameters/src/getting_started_single_ssm_parameter.py
+++ b/examples/parameters/src/getting_started_single_ssm_parameter.py
@@ -1,7 +1,13 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 import requests
 
 from aws_lambda_powertools.utilities import parameters
-from aws_lambda_powertools.utilities.typing import LambdaContext
+
+if TYPE_CHECKING:
+    from aws_lambda_powertools.utilities.typing import LambdaContext
 
 
 def lambda_handler(event: dict, context: LambdaContext) -> dict:

--- a/examples/parameters/src/handling_error_transform.py
+++ b/examples/parameters/src/handling_error_transform.py
@@ -1,7 +1,11 @@
-from typing import Any
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
 
 from aws_lambda_powertools.utilities import parameters
-from aws_lambda_powertools.utilities.typing import LambdaContext
+
+if TYPE_CHECKING:
+    from aws_lambda_powertools.utilities.typing import LambdaContext
 
 ssm_provider = parameters.SSMProvider()
 

--- a/examples/parameters/src/recursive_ssm_parameter_force_fetch.py
+++ b/examples/parameters/src/recursive_ssm_parameter_force_fetch.py
@@ -1,9 +1,13 @@
-from typing import Any
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
 
 import requests
 
 from aws_lambda_powertools.utilities import parameters
-from aws_lambda_powertools.utilities.typing import LambdaContext
+
+if TYPE_CHECKING:
+    from aws_lambda_powertools.utilities.typing import LambdaContext
 
 
 def lambda_handler(event: dict, context: LambdaContext):

--- a/examples/parameters/src/recursive_ssm_parameter_with_cache.py
+++ b/examples/parameters/src/recursive_ssm_parameter_with_cache.py
@@ -1,9 +1,13 @@
-from typing import Any
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
 
 import requests
 
 from aws_lambda_powertools.utilities import parameters
-from aws_lambda_powertools.utilities.typing import LambdaContext
+
+if TYPE_CHECKING:
+    from aws_lambda_powertools.utilities.typing import LambdaContext
 
 
 def lambda_handler(event: dict, context: LambdaContext):

--- a/examples/parameters/src/secret_force_fetch.py
+++ b/examples/parameters/src/secret_force_fetch.py
@@ -1,9 +1,13 @@
-from typing import Any
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
 
 import requests
 
 from aws_lambda_powertools.utilities import parameters
-from aws_lambda_powertools.utilities.typing import LambdaContext
+
+if TYPE_CHECKING:
+    from aws_lambda_powertools.utilities.typing import LambdaContext
 
 
 def lambda_handler(event: dict, context: LambdaContext):

--- a/examples/parameters/src/secret_with_cache.py
+++ b/examples/parameters/src/secret_with_cache.py
@@ -1,9 +1,13 @@
-from typing import Any
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
 
 import requests
 
 from aws_lambda_powertools.utilities import parameters
-from aws_lambda_powertools.utilities.typing import LambdaContext
+
+if TYPE_CHECKING:
+    from aws_lambda_powertools.utilities.typing import LambdaContext
 
 
 def lambda_handler(event: dict, context: LambdaContext):

--- a/examples/parameters/src/single_ssm_parameter_force_fetch.py
+++ b/examples/parameters/src/single_ssm_parameter_force_fetch.py
@@ -1,9 +1,13 @@
-from typing import Any
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
 
 import requests
 
 from aws_lambda_powertools.utilities import parameters
-from aws_lambda_powertools.utilities.typing import LambdaContext
+
+if TYPE_CHECKING:
+    from aws_lambda_powertools.utilities.typing import LambdaContext
 
 
 def lambda_handler(event: dict, context: LambdaContext):

--- a/examples/parameters/src/single_ssm_parameter_with_cache.py
+++ b/examples/parameters/src/single_ssm_parameter_with_cache.py
@@ -1,9 +1,13 @@
-from typing import Any
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
 
 import requests
 
 from aws_lambda_powertools.utilities import parameters
-from aws_lambda_powertools.utilities.typing import LambdaContext
+
+if TYPE_CHECKING:
+    from aws_lambda_powertools.utilities.typing import LambdaContext
 
 
 def lambda_handler(event: dict, context: LambdaContext):

--- a/examples/parameters/src/working_with_auto_transform.py
+++ b/examples/parameters/src/working_with_auto_transform.py
@@ -1,5 +1,11 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 from aws_lambda_powertools.utilities import parameters
-from aws_lambda_powertools.utilities.typing import LambdaContext
+
+if TYPE_CHECKING:
+    from aws_lambda_powertools.utilities.typing import LambdaContext
 
 ssm_provider = parameters.SSMProvider()
 

--- a/examples/parameters/src/working_with_own_provider_s3.py
+++ b/examples/parameters/src/working_with_own_provider_s3.py
@@ -1,10 +1,14 @@
-from typing import Any
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
 
 import requests
 from custom_provider_s3 import S3Provider
 
 from aws_lambda_powertools import Logger
-from aws_lambda_powertools.utilities.typing import LambdaContext
+
+if TYPE_CHECKING:
+    from aws_lambda_powertools.utilities.typing import LambdaContext
 
 logger = Logger()
 

--- a/examples/parameters/src/working_with_own_provider_vault.py
+++ b/examples/parameters/src/working_with_own_provider_vault.py
@@ -1,11 +1,15 @@
-from typing import Any
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
 
 import hvac
 import requests
 from custom_provider_vault import VaultProvider
 
 from aws_lambda_powertools import Logger
-from aws_lambda_powertools.utilities.typing import LambdaContext
+
+if TYPE_CHECKING:
+    from aws_lambda_powertools.utilities.typing import LambdaContext
 
 logger = Logger()
 

--- a/examples/parameters/src/working_with_sdk_additional_arguments.py
+++ b/examples/parameters/src/working_with_sdk_additional_arguments.py
@@ -1,5 +1,11 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 from aws_lambda_powertools.utilities import parameters
-from aws_lambda_powertools.utilities.typing import LambdaContext
+
+if TYPE_CHECKING:
+    from aws_lambda_powertools.utilities.typing import LambdaContext
 
 secrets_provider = parameters.SecretsProvider()
 

--- a/examples/parameters/src/working_with_transform_high_level.py
+++ b/examples/parameters/src/working_with_transform_high_level.py
@@ -1,9 +1,13 @@
-from typing import Any
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
 
 import requests
 
 from aws_lambda_powertools.utilities import parameters
-from aws_lambda_powertools.utilities.typing import LambdaContext
+
+if TYPE_CHECKING:
+    from aws_lambda_powertools.utilities.typing import LambdaContext
 
 
 def lambda_handler(event: dict, context: LambdaContext) -> dict:

--- a/examples/parameters/src/working_with_transform_provider.py
+++ b/examples/parameters/src/working_with_transform_provider.py
@@ -1,10 +1,14 @@
-from typing import Any
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
 
 import requests
 from botocore.config import Config
 
 from aws_lambda_powertools.utilities import parameters
-from aws_lambda_powertools.utilities.typing import LambdaContext
+
+if TYPE_CHECKING:
+    from aws_lambda_powertools.utilities.typing import LambdaContext
 
 config = Config(region_name="sa-east-1")
 appconf_provider = parameters.AppConfigProvider(environment="dev", application="comments", config=config)

--- a/examples/parameters/tests/src/__init__.py
+++ b/examples/parameters/tests/src/__init__.py
@@ -1,0 +1,1 @@
+from __future__ import annotations

--- a/examples/parameters/tests/src/app.py
+++ b/examples/parameters/tests/src/app.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from botocore.config import Config
 
 from aws_lambda_powertools.utilities import parameters

--- a/examples/parameters/tests/src/single_mock.py
+++ b/examples/parameters/tests/src/single_mock.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from aws_lambda_powertools.utilities import parameters
 
 

--- a/examples/parameters/tests/test_clear_cache_global.py
+++ b/examples/parameters/tests/test_clear_cache_global.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pytest
 from src import app
 

--- a/examples/parameters/tests/test_clear_cache_method.py
+++ b/examples/parameters/tests/test_clear_cache_method.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pytest
 from src import app
 

--- a/examples/parameters/tests/test_single_mock.py
+++ b/examples/parameters/tests/test_single_mock.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from src import single_mock
 
 

--- a/examples/parameters/tests/test_with_fixture.py
+++ b/examples/parameters/tests/test_with_fixture.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pytest
 from src import single_mock
 

--- a/examples/parameters/tests/test_with_monkeypatch.py
+++ b/examples/parameters/tests/test_with_monkeypatch.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from unittest.mock import patch
 
 from src import single_mock

--- a/examples/parser/src/extending_built_in_models_with_json_mypy.py
+++ b/examples/parser/src/extending_built_in_models_with_json_mypy.py
@@ -1,8 +1,14 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 from pydantic import BaseModel, Json
 
 from aws_lambda_powertools.utilities.parser import event_parser
 from aws_lambda_powertools.utilities.parser.models import APIGatewayProxyEventV2Model
-from aws_lambda_powertools.utilities.typing import LambdaContext
+
+if TYPE_CHECKING:
+    from aws_lambda_powertools.utilities.typing import LambdaContext
 
 
 class CancelOrder(BaseModel):

--- a/examples/parser/src/extending_built_in_models_with_json_validator.py
+++ b/examples/parser/src/extending_built_in_models_with_json_validator.py
@@ -1,10 +1,15 @@
+from __future__ import annotations
+
 import json
+from typing import TYPE_CHECKING
 
 from pydantic import BaseModel, validator
 
 from aws_lambda_powertools.utilities.parser import event_parser
 from aws_lambda_powertools.utilities.parser.models import APIGatewayProxyEventV2Model
-from aws_lambda_powertools.utilities.typing import LambdaContext
+
+if TYPE_CHECKING:
+    from aws_lambda_powertools.utilities.typing import LambdaContext
 
 
 class CancelOrder(BaseModel):

--- a/examples/parser/src/multiple_model_parsing.py
+++ b/examples/parser/src/multiple_model_parsing.py
@@ -1,4 +1,6 @@
-from typing import Any, Literal, Union
+from __future__ import annotations
+
+from typing import Any, Literal
 
 from pydantic import BaseModel, Field
 from typing_extensions import Annotated
@@ -19,7 +21,7 @@ class Dog(BaseModel):
 
 
 Animal = Annotated[
-    Union[Cat, Dog],
+    Cat | Dog,
     Field(discriminator="animal"),
 ]
 

--- a/examples/parser/src/using_the_model_from_event.py
+++ b/examples/parser/src/using_the_model_from_event.py
@@ -1,10 +1,15 @@
+from __future__ import annotations
+
 import json
+from typing import TYPE_CHECKING
 
 from pydantic import BaseModel, validator
 
 from aws_lambda_powertools.utilities.parser import event_parser
 from aws_lambda_powertools.utilities.parser.models import APIGatewayProxyEventV2Model
-from aws_lambda_powertools.utilities.typing import LambdaContext
+
+if TYPE_CHECKING:
+    from aws_lambda_powertools.utilities.typing import LambdaContext
 
 
 class CancelOrder(BaseModel):

--- a/examples/streaming/src/assert_transformation.py
+++ b/examples/streaming/src/assert_transformation.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import io
 
 import boto3

--- a/examples/streaming/src/assert_transformation_module.py
+++ b/examples/streaming/src/assert_transformation_module.py
@@ -1,5 +1,7 @@
+from __future__ import annotations
+
 import io
-from typing import IO, Optional
+from typing import IO
 
 from aws_lambda_powertools.utilities.streaming.transformations import BaseTransform
 
@@ -9,7 +11,7 @@ class UpperIO(io.RawIOBase):
         self.encoding = encoding
         self.input_stream = io.TextIOWrapper(input_stream, encoding=encoding)
 
-    def read(self, size: int = -1) -> Optional[bytes]:
+    def read(self, size: int = -1) -> bytes | None:
         data = self.input_stream.read(size)
         return data.upper().encode(self.encoding)
 

--- a/examples/streaming/src/s3_basic_stream.py
+++ b/examples/streaming/src/s3_basic_stream.py
@@ -1,10 +1,14 @@
-from typing import Dict
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
 
 from aws_lambda_powertools.utilities.streaming.s3_object import S3Object
-from aws_lambda_powertools.utilities.typing import LambdaContext
+
+if TYPE_CHECKING:
+    from aws_lambda_powertools.utilities.typing import LambdaContext
 
 
-def lambda_handler(event: Dict[str, str], context: LambdaContext):
+def lambda_handler(event: dict[str, str], context: LambdaContext):
     s3 = S3Object(bucket=event["bucket"], key=event["key"])
     for line in s3:
         print(line)

--- a/examples/streaming/src/s3_basic_stream_with_version.py
+++ b/examples/streaming/src/s3_basic_stream_with_version.py
@@ -1,10 +1,14 @@
-from typing import Dict
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
 
 from aws_lambda_powertools.utilities.streaming.s3_object import S3Object
-from aws_lambda_powertools.utilities.typing import LambdaContext
+
+if TYPE_CHECKING:
+    from aws_lambda_powertools.utilities.typing import LambdaContext
 
 
-def lambda_handler(event: Dict[str, str], context: LambdaContext):
+def lambda_handler(event: dict[str, str], context: LambdaContext):
     s3 = S3Object(bucket=event["bucket"], key=event["key"], version_id=event["version_id"])
     for line in s3:
         print(line)

--- a/examples/streaming/src/s3_csv_stream_non_uniform_seek.py
+++ b/examples/streaming/src/s3_csv_stream_non_uniform_seek.py
@@ -1,15 +1,19 @@
+from __future__ import annotations
+
 import io
-from typing import Dict
+from typing import TYPE_CHECKING
 
 from aws_lambda_powertools.utilities.streaming.s3_object import S3Object
 from aws_lambda_powertools.utilities.streaming.transformations import CsvTransform
-from aws_lambda_powertools.utilities.typing import LambdaContext
+
+if TYPE_CHECKING:
+    from aws_lambda_powertools.utilities.typing import LambdaContext
 
 LAST_ROW_SIZE = 30
 CSV_HEADERS = ["id", "name", "location"]
 
 
-def lambda_handler(event: Dict[str, str], context: LambdaContext):
+def lambda_handler(event: dict[str, str], context: LambdaContext):
     sample_csv = S3Object(bucket=event["bucket"], key="sample.csv")
 
     # From the end of the file, jump exactly 30 bytes backwards

--- a/examples/streaming/src/s3_csv_stream_seek.py
+++ b/examples/streaming/src/s3_csv_stream_seek.py
@@ -1,9 +1,13 @@
+from __future__ import annotations
+
 import io
-from typing import Dict
+from typing import TYPE_CHECKING
 
 from aws_lambda_powertools.utilities.streaming.s3_object import S3Object
 from aws_lambda_powertools.utilities.streaming.transformations import CsvTransform
-from aws_lambda_powertools.utilities.typing import LambdaContext
+
+if TYPE_CHECKING:
+    from aws_lambda_powertools.utilities.typing import LambdaContext
 
 """
 Assuming the CSV files contains rows after the header always has 8 bytes + 1 byte newline:
@@ -21,7 +25,7 @@ HEADER_SIZE = 21 + 1  # 1 byte newline
 LINES_TO_JUMP = 100
 
 
-def lambda_handler(event: Dict[str, str], context: LambdaContext):
+def lambda_handler(event: dict[str, str], context: LambdaContext):
     sample_csv = S3Object(bucket=event["bucket"], key=event["key"])
 
     # Skip the header line

--- a/examples/streaming/src/s3_json_transform.py
+++ b/examples/streaming/src/s3_json_transform.py
@@ -1,5 +1,7 @@
+from __future__ import annotations
+
 import io
-from typing import IO, Optional
+from typing import IO
 
 import ijson
 
@@ -11,10 +13,10 @@ class JsonDeserializer(io.RawIOBase):
     def __init__(self, input_stream: IO[bytes]):
         self.input = ijson.items(input_stream, "", multiple_values=True)
 
-    def read(self, size: int = -1) -> Optional[bytes]:
+    def read(self, size: int = -1) -> bytes | None:
         raise NotImplementedError(f"{__name__} does not implement read")
 
-    def readline(self, size: Optional[int] = None) -> bytes:
+    def readline(self, size: int | None = None) -> bytes:
         raise NotImplementedError(f"{__name__} does not implement readline")
 
     def read_object(self) -> dict:

--- a/examples/streaming/src/s3_transform.py
+++ b/examples/streaming/src/s3_transform.py
@@ -1,14 +1,18 @@
-from typing import Dict
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
 
 from aws_lambda_powertools.utilities.streaming.s3_object import S3Object
 from aws_lambda_powertools.utilities.streaming.transformations import (
     CsvTransform,
     GzipTransform,
 )
-from aws_lambda_powertools.utilities.typing import LambdaContext
+
+if TYPE_CHECKING:
+    from aws_lambda_powertools.utilities.typing import LambdaContext
 
 
-def lambda_handler(event: Dict[str, str], context: LambdaContext):
+def lambda_handler(event: dict[str, str], context: LambdaContext):
     s3 = S3Object(bucket=event["bucket"], key=event["key"])
     data = s3.transform([GzipTransform(), CsvTransform()])
     for line in data:

--- a/examples/streaming/src/s3_transform_common.py
+++ b/examples/streaming/src/s3_transform_common.py
@@ -1,10 +1,14 @@
-from typing import Dict
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
 
 from aws_lambda_powertools.utilities.streaming.s3_object import S3Object
-from aws_lambda_powertools.utilities.typing import LambdaContext
+
+if TYPE_CHECKING:
+    from aws_lambda_powertools.utilities.typing import LambdaContext
 
 
-def lambda_handler(event: Dict[str, str], context: LambdaContext):
+def lambda_handler(event: dict[str, str], context: LambdaContext):
     s3 = S3Object(bucket=event["bucket"], key=event["key"], is_gzip=True, is_csv=True)
     for line in s3:
         print(line)

--- a/examples/streaming/src/s3_transform_in_place.py
+++ b/examples/streaming/src/s3_transform_in_place.py
@@ -1,14 +1,18 @@
-from typing import Dict
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
 
 from aws_lambda_powertools.utilities.streaming.s3_object import S3Object
 from aws_lambda_powertools.utilities.streaming.transformations import (
     CsvTransform,
     GzipTransform,
 )
-from aws_lambda_powertools.utilities.typing import LambdaContext
+
+if TYPE_CHECKING:
+    from aws_lambda_powertools.utilities.typing import LambdaContext
 
 
-def lambda_handler(event: Dict[str, str], context: LambdaContext):
+def lambda_handler(event: dict[str, str], context: LambdaContext):
     s3 = S3Object(bucket=event["bucket"], key=event["key"])
     s3.transform([GzipTransform(), CsvTransform()], in_place=True)
     for line in s3:

--- a/examples/streaming/src/s3_transform_lzma.py
+++ b/examples/streaming/src/s3_transform_lzma.py
@@ -1,12 +1,16 @@
+from __future__ import annotations
+
 import zipfile
-from typing import Dict
+from typing import TYPE_CHECKING
 
 from aws_lambda_powertools.utilities.streaming.s3_object import S3Object
 from aws_lambda_powertools.utilities.streaming.transformations import ZipTransform
-from aws_lambda_powertools.utilities.typing import LambdaContext
+
+if TYPE_CHECKING:
+    from aws_lambda_powertools.utilities.typing import LambdaContext
 
 
-def lambda_handler(event: Dict[str, str], context: LambdaContext):
+def lambda_handler(event: dict[str, str], context: LambdaContext):
     s3 = S3Object(bucket=event["bucket"], key=event["key"])
 
     zf = s3.transform(ZipTransform(compression=zipfile.ZIP_LZMA))

--- a/examples/streaming/src/s3_transform_tsv.py
+++ b/examples/streaming/src/s3_transform_tsv.py
@@ -1,11 +1,15 @@
-from typing import Dict
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
 
 from aws_lambda_powertools.utilities.streaming.s3_object import S3Object
 from aws_lambda_powertools.utilities.streaming.transformations import CsvTransform
-from aws_lambda_powertools.utilities.typing import LambdaContext
+
+if TYPE_CHECKING:
+    from aws_lambda_powertools.utilities.typing import LambdaContext
 
 
-def lambda_handler(event: Dict[str, str], context: LambdaContext):
+def lambda_handler(event: dict[str, str], context: LambdaContext):
     s3 = S3Object(bucket=event["bucket"], key=event["key"])
 
     tsv_stream = s3.transform(CsvTransform(delimiter="\t"))

--- a/examples/streaming/src/s3_transform_zipfile.py
+++ b/examples/streaming/src/s3_transform_zipfile.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from aws_lambda_powertools.utilities.streaming import S3Object
 from aws_lambda_powertools.utilities.streaming.transformations import ZipTransform
 

--- a/examples/tracer/src/capture_lambda_handler.py
+++ b/examples/tracer/src/capture_lambda_handler.py
@@ -1,5 +1,11 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 from aws_lambda_powertools import Tracer
-from aws_lambda_powertools.utilities.typing import LambdaContext
+
+if TYPE_CHECKING:
+    from aws_lambda_powertools.utilities.typing import LambdaContext
 
 tracer = Tracer()  # Sets service via POWERTOOLS_SERVICE_NAME env var
 # OR tracer = Tracer(service="example")

--- a/examples/tracer/src/capture_method.py
+++ b/examples/tracer/src/capture_method.py
@@ -1,5 +1,11 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 from aws_lambda_powertools import Tracer
-from aws_lambda_powertools.utilities.typing import LambdaContext
+
+if TYPE_CHECKING:
+    from aws_lambda_powertools.utilities.typing import LambdaContext
 
 tracer = Tracer()
 

--- a/examples/tracer/src/capture_method_async.py
+++ b/examples/tracer/src/capture_method_async.py
@@ -1,7 +1,12 @@
+from __future__ import annotations
+
 import asyncio
+from typing import TYPE_CHECKING
 
 from aws_lambda_powertools import Tracer
-from aws_lambda_powertools.utilities.typing import LambdaContext
+
+if TYPE_CHECKING:
+    from aws_lambda_powertools.utilities.typing import LambdaContext
 
 tracer = Tracer()
 

--- a/examples/tracer/src/capture_method_async_concurrency.py
+++ b/examples/tracer/src/capture_method_async_concurrency.py
@@ -1,7 +1,12 @@
+from __future__ import annotations
+
 import asyncio
+from typing import TYPE_CHECKING
 
 from aws_lambda_powertools import Tracer
-from aws_lambda_powertools.utilities.typing import LambdaContext
+
+if TYPE_CHECKING:
+    from aws_lambda_powertools.utilities.typing import LambdaContext
 
 tracer = Tracer()
 

--- a/examples/tracer/src/capture_method_context_manager.py
+++ b/examples/tracer/src/capture_method_context_manager.py
@@ -1,8 +1,14 @@
+from __future__ import annotations
+
 import contextlib
-from collections.abc import Generator
+from typing import TYPE_CHECKING
 
 from aws_lambda_powertools import Logger, Tracer
-from aws_lambda_powertools.utilities.typing import LambdaContext
+
+if TYPE_CHECKING:
+    from collections.abc import Generator
+
+    from aws_lambda_powertools.utilities.typing import LambdaContext
 
 tracer = Tracer()
 logger = Logger()

--- a/examples/tracer/src/capture_method_generators.py
+++ b/examples/tracer/src/capture_method_generators.py
@@ -1,7 +1,13 @@
-from collections.abc import Generator
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
 
 from aws_lambda_powertools import Tracer
-from aws_lambda_powertools.utilities.typing import LambdaContext
+
+if TYPE_CHECKING:
+    from collections.abc import Generator
+
+    from aws_lambda_powertools.utilities.typing import LambdaContext
 
 tracer = Tracer()
 

--- a/examples/tracer/src/disable_capture_error.py
+++ b/examples/tracer/src/disable_capture_error.py
@@ -1,16 +1,20 @@
+from __future__ import annotations
+
 import os
+from typing import TYPE_CHECKING
 
 import requests
 
 from aws_lambda_powertools import Tracer
-from aws_lambda_powertools.utilities.typing import LambdaContext
+
+if TYPE_CHECKING:
+    from aws_lambda_powertools.utilities.typing import LambdaContext
 
 tracer = Tracer()
 ENDPOINT = os.getenv("PAYMENT_API", "")
 
 
-class PaymentError(Exception):
-    ...
+class PaymentError(Exception): ...
 
 
 @tracer.capture_method(capture_error=False)

--- a/examples/tracer/src/disable_capture_response.py
+++ b/examples/tracer/src/disable_capture_response.py
@@ -1,5 +1,11 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 from aws_lambda_powertools import Logger, Tracer
-from aws_lambda_powertools.utilities.typing import LambdaContext
+
+if TYPE_CHECKING:
+    from aws_lambda_powertools.utilities.typing import LambdaContext
 
 tracer = Tracer()
 logger = Logger()

--- a/examples/tracer/src/disable_capture_response_streaming_body.py
+++ b/examples/tracer/src/disable_capture_response_streaming_body.py
@@ -1,10 +1,16 @@
+from __future__ import annotations
+
 import os
+from typing import TYPE_CHECKING
 
 import boto3
-from botocore.response import StreamingBody
 
 from aws_lambda_powertools import Logger, Tracer
-from aws_lambda_powertools.utilities.typing import LambdaContext
+
+if TYPE_CHECKING:
+    from botocore.response import StreamingBody
+
+    from aws_lambda_powertools.utilities.typing import LambdaContext
 
 BUCKET = os.getenv("BUCKET_NAME", "")
 REPORT_KEY = os.getenv("REPORT_KEY", "")

--- a/examples/tracer/src/ignore_endpoints.py
+++ b/examples/tracer/src/ignore_endpoints.py
@@ -1,9 +1,14 @@
+from __future__ import annotations
+
 import os
+from typing import TYPE_CHECKING
 
 import requests
 
 from aws_lambda_powertools import Tracer
-from aws_lambda_powertools.utilities.typing import LambdaContext
+
+if TYPE_CHECKING:
+    from aws_lambda_powertools.utilities.typing import LambdaContext
 
 ENDPOINT = os.getenv("PAYMENT_API", "")
 IGNORE_URLS = ["/collect", "/refund"]
@@ -13,8 +18,7 @@ tracer.ignore_endpoint(hostname=ENDPOINT, urls=IGNORE_URLS)
 tracer.ignore_endpoint(hostname=f"*.{ENDPOINT}", urls=IGNORE_URLS)  # `<stage>.ENDPOINT`
 
 
-class PaymentError(Exception):
-    ...
+class PaymentError(Exception): ...
 
 
 @tracer.capture_method(capture_error=False)

--- a/examples/tracer/src/patch_modules.py
+++ b/examples/tracer/src/patch_modules.py
@@ -1,7 +1,13 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 import requests
 
 from aws_lambda_powertools import Tracer
-from aws_lambda_powertools.utilities.typing import LambdaContext
+
+if TYPE_CHECKING:
+    from aws_lambda_powertools.utilities.typing import LambdaContext
 
 MODULES = ["requests"]
 

--- a/examples/tracer/src/put_trace_annotations.py
+++ b/examples/tracer/src/put_trace_annotations.py
@@ -1,5 +1,11 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 from aws_lambda_powertools import Tracer
-from aws_lambda_powertools.utilities.typing import LambdaContext
+
+if TYPE_CHECKING:
+    from aws_lambda_powertools.utilities.typing import LambdaContext
 
 tracer = Tracer()
 

--- a/examples/tracer/src/put_trace_metadata.py
+++ b/examples/tracer/src/put_trace_metadata.py
@@ -1,5 +1,11 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 from aws_lambda_powertools import Tracer
-from aws_lambda_powertools.utilities.typing import LambdaContext
+
+if TYPE_CHECKING:
+    from aws_lambda_powertools.utilities.typing import LambdaContext
 
 tracer = Tracer()
 

--- a/examples/tracer/src/sdk_escape_hatch.py
+++ b/examples/tracer/src/sdk_escape_hatch.py
@@ -1,5 +1,11 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 from aws_lambda_powertools import Tracer
-from aws_lambda_powertools.utilities.typing import LambdaContext
+
+if TYPE_CHECKING:
+    from aws_lambda_powertools.utilities.typing import LambdaContext
 
 tracer = Tracer()
 

--- a/examples/tracer/src/tracer_reuse.py
+++ b/examples/tracer/src/tracer_reuse.py
@@ -1,7 +1,13 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 from tracer_reuse_module import collect_payment
 
 from aws_lambda_powertools import Tracer
-from aws_lambda_powertools.utilities.typing import LambdaContext
+
+if TYPE_CHECKING:
+    from aws_lambda_powertools.utilities.typing import LambdaContext
 
 tracer = Tracer()
 

--- a/examples/tracer/src/tracer_reuse_module.py
+++ b/examples/tracer/src/tracer_reuse_module.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from aws_lambda_powertools import Tracer
 
 tracer = Tracer()

--- a/examples/tracer/src/tracing_aiohttp.py
+++ b/examples/tracer/src/tracing_aiohttp.py
@@ -1,11 +1,16 @@
+from __future__ import annotations
+
 import asyncio
 import os
+from typing import TYPE_CHECKING
 
 import aiohttp
 
 from aws_lambda_powertools import Tracer
 from aws_lambda_powertools.tracing import aiohttp_trace_config
-from aws_lambda_powertools.utilities.typing import LambdaContext
+
+if TYPE_CHECKING:
+    from aws_lambda_powertools.utilities.typing import LambdaContext
 
 ENDPOINT = os.getenv("PAYMENT_API", "")
 

--- a/examples/typing/src/getting_started_typing_function.py
+++ b/examples/typing/src/getting_started_typing_function.py
@@ -1,4 +1,9 @@
-from aws_lambda_powertools.utilities.typing import LambdaContext
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from aws_lambda_powertools.utilities.typing import LambdaContext
 
 
 def handler(event: dict, context: LambdaContext) -> dict:

--- a/examples/typing/src/working_with_context_function.py
+++ b/examples/typing/src/working_with_context_function.py
@@ -1,9 +1,14 @@
+from __future__ import annotations
+
 from time import sleep
+from typing import TYPE_CHECKING
 
 import requests
 
 from aws_lambda_powertools import Logger
-from aws_lambda_powertools.utilities.typing import LambdaContext
+
+if TYPE_CHECKING:
+    from aws_lambda_powertools.utilities.typing import LambdaContext
 
 logger = Logger()
 

--- a/examples/validation/src/custom_format_function.py
+++ b/examples/validation/src/custom_format_function.py
@@ -1,11 +1,16 @@
+from __future__ import annotations
+
 import json
 import re
+from typing import TYPE_CHECKING
 
 import boto3
 import custom_format_schema as schemas
 
-from aws_lambda_powertools.utilities.typing import LambdaContext
 from aws_lambda_powertools.utilities.validation import SchemaValidationError, validate
+
+if TYPE_CHECKING:
+    from aws_lambda_powertools.utilities.typing import LambdaContext
 
 # awsaccountid must have 12 digits
 custom_format = {"awsaccountid": lambda value: re.match(r"^(\d{12})$", value)}

--- a/examples/validation/src/custom_format_schema.py
+++ b/examples/validation/src/custom_format_schema.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 INPUT = {
     "definitions": {},
     "$schema": "http://json-schema.org/draft-07/schema#",

--- a/examples/validation/src/getting_started_validator_decorator_function.py
+++ b/examples/validation/src/getting_started_validator_decorator_function.py
@@ -1,19 +1,23 @@
+from __future__ import annotations
+
 from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
 from uuid import uuid4
 
 import getting_started_validator_decorator_schema as schemas
 
 from aws_lambda_powertools.utilities import parameters
-from aws_lambda_powertools.utilities.typing import LambdaContext
 from aws_lambda_powertools.utilities.validation import validator
+
+if TYPE_CHECKING:
+    from aws_lambda_powertools.utilities.typing import LambdaContext
 
 # we can get list of allowed IPs from AWS Parameter Store using Parameters Utility
 # See: https://docs.powertools.aws.dev/lambda/python/latest/utilities/parameters/
 ALLOWED_IPS = parameters.get_parameter("/lambda-powertools/allowed_ips")
 
 
-class UserPermissionsError(Exception):
-    ...
+class UserPermissionsError(Exception): ...
 
 
 @dataclass

--- a/examples/validation/src/getting_started_validator_decorator_schema.py
+++ b/examples/validation/src/getting_started_validator_decorator_schema.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 INPUT = {
     "$schema": "http://json-schema.org/draft-07/schema",
     "$id": "http://example.com/example.json",

--- a/examples/validation/src/getting_started_validator_standalone_function.py
+++ b/examples/validation/src/getting_started_validator_standalone_function.py
@@ -1,8 +1,14 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 import getting_started_validator_standalone_schema as schemas
 
 from aws_lambda_powertools.utilities import parameters
-from aws_lambda_powertools.utilities.typing import LambdaContext
 from aws_lambda_powertools.utilities.validation import SchemaValidationError, validate
+
+if TYPE_CHECKING:
+    from aws_lambda_powertools.utilities.typing import LambdaContext
 
 # we can get list of allowed IPs from AWS Parameter Store using Parameters Utility
 # See: https://docs.powertools.aws.dev/lambda/python/latest/utilities/parameters/

--- a/examples/validation/src/getting_started_validator_standalone_schema.py
+++ b/examples/validation/src/getting_started_validator_standalone_schema.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 INPUT = {
     "$schema": "http://json-schema.org/draft-07/schema",
     "$id": "http://example.com/example.json",

--- a/examples/validation/src/getting_started_validator_unwrapping_function.py
+++ b/examples/validation/src/getting_started_validator_unwrapping_function.py
@@ -1,11 +1,17 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 import boto3
 import getting_started_validator_unwrapping_schema as schemas
 
 from aws_lambda_powertools.utilities.data_classes.event_bridge_event import (
     EventBridgeEvent,
 )
-from aws_lambda_powertools.utilities.typing import LambdaContext
 from aws_lambda_powertools.utilities.validation import validator
+
+if TYPE_CHECKING:
+    from aws_lambda_powertools.utilities.typing import LambdaContext
 
 s3_client = boto3.resource("s3")
 

--- a/examples/validation/src/getting_started_validator_unwrapping_schema.py
+++ b/examples/validation/src/getting_started_validator_unwrapping_schema.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 INPUT = {
     "$schema": "http://json-schema.org/draft-07/schema#",
     "$id": "https://example.com/object1660222326.json",

--- a/examples/validation/src/unwrapping_popular_event_source_function.py
+++ b/examples/validation/src/unwrapping_popular_event_source_function.py
@@ -1,3 +1,7 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 import boto3
 import unwrapping_popular_event_source_schema as schemas
 from botocore.exceptions import ClientError
@@ -5,8 +9,10 @@ from botocore.exceptions import ClientError
 from aws_lambda_powertools.utilities.data_classes.event_bridge_event import (
     EventBridgeEvent,
 )
-from aws_lambda_powertools.utilities.typing import LambdaContext
 from aws_lambda_powertools.utilities.validation import envelopes, validator
+
+if TYPE_CHECKING:
+    from aws_lambda_powertools.utilities.typing import LambdaContext
 
 
 # extracting detail from EventBridge custom event

--- a/examples/validation/src/unwrapping_popular_event_source_schema.py
+++ b/examples/validation/src/unwrapping_popular_event_source_schema.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 INPUT = {
     "definitions": {},
     "$schema": "http://json-schema.org/draft-07/schema#",


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
**Issue number:** #4607

## Summary

### Changes

Add `from __future__ import annotations` to all examples

### User experience

Discussed in #4607

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [X] [Meet tenets criteria](https://docs.powertools.aws.dev/lambda/python/#tenets)
* [X] I have performed a self-review of this change
* [X] Changes have been tested
* [ ] Changes are documented
* [X] PR title follows [conventional commit semantics](https://github.com/aws-powertools/powertools-lambda-python/blob/develop/.github/semantic.yml)

<details>
<summary>Is this a breaking change?</summary>

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
