### PR TITLE
refactor(idempotency): add from __future__ import annotations

### DIFF
--- a/aws_lambda_powertools/utilities/idempotency/config.py
+++ b/aws_lambda_powertools/utilities/idempotency/config.py
@@ -1,7 +1,10 @@
-from typing import Dict, Optional
+from __future__ import annotations
 
-from aws_lambda_powertools.utilities.idempotency import IdempotentHookFunction
-from aws_lambda_powertools.utilities.typing import LambdaContext
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from aws_lambda_powertools.utilities.idempotency import IdempotentHookFunction
+    from aws_lambda_powertools.utilities.typing import LambdaContext
 
 
 class IdempotencyConfig:
@@ -9,14 +12,14 @@ class IdempotencyConfig:
         self,
         event_key_jmespath: str = "",
         payload_validation_jmespath: str = "",
-        jmespath_options: Optional[Dict] = None,
+        jmespath_options: dict | None = None,
         raise_on_no_idempotency_key: bool = False,
         expires_after_seconds: int = 60 * 60,  # 1 hour default
         use_local_cache: bool = False,
         local_cache_max_items: int = 256,
         hash_function: str = "md5",
-        lambda_context: Optional[LambdaContext] = None,
-        response_hook: Optional[IdempotentHookFunction] = None,
+        lambda_context: LambdaContext | None = None,
+        response_hook: IdempotentHookFunction | None = None,
     ):
         """
         Initialize the base persistence layer
@@ -50,8 +53,8 @@ class IdempotencyConfig:
         self.use_local_cache = use_local_cache
         self.local_cache_max_items = local_cache_max_items
         self.hash_function = hash_function
-        self.lambda_context: Optional[LambdaContext] = lambda_context
-        self.response_hook: Optional[IdempotentHookFunction] = response_hook
+        self.lambda_context: LambdaContext | None = lambda_context
+        self.response_hook: IdempotentHookFunction | None = response_hook
 
     def register_lambda_context(self, lambda_context: LambdaContext):
         """Captures the Lambda context, to calculate the remaining time before the invocation times out"""

--- a/aws_lambda_powertools/utilities/idempotency/exceptions.py
+++ b/aws_lambda_powertools/utilities/idempotency/exceptions.py
@@ -2,9 +2,12 @@
 Idempotency errors
 """
 
-from typing import Optional, Union
+from __future__ import annotations
 
-from aws_lambda_powertools.utilities.idempotency.persistence.datarecord import DataRecord
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from aws_lambda_powertools.utilities.idempotency.persistence.datarecord import DataRecord
 
 
 class BaseError(Exception):
@@ -13,7 +16,7 @@ class BaseError(Exception):
     See https://github.com/aws-powertools/powertools-lambda-python/issues/1772
     """
 
-    def __init__(self, *args: Optional[Union[str, Exception]]):
+    def __init__(self, *args: str | Exception | None):
         self.message = str(args[0]) if args else ""
         self.details = "".join(str(arg) for arg in args[1:]) if args[1:] else None
 
@@ -31,7 +34,7 @@ class IdempotencyItemAlreadyExistsError(BaseError):
     Item attempting to be inserted into persistence store already exists and is not expired
     """
 
-    def __init__(self, *args: Optional[Union[str, Exception]], old_data_record: Optional[DataRecord] = None):
+    def __init__(self, *args: str | Exception | None, old_data_record: DataRecord | None = None):
         self.old_data_record = old_data_record
         super().__init__(*args)
 

--- a/aws_lambda_powertools/utilities/idempotency/hook.py
+++ b/aws_lambda_powertools/utilities/idempotency/hook.py
@@ -1,6 +1,9 @@
-from typing import Any, Protocol
+from __future__ import annotations
 
-from aws_lambda_powertools.utilities.idempotency.persistence.datarecord import DataRecord
+from typing import TYPE_CHECKING, Any, Protocol
+
+if TYPE_CHECKING:
+    from aws_lambda_powertools.utilities.idempotency.persistence.datarecord import DataRecord
 
 
 class IdempotentHookFunction(Protocol):

