### PR TITLE
refactor(parameters): add from __future__ import annotations

### DIFF
--- a/aws_lambda_powertools/utilities/parameters/appconfig.py
+++ b/aws_lambda_powertools/utilities/parameters/appconfig.py
@@ -15,9 +15,9 @@ from aws_lambda_powertools.shared.functions import (
     resolve_env_var_choice,
     resolve_max_age,
 )
+from aws_lambda_powertools.utilities.parameters.base import BaseProvider
+from aws_lambda_powertools.utilities.parameters.constants import DEFAULT_MAX_AGE_SECS, DEFAULT_PROVIDERS
 from aws_lambda_powertools.warnings import PowertoolsDeprecationWarning
-
-from .base import DEFAULT_MAX_AGE_SECS, DEFAULT_PROVIDERS, BaseProvider
 
 if TYPE_CHECKING:
     from botocore.config import Config

--- a/aws_lambda_powertools/utilities/parameters/appconfig.py
+++ b/aws_lambda_powertools/utilities/parameters/appconfig.py
@@ -2,26 +2,28 @@
 AWS App Config configuration retrieval and caching utility
 """
 
+from __future__ import annotations
+
 import os
 import warnings
-from typing import TYPE_CHECKING, Dict, Optional, Union
+from typing import TYPE_CHECKING
 
 import boto3
-from botocore.config import Config
-
-from aws_lambda_powertools.utilities.parameters.types import TransformOptions
-from aws_lambda_powertools.warnings import PowertoolsDeprecationWarning
-
-if TYPE_CHECKING:
-    from mypy_boto3_appconfigdata.client import AppConfigDataClient
 
 from aws_lambda_powertools.shared import constants
 from aws_lambda_powertools.shared.functions import (
     resolve_env_var_choice,
     resolve_max_age,
 )
+from aws_lambda_powertools.warnings import PowertoolsDeprecationWarning
 
 from .base import DEFAULT_MAX_AGE_SECS, DEFAULT_PROVIDERS, BaseProvider
+
+if TYPE_CHECKING:
+    from botocore.config import Config
+    from mypy_boto3_appconfigdata.client import AppConfigDataClient
+
+    from aws_lambda_powertools.utilities.parameters.types import TransformOptions
 
 
 class AppConfigProvider(BaseProvider):
@@ -72,11 +74,11 @@ class AppConfigProvider(BaseProvider):
     def __init__(
         self,
         environment: str,
-        application: Optional[str] = None,
-        config: Optional[Config] = None,
-        boto_config: Optional[Config] = None,
-        boto3_session: Optional[boto3.session.Session] = None,
-        boto3_client: Optional["AppConfigDataClient"] = None,
+        application: str | None = None,
+        config: Config | None = None,
+        boto_config: Config | None = None,
+        boto3_session: boto3.session.Session | None = None,
+        boto3_client: AppConfigDataClient | None = None,
     ):
         """
         Initialize the App Config client
@@ -105,9 +107,9 @@ class AppConfigProvider(BaseProvider):
         self.environment = environment
         self.current_version = ""
 
-        self._next_token: Dict[str, str] = {}  # nosec - token for get_latest_configuration executions
+        self._next_token: dict[str, str] = {}  # nosec - token for get_latest_configuration executions
         # Dict to store the recently retrieved value for a specific configuration.
-        self.last_returned_value: Dict[str, bytes] = {}
+        self.last_returned_value: dict[str, bytes] = {}
 
         super().__init__(client=self.client)
 
@@ -145,7 +147,7 @@ class AppConfigProvider(BaseProvider):
 
         return self.last_returned_value[name]
 
-    def _get_multiple(self, path: str, **sdk_options) -> Dict[str, str]:
+    def _get_multiple(self, path: str, **sdk_options) -> dict[str, str]:
         """
         Retrieving multiple parameter values is not supported with AWS App Config Provider
         """
