### PR TITLE
refactor(jmespath_utils): add from __future__ import annotations

### DIFF
--- a/aws_lambda_powertools/utilities/jmespath_utils/__init__.py
+++ b/aws_lambda_powertools/utilities/jmespath_utils/__init__.py
@@ -1,9 +1,11 @@
+from __future__ import annotations
+
 import base64
 import gzip
 import json
 import logging
 import warnings
-from typing import Any, Dict, Optional, Union
+from typing import Any
 
 import jmespath
 from jmespath.exceptions import LexerError
@@ -33,7 +35,7 @@ class PowertoolsFunctions(Functions):
         return uncompressed.decode()
 
 
-def query(data: Union[Dict, str], envelope: str, jmespath_options: Optional[Dict] = None) -> Any:
+def query(data: dict | str, envelope: str, jmespath_options: dict | None = None) -> Any:
     """Searches and extracts data using JMESPath
 
     Envelope being the JMESPath expression to extract the data you're after
@@ -57,11 +59,11 @@ def query(data: Union[Dict, str], envelope: str, jmespath_options: Optional[Dict
 
     Parameters
     ----------
-    data : Dict
+    data : dict | str
         Data set to be filtered
     envelope : str
         JMESPath expression to filter data against
-    jmespath_options : Dict
+    jmespath_options : dict | None
         Alternative JMESPath options to be included when filtering expr
 
 
@@ -82,7 +84,7 @@ def query(data: Union[Dict, str], envelope: str, jmespath_options: Optional[Dict
 
 
 @deprecated("`extract_data_from_envelope` is deprecated; use `query` instead.", category=None)
-def extract_data_from_envelope(data: Union[Dict, str], envelope: str, jmespath_options: Optional[Dict] = None) -> Any:
+def extract_data_from_envelope(data: dict | str, envelope: str, jmespath_options: dict | None = None) -> Any:
     """Searches and extracts data using JMESPath
 
     *Deprecated*: Use query instead


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
**Issue number:** #4963 

## Summary

### Changes

Add `from __future__ import annotations` to jmespath_utils package

### User experience

Discussed in #4607

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [X] [Meet tenets criteria](https://docs.powertools.aws.dev/lambda/python/#tenets)
* [X] I have performed a self-review of this change
* [X] Changes have been tested
* [ ] Changes are documented
* [X] PR title follows [conventional commit semantics](https://github.com/aws-powertools/powertools-lambda-python/blob/develop/.github/semantic.yml)

<details>
<summary>Is this a breaking change?</summary>

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