--- a/aws_lambda_powertools/utilities/idempotency/idempotency.py
+++ b/aws_lambda_powertools/utilities/idempotency/idempotency.py
@@ -2,25 +2,29 @@
 Primary interface for idempotent Lambda functions utility
 """
 
+from __future__ import annotations
+
 import functools
 import logging
 import os
 from inspect import isclass
-from typing import Any, Callable, Dict, Optional, Type, Union, cast
+from typing import TYPE_CHECKING, Any, Callable, cast
 
 from aws_lambda_powertools.middleware_factory import lambda_handler_decorator
 from aws_lambda_powertools.shared import constants
 from aws_lambda_powertools.shared.types import AnyCallableT
 from aws_lambda_powertools.utilities.idempotency.base import IdempotencyHandler
 from aws_lambda_powertools.utilities.idempotency.config import IdempotencyConfig
-from aws_lambda_powertools.utilities.idempotency.persistence.base import (
-    BasePersistenceLayer,
-)
 from aws_lambda_powertools.utilities.idempotency.serialization.base import (
     BaseIdempotencyModelSerializer,
     BaseIdempotencySerializer,
 )
-from aws_lambda_powertools.utilities.typing import LambdaContext
+
+if TYPE_CHECKING:
+    from aws_lambda_powertools.utilities.idempotency.persistence.base import (
+        BasePersistenceLayer,
+    )
+    from aws_lambda_powertools.utilities.typing import LambdaContext
 
 logger = logging.getLogger(__name__)
 
@@ -28,10 +32,10 @@ logger = logging.getLogger(__name__)
 @lambda_handler_decorator
 def idempotent(
     handler: Callable[[Any, LambdaContext], Any],
-    event: Dict[str, Any],
+    event: dict[str, Any],
     context: LambdaContext,
     persistence_store: BasePersistenceLayer,
-    config: Optional[IdempotencyConfig] = None,
+    config: IdempotencyConfig | None = None,
     **kwargs,
 ) -> Any:
     """