@@ -155,12 +157,12 @@ class AppConfigProvider(BaseProvider):
 def get_app_config(
     name: str,
     environment: str,
-    application: Optional[str] = None,
+    application: str | None = None,
     transform: TransformOptions = None,
     force_fetch: bool = False,
-    max_age: Optional[int] = None,
+    max_age: int | None = None,
     **sdk_options,
-) -> Union[str, list, dict, bytes]:
+) -> str | bytes | list | dict:
     """
     Retrieve a configuration value from AWS App Config.
 

--- a/aws_lambda_powertools/utilities/parameters/base.py
+++ b/aws_lambda_powertools/utilities/parameters/base.py
@@ -4,8 +4,6 @@ Base for Parameter providers
 
 from __future__ import annotations
 
-import base64
-import json
 import os
 from abc import ABC, abstractmethod
 from datetime import datetime, timedelta
@@ -19,21 +17,12 @@ from .exceptions import GetParameterError, TransformParameterError
 if TYPE_CHECKING:
     from aws_lambda_powertools.utilities.parameters.types import TransformOptions
 
-DEFAULT_MAX_AGE_SECS = "300"
 
-# These providers will be dynamically initialized on first use of the helper functions
-DEFAULT_PROVIDERS: dict[str, Any] = {}
-TRANSFORM_METHOD_JSON = "json"
-TRANSFORM_METHOD_BINARY = "binary"
-SUPPORTED_TRANSFORM_METHODS = [TRANSFORM_METHOD_JSON, TRANSFORM_METHOD_BINARY]
-
-TRANSFORM_METHOD_MAPPING = {
-    TRANSFORM_METHOD_JSON: json.loads,
-    TRANSFORM_METHOD_BINARY: base64.b64decode,
-    ".json": json.loads,
-    ".binary": base64.b64decode,
-    None: lambda x: x,
-}
+from aws_lambda_powertools.utilities.parameters.constants import (
+    DEFAULT_MAX_AGE_SECS,
+    DEFAULT_PROVIDERS,
+    TRANSFORM_METHOD_MAPPING,
+)
 
 
 class ExpirableValue(NamedTuple):

--- a/aws_lambda_powertools/utilities/parameters/base.py
+++ b/aws_lambda_powertools/utilities/parameters/base.py
@@ -11,8 +11,7 @@ from typing import TYPE_CHECKING, Any, Callable, NamedTuple, cast, overload
 
 from aws_lambda_powertools.shared import constants, user_agent
 from aws_lambda_powertools.shared.functions import resolve_max_age
-
-from .exceptions import GetParameterError, TransformParameterError
+from aws_lambda_powertools.utilities.parameters.exceptions import GetParameterError, TransformParameterError
 
 if TYPE_CHECKING:
     from aws_lambda_powertools.utilities.parameters.types import TransformOptions

--- a/aws_lambda_powertools/utilities/parameters/constants.py
+++ b/aws_lambda_powertools/utilities/parameters/constants.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+import base64
+import json
+from typing import Any, Literal
+
+SSM_PARAMETER_TYPES = Literal["String", "StringList", "SecureString"]
+SSM_PARAMETER_TIER = Literal["Standard", "Advanced", "Intelligent-Tiering"]
+
+DEFAULT_MAX_AGE_SECS = "300"
+
+# These providers will be dynamically initialized on first use of the helper functions
+DEFAULT_PROVIDERS: dict[str, Any] = {}
+TRANSFORM_METHOD_JSON = "json"
+TRANSFORM_METHOD_BINARY = "binary"
+TRANSFORM_METHOD_MAPPING = {
+    TRANSFORM_METHOD_JSON: json.loads,
+    TRANSFORM_METHOD_BINARY: base64.b64decode,
+    ".json": json.loads,
+    ".binary": base64.b64decode,
+    None: lambda x: x,
+}

--- a/aws_lambda_powertools/utilities/parameters/dynamodb.py
+++ b/aws_lambda_powertools/utilities/parameters/dynamodb.py
@@ -10,9 +10,8 @@ from typing import TYPE_CHECKING
 import boto3
 from boto3.dynamodb.conditions import Key
 
+from aws_lambda_powertools.utilities.parameters.base import BaseProvider
 from aws_lambda_powertools.warnings import PowertoolsDeprecationWarning
-
-from .base import BaseProvider
 
 if TYPE_CHECKING:
     from botocore.config import Config

--- a/aws_lambda_powertools/utilities/parameters/dynamodb.py
+++ b/aws_lambda_powertools/utilities/parameters/dynamodb.py
@@ -2,18 +2,20 @@
 Amazon DynamoDB parameter retrieval and caching utility
 """
 
+from __future__ import annotations
+
 import warnings
-from typing import TYPE_CHECKING, Dict, Optional
+from typing import TYPE_CHECKING
 
 import boto3
 from boto3.dynamodb.conditions import Key
-from botocore.config import Config
 
 from aws_lambda_powertools.warnings import PowertoolsDeprecationWarning
 
 from .base import BaseProvider
 
 if TYPE_CHECKING:
+    from botocore.config import Config
     from mypy_boto3_dynamodb.service_resource import DynamoDBServiceResource
 
 
@@ -156,11 +158,11 @@ class DynamoDBProvider(BaseProvider):
         key_attr: str = "id",
         sort_attr: str = "sk",
         value_attr: str = "value",
-        endpoint_url: Optional[str] = None,
-        config: Optional[Config] = None,
-        boto_config: Optional[Config] = None,
-        boto3_session: Optional[boto3.session.Session] = None,
-        boto3_client: Optional["DynamoDBServiceResource"] = None,
+        endpoint_url: str | None = None,
+        config: Config | None = None,
+        boto_config: Config | None = None,
+        boto3_session: boto3.session.Session | None = None,
+        boto3_client: DynamoDBServiceResource | None = None,
     ):
         """
         Initialize the DynamoDB client
@@ -203,7 +205,7 @@ class DynamoDBProvider(BaseProvider):
         # without a breaking change within ABC return type
         return self.table.get_item(**sdk_options)["Item"][self.value_attr]  # type: ignore[return-value]
 
-    def _get_multiple(self, path: str, **sdk_options) -> Dict[str, str]:
+    def _get_multiple(self, path: str, **sdk_options) -> dict[str, str]:
         """
         Retrieve multiple parameter values from Amazon DynamoDB
 

--- a/aws_lambda_powertools/utilities/parameters/secrets.py
+++ b/aws_lambda_powertools/utilities/parameters/secrets.py
@@ -8,23 +8,23 @@ import json
 import logging
 import os
 import warnings
-from typing import TYPE_CHECKING, Dict, Literal, Optional, Union, overload
+from typing import TYPE_CHECKING, Literal, overload
 
 import boto3
-from botocore.config import Config
-
-from aws_lambda_powertools.warnings import PowertoolsDeprecationWarning
-
-if TYPE_CHECKING:
-    from mypy_boto3_secretsmanager.client import SecretsManagerClient
-    from mypy_boto3_secretsmanager.type_defs import CreateSecretResponseTypeDef
 
 from aws_lambda_powertools.shared import constants
 from aws_lambda_powertools.shared.functions import resolve_max_age
 from aws_lambda_powertools.shared.json_encoder import Encoder
 from aws_lambda_powertools.utilities.parameters.base import DEFAULT_MAX_AGE_SECS, DEFAULT_PROVIDERS, BaseProvider
 from aws_lambda_powertools.utilities.parameters.exceptions import SetSecretError
-from aws_lambda_powertools.utilities.parameters.types import TransformOptions
+from aws_lambda_powertools.warnings import PowertoolsDeprecationWarning
+
+if TYPE_CHECKING:
+    from botocore.config import Config
+    from mypy_boto3_secretsmanager.client import SecretsManagerClient
+    from mypy_boto3_secretsmanager.type_defs import CreateSecretResponseTypeDef
+
+    from aws_lambda_powertools.utilities.parameters.types import TransformOptions
 
 logger = logging.getLogger(__name__)
 
@@ -80,10 +80,10 @@ class SecretsProvider(BaseProvider):
 
     def __init__(
         self,
-        config: Optional[Config] = None,
-        boto_config: Optional[Config] = None,
-        boto3_session: Optional[boto3.session.Session] = None,
-        boto3_client: Optional[SecretsManagerClient] = None,
+        config: Config | None = None,
+        boto_config: Config | None = None,
+        boto3_session: boto3.session.Session | None = None,
+        boto3_client: SecretsManagerClient | None = None,
     ):
         """
         Initialize the Secrets Manager client
@@ -103,7 +103,7 @@ class SecretsProvider(BaseProvider):
 
         super().__init__(client=self.client)
 
-    def _get(self, name: str, **sdk_options) -> Union[str, bytes]:
+    def _get(self, name: str, **sdk_options) -> str | bytes:
         """
         Retrieve a parameter value from AWS Systems Manager Parameter Store
 
@@ -125,7 +125,7 @@ class SecretsProvider(BaseProvider):
 
         return secret_value["SecretBinary"]
 
-    def _get_multiple(self, path: str, **sdk_options) -> Dict[str, str]:
+    def _get_multiple(self, path: str, **sdk_options) -> dict[str, str]:
         """
         Retrieving multiple parameter values is not supported with AWS Secrets Manager
         """