@@ -41,9 +45,9 @@ def idempotent(
     ----------
     handler: Callable
         Lambda's handler
-    event: Dict
+    event: dict
         Lambda's Event
-    context: Dict
+    context: dict
         Lambda's Context
     persistence_store: BasePersistenceLayer
         Instance of BasePersistenceLayer to store data
@@ -86,12 +90,12 @@ def idempotent(
 
 
 def idempotent_function(
-    function: Optional[AnyCallableT] = None,
+    function: AnyCallableT | None = None,
     *,
     data_keyword_argument: str,
     persistence_store: BasePersistenceLayer,
-    config: Optional[IdempotencyConfig] = None,
-    output_serializer: Optional[Union[BaseIdempotencySerializer, Type[BaseIdempotencyModelSerializer]]] = None,
+    config: IdempotencyConfig | None = None,
+    output_serializer: BaseIdempotencySerializer | type[BaseIdempotencyModelSerializer] | None = None,
     **kwargs: Any,
 ) -> Any:
     """
@@ -107,7 +111,7 @@ def idempotent_function(
         Instance of BasePersistenceLayer to store data
     config: IdempotencyConfig
         Configuration
-    output_serializer: Optional[Union[BaseIdempotencySerializer, Type[BaseIdempotencyModelSerializer]]]
+    output_serializer: BaseIdempotencySerializer | type[BaseIdempotencyModelSerializer] | None
             Serializer to transform the data to and from a dictionary.
             If not supplied, no serialization is done via the NoOpSerializer.
             In case a serializer of type inheriting BaseIdempotencyModelSerializer is given,

--- a/aws_lambda_powertools/utilities/idempotency/persistence/datarecord.py
+++ b/aws_lambda_powertools/utilities/idempotency/persistence/datarecord.py
@@ -2,11 +2,12 @@
 Data Class for idempotency records.
 """
 
+from __future__ import annotations
+
 import datetime
 import json
 import logging
 from types import MappingProxyType
-from typing import Optional
 
 logger = logging.getLogger(__name__)
 
@@ -22,8 +23,8 @@ class DataRecord:
         self,
         idempotency_key: str,
         status: str = "",
-        expiry_timestamp: Optional[int] = None,
-        in_progress_expiry_timestamp: Optional[int] = None,
+        expiry_timestamp: int | None = None,
+        in_progress_expiry_timestamp: int | None = None,
         response_data: str = "",
         payload_hash: str = "",
     ) -> None:
@@ -81,13 +82,13 @@ class DataRecord:
 
         raise IdempotencyInvalidStatusError(self._status)
 
-    def response_json_as_dict(self) -> Optional[dict]:
+    def response_json_as_dict(self) -> dict | None:
         """
         Get response data deserialized to python dict
 
         Returns
         -------
-        Optional[dict]
+        dict | None
             previous response data deserialized
         """
         return json.loads(self.response_data) if self.response_data else None

--- a/aws_lambda_powertools/utilities/idempotency/persistence/redis.py
+++ b/aws_lambda_powertools/utilities/idempotency/persistence/redis.py
@@ -5,7 +5,7 @@ import json
 import logging
 from contextlib import contextmanager
 from datetime import timedelta
-from typing import Any, Dict, Literal, Protocol
+from typing import Any, Literal, Protocol
 
 import redis
 
@@ -185,7 +185,7 @@ class RedisConnection:
                 return client.from_url(url=self.url)
             else:
                 # Redis in cluster mode doesn't support db parameter
-                extra_param_connection: Dict[str, Any] = {}
+                extra_param_connection: dict[str, Any] = {}
                 if self.mode != "cluster":
                     extra_param_connection = {"db": self.db_index}
 
@@ -321,7 +321,7 @@ class RedisCachePersistenceLayer(BasePersistenceLayer):
             return expiry_timestamp - int(datetime.datetime.now().timestamp())
         return self.expires_after_seconds
 
-    def _item_to_data_record(self, idempotency_key: str, item: Dict[str, Any]) -> DataRecord:
+    def _item_to_data_record(self, idempotency_key: str, item: dict[str, Any]) -> DataRecord:
         in_progress_expiry_timestamp = item.get(self.in_progress_expiry_attr)
 
         return DataRecord(
@@ -357,7 +357,7 @@ class RedisCachePersistenceLayer(BasePersistenceLayer):
         return self._item_to_data_record(idempotency_key, item)
 
     def _put_in_progress_record(self, data_record: DataRecord) -> None:
-        item: Dict[str, Any] = {
+        item: dict[str, Any] = {
             "name": data_record.idempotency_key,
             "mapping": {
                 self.status_attr: data_record.status,
@@ -480,7 +480,7 @@ class RedisCachePersistenceLayer(BasePersistenceLayer):
             raise NotImplementedError
 
     def _update_record(self, data_record: DataRecord) -> None:
-        item: Dict[str, Any] = {
+        item: dict[str, Any] = {
             "name": data_record.idempotency_key,
             "mapping": {
                 self.data_attr: data_record.response_data,

--- a/aws_lambda_powertools/utilities/idempotency/serialization/base.py
+++ b/aws_lambda_powertools/utilities/idempotency/serialization/base.py
@@ -2,8 +2,10 @@
 Serialization for supporting idempotency
 """
 
+from __future__ import annotations
+
 from abc import ABC, abstractmethod
-from typing import Any, Dict
+from typing import Any
 
 
 class BaseIdempotencySerializer(ABC):
@@ -12,11 +14,11 @@ class BaseIdempotencySerializer(ABC):
     """
 
     @abstractmethod
-    def to_dict(self, data: Any) -> Dict:
+    def to_dict(self, data: Any) -> dict:
         raise NotImplementedError("Implementation of to_dict is required")
 
     @abstractmethod
-    def from_dict(self, data: Dict) -> Any:
+    def from_dict(self, data: dict) -> Any:
         raise NotImplementedError("Implementation of from_dict is required")
 
 

--- a/aws_lambda_powertools/utilities/idempotency/serialization/custom_dict.py
+++ b/aws_lambda_powertools/utilities/idempotency/serialization/custom_dict.py
@@ -1,23 +1,25 @@
-from typing import Any, Callable, Dict
+from __future__ import annotations
+
+from typing import Any, Callable
 
 from aws_lambda_powertools.utilities.idempotency.serialization.base import BaseIdempotencySerializer
 
 
 class CustomDictSerializer(BaseIdempotencySerializer):
-    def __init__(self, to_dict: Callable[[Any], Dict], from_dict: Callable[[Dict], Any]):
+    def __init__(self, to_dict: Callable[[Any], dict], from_dict: Callable[[dict], Any]):
         """
         Parameters
         ----------
-        to_dict: Callable[[Any], Dict]
+        to_dict: Callable[[Any], dict]
             A function capable of transforming the saved data object representation into a dictionary
-        from_dict: Callable[[Dict], Any]
+        from_dict: Callable[[dict], Any]
             A function capable of transforming the saved dictionary into the original data object representation
         """
-        self.__to_dict: Callable[[Any], Dict] = to_dict
-        self.__from_dict: Callable[[Dict], Any] = from_dict
+        self.__to_dict: Callable[[Any], dict] = to_dict
+        self.__from_dict: Callable[[dict], Any] = from_dict
 
-    def to_dict(self, data: Any) -> Dict:
+    def to_dict(self, data: Any) -> dict:
         return self.__to_dict(data)
 
-    def from_dict(self, data: Dict) -> Any:
+    def from_dict(self, data: dict) -> Any:
         return self.__from_dict(data)

--- a/aws_lambda_powertools/utilities/idempotency/serialization/dataclass.py
+++ b/aws_lambda_powertools/utilities/idempotency/serialization/dataclass.py
@@ -1,5 +1,7 @@
+from __future__ import annotations
+
 from dataclasses import asdict, is_dataclass
-from typing import Any, Dict, Type
+from typing import Any
 
 from aws_lambda_powertools.utilities.idempotency.exceptions import (
     IdempotencyModelTypeError,
@@ -18,19 +20,19 @@ class DataclassSerializer(BaseIdempotencyModelSerializer):
     A serializer class for transforming data between dataclass objects and dictionaries.
     """
 
-    def __init__(self, model: Type[DataClass]):
+    def __init__(self, model: type[DataClass]):
         """
         Parameters
         ----------
-        model: Type[DataClass]
+        model: type[DataClass]
             A dataclass type to be used for serialization and deserialization
         """
-        self.__model: Type[DataClass] = model
+        self.__model: type[DataClass] = model
 
-    def to_dict(self, data: DataClass) -> Dict:
+    def to_dict(self, data: DataClass) -> dict:
         return asdict(data)
 
-    def from_dict(self, data: Dict) -> DataClass:
+    def from_dict(self, data: dict) -> DataClass:
         return self.__model(**data)
 
     @classmethod

--- a/aws_lambda_powertools/utilities/idempotency/serialization/no_op.py
+++ b/aws_lambda_powertools/utilities/idempotency/serialization/no_op.py
@@ -1,4 +1,4 @@
-from typing import Dict
+from __future__ import annotations
 
 from aws_lambda_powertools.utilities.idempotency.serialization.base import BaseIdempotencySerializer
 
@@ -11,8 +11,8 @@ class NoOpSerializer(BaseIdempotencySerializer):
         Default serializer, does not transform data
         """
 
-    def to_dict(self, data: Dict) -> Dict:
+    def to_dict(self, data: dict) -> dict:
         return data
 
-    def from_dict(self, data: Dict) -> Dict:
+    def from_dict(self, data: dict) -> dict:
         return data

--- a/aws_lambda_powertools/utilities/idempotency/serialization/pydantic.py
+++ b/aws_lambda_powertools/utilities/idempotency/serialization/pydantic.py
@@ -1,4 +1,6 @@
-from typing import Any, Dict, Type
+from __future__ import annotations
+
+from typing import Any
 
 from pydantic import BaseModel
 
@@ -15,19 +17,19 @@ from aws_lambda_powertools.utilities.idempotency.serialization.base import (
 class PydanticSerializer(BaseIdempotencyModelSerializer):
     """Pydantic serializer for idempotency models"""
 
-    def __init__(self, model: Type[BaseModel]):
+    def __init__(self, model: type[BaseModel]):
         """
         Parameters
         ----------
         model: Model
             Pydantic model to be used for serialization
         """
-        self.__model: Type[BaseModel] = model
+        self.__model: type[BaseModel] = model
 
-    def to_dict(self, data: BaseModel) -> Dict:
+    def to_dict(self, data: BaseModel) -> dict:
         return data.model_dump()
 
-    def from_dict(self, data: Dict) -> BaseModel:
+    def from_dict(self, data: dict) -> BaseModel:
         return self.__model.model_validate(data)
 
     @classmethod


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
**Issue number:**  #4964 

## Summary

### Changes

Add `from __future__ import annotations` to idempotency package

### User experience

Discussed in #4607

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [X] [Meet tenets criteria](https://docs.powertools.aws.dev/lambda/python/#tenets)
* [X] I have performed a self-review of this change
* [X] Changes have been tested
* [ ] Changes are documented
* [X] PR title follows [conventional commit semantics](https://github.com/aws-powertools/powertools-lambda-python/blob/develop/.github/semantic.yml)

<details>
<summary>Is this a breaking change?</summary>

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