@@ -168,9 +168,9 @@ class SecretsProvider(BaseProvider):
     def set(
         self,
         name: str,
-        value: Union[str, dict, bytes],
+        value: str | bytes | dict,
         *,  # force keyword arguments
-        client_request_token: Optional[str] = None,
+        client_request_token: str | None = None,
         **sdk_options,
     ) -> CreateSecretResponseTypeDef:
         """
@@ -265,7 +265,7 @@ def get_secret(
     name: str,
     transform: None = None,
     force_fetch: bool = False,
-    max_age: Optional[int] = None,
+    max_age: int | None = None,
     **sdk_options,
 ) -> str: ...
 
@@ -275,7 +275,7 @@ def get_secret(
     name: str,
     transform: Literal["json"],
     force_fetch: bool = False,
-    max_age: Optional[int] = None,
+    max_age: int | None = None,
     **sdk_options,
 ) -> dict: ...
 
@@ -285,9 +285,9 @@ def get_secret(
     name: str,
     transform: Literal["binary"],
     force_fetch: bool = False,
-    max_age: Optional[int] = None,
+    max_age: int | None = None,
     **sdk_options,
-) -> Union[str, dict, bytes]: ...
+) -> str | bytes | dict: ...
 
 
 @overload
@@ -295,7 +295,7 @@ def get_secret(
     name: str,
     transform: Literal["auto"],
     force_fetch: bool = False,
-    max_age: Optional[int] = None,
+    max_age: int | None = None,
     **sdk_options,
 ) -> bytes: ...
 
@@ -304,9 +304,9 @@ def get_secret(
     name: str,
     transform: TransformOptions = None,
     force_fetch: bool = False,
-    max_age: Optional[int] = None,
+    max_age: int | None = None,
     **sdk_options,
-) -> Union[str, dict, bytes]:
+) -> str | bytes | dict:
     """
     Retrieve a parameter value from AWS Secrets Manager
 
@@ -370,9 +370,9 @@ def get_secret(
 
 def set_secret(
     name: str,
-    value: Union[str, bytes],
+    value: str | bytes,
     *,  # force keyword arguments
-    client_request_token: Optional[str] = None,
+    client_request_token: str | None = None,
     **sdk_options,
 ) -> CreateSecretResponseTypeDef:
     """

--- a/aws_lambda_powertools/utilities/parameters/secrets.py
+++ b/aws_lambda_powertools/utilities/parameters/secrets.py
@@ -15,7 +15,8 @@ import boto3
 from aws_lambda_powertools.shared import constants
 from aws_lambda_powertools.shared.functions import resolve_max_age
 from aws_lambda_powertools.shared.json_encoder import Encoder
-from aws_lambda_powertools.utilities.parameters.base import DEFAULT_MAX_AGE_SECS, DEFAULT_PROVIDERS, BaseProvider
+from aws_lambda_powertools.utilities.parameters.base import BaseProvider
+from aws_lambda_powertools.utilities.parameters.constants import DEFAULT_MAX_AGE_SECS, DEFAULT_PROVIDERS
 from aws_lambda_powertools.utilities.parameters.exceptions import SetSecretError
 from aws_lambda_powertools.warnings import PowertoolsDeprecationWarning
 

--- a/aws_lambda_powertools/utilities/parameters/ssm.py
+++ b/aws_lambda_powertools/utilities/parameters/ssm.py
@@ -18,10 +18,14 @@ from aws_lambda_powertools.shared.functions import (
     slice_dictionary,
 )
 from aws_lambda_powertools.utilities.parameters.base import (
-    DEFAULT_MAX_AGE_SECS,
-    DEFAULT_PROVIDERS,
     BaseProvider,
     transform_value,
+)
+from aws_lambda_powertools.utilities.parameters.constants import (
+    DEFAULT_MAX_AGE_SECS,
+    DEFAULT_PROVIDERS,
+    SSM_PARAMETER_TIER,
+    SSM_PARAMETER_TYPES,
 )
 from aws_lambda_powertools.utilities.parameters.exceptions import GetParameterError, SetParameterError
 from aws_lambda_powertools.warnings import PowertoolsDeprecationWarning
@@ -32,9 +36,6 @@ if TYPE_CHECKING:
     from mypy_boto3_ssm.type_defs import GetParametersResultTypeDef, PutParameterResultTypeDef
 
     from aws_lambda_powertools.utilities.parameters.types import TransformOptions
-
-SSM_PARAMETER_TYPES = Literal["String", "StringList", "SecureString"]
-SSM_PARAMETER_TIER = Literal["Standard", "Advanced", "Intelligent-Tiering"]
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
**Issue number:** #4979 

## Summary

### Changes

Add `from __future__ import annotations` to parameters package

### User experience

Discussed in #4607

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [X] [Meet tenets criteria](https://docs.powertools.aws.dev/lambda/python/#tenets)
* [X] I have performed a self-review of this change
* [X] Changes have been tested
* [ ] Changes are documented
* [X] PR title follows [conventional commit semantics](https://github.com/aws-powertools/powertools-lambda-python/blob/develop/.github/semantic.yml)

<details>
<summary>Is this a breaking change?</summary>

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
