### PR TITLE
refactor(parser): add from __future__ import annotations

### DIFF
--- a/aws_lambda_powertools/utilities/parser/envelopes/apigw.py
+++ b/aws_lambda_powertools/utilities/parser/envelopes/apigw.py
@@ -1,9 +1,13 @@
-import logging
-from typing import Any, Dict, Optional, Type, Union
+from __future__ import annotations
 
-from ..models import APIGatewayProxyEventModel
-from ..types import Model
-from .base import BaseEnvelope
+import logging
+from typing import TYPE_CHECKING, Any
+
+from aws_lambda_powertools.utilities.parser.envelopes.base import BaseEnvelope
+from aws_lambda_powertools.utilities.parser.models import APIGatewayProxyEventModel
+
+if TYPE_CHECKING:
+    from aws_lambda_powertools.utilities.parser.types import Model
 
 logger = logging.getLogger(__name__)
 
@@ -11,14 +15,14 @@ logger = logging.getLogger(__name__)
 class ApiGatewayEnvelope(BaseEnvelope):
     """API Gateway envelope to extract data within body key"""
 
-    def parse(self, data: Optional[Union[Dict[str, Any], Any]], model: Type[Model]) -> Optional[Model]:
+    def parse(self, data: dict[str, Any] | Any | None, model: type[Model]) -> Model | None:
         """Parses data found with model provided
 
         Parameters
         ----------
-        data : Dict
+        data : dict
             Lambda event to be parsed
-        model : Type[Model]
+        model : type[Model]
             Data model provided to parse after extracting data using envelope
 
         Returns

--- a/aws_lambda_powertools/utilities/parser/envelopes/apigwv2.py
+++ b/aws_lambda_powertools/utilities/parser/envelopes/apigwv2.py
@@ -1,9 +1,13 @@
-import logging
-from typing import Any, Dict, Optional, Type, Union
+from __future__ import annotations
 
-from ..models import APIGatewayProxyEventV2Model
-from ..types import Model
-from .base import BaseEnvelope
+import logging
+from typing import TYPE_CHECKING, Any
+
+from aws_lambda_powertools.utilities.parser.envelopes.base import BaseEnvelope
+from aws_lambda_powertools.utilities.parser.models import APIGatewayProxyEventV2Model
+
+if TYPE_CHECKING:
+    from aws_lambda_powertools.utilities.parser.types import Model
 
 logger = logging.getLogger(__name__)
 
@@ -11,14 +15,14 @@ logger = logging.getLogger(__name__)
 class ApiGatewayV2Envelope(BaseEnvelope):
     """API Gateway V2 envelope to extract data within body key"""
 
-    def parse(self, data: Optional[Union[Dict[str, Any], Any]], model: Type[Model]) -> Optional[Model]:
+    def parse(self, data: dict[str, Any] | Any | None, model: type[Model]) -> Model | None:
         """Parses data found with model provided
 
         Parameters
         ----------
-        data : Dict
+        data : dict
             Lambda event to be parsed
-        model : Type[Model]
+        model : type[Model]
             Data model provided to parse after extracting data using envelope
 
         Returns

--- a/aws_lambda_powertools/utilities/parser/envelopes/base.py
+++ b/aws_lambda_powertools/utilities/parser/envelopes/base.py
@@ -2,10 +2,12 @@ from __future__ import annotations
 
 import logging
 from abc import ABC, abstractmethod
-from typing import Any, Dict, Optional, TypeVar, Union
+from typing import TYPE_CHECKING, Any, TypeVar
 
 from aws_lambda_powertools.utilities.parser.functions import _retrieve_or_set_model_from_cache
-from aws_lambda_powertools.utilities.parser.types import T
+
+if TYPE_CHECKING:
+    from aws_lambda_powertools.utilities.parser.types import T
 
 logger = logging.getLogger(__name__)
 
@@ -14,12 +16,12 @@ class BaseEnvelope(ABC):
     """ABC implementation for creating a supported Envelope"""
 
     @staticmethod
-    def _parse(data: Optional[Union[Dict[str, Any], Any]], model: type[T]) -> Union[T, None]:
+    def _parse(data: dict[str, Any] | Any | None, model: type[T]) -> T | None:
         """Parses envelope data against model provided
 
         Parameters
         ----------
-        data : Dict
+        data : dict
             Data to be parsed and validated
         model : type[T]
             Data model to parse and validate data against
@@ -43,7 +45,7 @@ class BaseEnvelope(ABC):
         return adapter.validate_python(data)
 
     @abstractmethod
-    def parse(self, data: Optional[Union[Dict[str, Any], Any]], model: type[T]):
+    def parse(self, data: dict[str, Any] | Any | None, model: type[T]):
         """Implementation to parse data against envelope model, then against the data model
 
         NOTE: Call `_parse` method to fully parse data with model provided.

--- a/aws_lambda_powertools/utilities/parser/envelopes/bedrock_agent.py
+++ b/aws_lambda_powertools/utilities/parser/envelopes/bedrock_agent.py
@@ -1,9 +1,13 @@
-import logging
-from typing import Any, Dict, Optional, Type, Union
+from __future__ import annotations
 
-from ..models import BedrockAgentEventModel
-from ..types import Model
-from .base import BaseEnvelope
+import logging
+from typing import TYPE_CHECKING, Any
+
+from aws_lambda_powertools.utilities.parser.envelopes.base import BaseEnvelope
+from aws_lambda_powertools.utilities.parser.models import BedrockAgentEventModel
+
+if TYPE_CHECKING:
+    from aws_lambda_powertools.utilities.parser.types import Model
 
 logger = logging.getLogger(__name__)
 
@@ -11,19 +15,19 @@ logger = logging.getLogger(__name__)
 class BedrockAgentEnvelope(BaseEnvelope):
     """Bedrock Agent envelope to extract data within input_text key"""
 
-    def parse(self, data: Optional[Union[Dict[str, Any], Any]], model: Type[Model]) -> Optional[Model]:
+    def parse(self, data: dict[str, Any] | Any | None, model: type[Model]) -> Model | None:
         """Parses data found with model provided
 
         Parameters
         ----------
-        data : Dict
+        data : dict
             Lambda event to be parsed
-        model : Type[Model]
+        model : type[Model]
             Data model provided to parse after extracting data using envelope
 
         Returns
         -------
-        Optional[Model]
+        Model | None
             Parsed detail payload with model provided
         """
         logger.debug(f"Parsing incoming data with Bedrock Agent model {BedrockAgentEventModel}")

--- a/aws_lambda_powertools/utilities/parser/envelopes/cloudwatch.py
+++ b/aws_lambda_powertools/utilities/parser/envelopes/cloudwatch.py
@@ -1,15 +1,19 @@
-import logging
-from typing import Any, Dict, List, Optional, Type, Union
+from __future__ import annotations
 
-from ..models import CloudWatchLogsModel
-from ..types import Model
-from .base import BaseEnvelope
+import logging
+from typing import TYPE_CHECKING, Any
+
+from aws_lambda_powertools.utilities.parser.envelopes.base import BaseEnvelope
+from aws_lambda_powertools.utilities.parser.models import CloudWatchLogsModel
+
+if TYPE_CHECKING:
+    from aws_lambda_powertools.utilities.parser.types import Model
 
 logger = logging.getLogger(__name__)
 
 
 class CloudWatchLogsEnvelope(BaseEnvelope):
-    """CloudWatch Envelope to extract a List of log records.
+    """CloudWatch Envelope to extract a list of log records.
 
     The record's body parameter is a string (after being base64 decoded and gzipped),
     though it can also be a JSON encoded string.
@@ -18,19 +22,19 @@ class CloudWatchLogsEnvelope(BaseEnvelope):
     Note: The record will be parsed the same way so if model is str
     """
 
-    def parse(self, data: Optional[Union[Dict[str, Any], Any]], model: Type[Model]) -> List[Optional[Model]]:
+    def parse(self, data: dict[str, Any] | Any | None, model: type[Model]) -> list[Model | None]:
         """Parses records found with model provided
 
         Parameters
         ----------
-        data : Dict
+        data : dict
             Lambda event to be parsed
-        model : Type[Model]
+        model : type[Model]
             Data model provided to parse after extracting data using envelope
 
         Returns
         -------
-        List
+        list
             List of records parsed with model provided
         """
         logger.debug(f"Parsing incoming data with SNS model {CloudWatchLogsModel}")

--- a/aws_lambda_powertools/utilities/parser/envelopes/dynamodb.py
+++ b/aws_lambda_powertools/utilities/parser/envelopes/dynamodb.py
@@ -1,9 +1,13 @@
-import logging
-from typing import Any, Dict, List, Optional, Type, Union
+from __future__ import annotations
 
-from ..models import DynamoDBStreamModel
-from ..types import Model
-from .base import BaseEnvelope
+import logging
+from typing import TYPE_CHECKING, Any
+
+from aws_lambda_powertools.utilities.parser.envelopes.base import BaseEnvelope
+from aws_lambda_powertools.utilities.parser.models import DynamoDBStreamModel
+
+if TYPE_CHECKING:
+    from aws_lambda_powertools.utilities.parser.types import Model
 
 logger = logging.getLogger(__name__)
 
@@ -15,19 +19,19 @@ class DynamoDBStreamEnvelope(BaseEnvelope):
     length of the list is the record's amount in the original event.
     """
 
-    def parse(self, data: Optional[Union[Dict[str, Any], Any]], model: Type[Model]) -> List[Dict[str, Optional[Model]]]:
+    def parse(self, data: dict[str, Any] | Any | None, model: type[Model]) -> list[dict[str, Model | None]]:
         """Parses DynamoDB Stream records found in either NewImage and OldImage with model provided
 
         Parameters
         ----------
-        data : Dict
+        data : dict
             Lambda event to be parsed
-        model : Type[Model]
+        model : type[Model]
             Data model provided to parse after extracting data using envelope
 
         Returns
         -------
-        List
+        list
             List of dictionaries with NewImage and OldImage records parsed with model provided
         """
         logger.debug(f"Parsing incoming data with DynamoDB Stream model {DynamoDBStreamModel}")

--- a/aws_lambda_powertools/utilities/parser/envelopes/event_bridge.py
+++ b/aws_lambda_powertools/utilities/parser/envelopes/event_bridge.py
@@ -1,9 +1,13 @@
-import logging
-from typing import Any, Dict, Optional, Type, Union
+from __future__ import annotations
 
-from ..models import EventBridgeModel
-from ..types import Model
-from .base import BaseEnvelope
+import logging
+from typing import TYPE_CHECKING, Any
+
+from aws_lambda_powertools.utilities.parser.envelopes.base import BaseEnvelope
+from aws_lambda_powertools.utilities.parser.models import EventBridgeModel
+
+if TYPE_CHECKING:
+    from aws_lambda_powertools.utilities.parser.types import Model
 
 logger = logging.getLogger(__name__)
 
@@ -11,14 +15,14 @@ logger = logging.getLogger(__name__)
 class EventBridgeEnvelope(BaseEnvelope):
     """EventBridge envelope to extract data within detail key"""
 
-    def parse(self, data: Optional[Union[Dict[str, Any], Any]], model: Type[Model]) -> Optional[Model]:
+    def parse(self, data: dict[str, Any] | Any | None, model: type[Model]) -> Model | None:
         """Parses data found with model provided
 
         Parameters
         ----------
-        data : Dict
+        data : dict
             Lambda event to be parsed
-        model : Type[Model]
+        model : type[Model]
             Data model provided to parse after extracting data using envelope
 
         Returns

--- a/aws_lambda_powertools/utilities/parser/envelopes/kafka.py
+++ b/aws_lambda_powertools/utilities/parser/envelopes/kafka.py
@@ -1,9 +1,13 @@
-import logging
-from typing import Any, Dict, List, Optional, Type, Union, cast
+from __future__ import annotations
 
-from ..models import KafkaMskEventModel, KafkaSelfManagedEventModel
-from ..types import Model
-from .base import BaseEnvelope
+import logging
+from typing import TYPE_CHECKING, Any, cast
+
+from aws_lambda_powertools.utilities.parser.envelopes.base import BaseEnvelope
+from aws_lambda_powertools.utilities.parser.models import KafkaMskEventModel, KafkaSelfManagedEventModel
+
+if TYPE_CHECKING:
+    from aws_lambda_powertools.utilities.parser.types import Model
 
 logger = logging.getLogger(__name__)
 
@@ -17,23 +21,23 @@ class KafkaEnvelope(BaseEnvelope):
     all items in the list will be parsed as str and npt as JSON (and vice versa)
     """
 
-    def parse(self, data: Optional[Union[Dict[str, Any], Any]], model: Type[Model]) -> List[Optional[Model]]:
+    def parse(self, data: dict[str, Any] | Any | None, model: type[Model]) -> list[Model | None]:
         """Parses data found with model provided
 
         Parameters
         ----------
-        data : Dict
+        data : dict
             Lambda event to be parsed
-        model : Type[Model]
+        model : type[Model]
             Data model provided to parse after extracting data using envelope
 
         Returns
         -------
-        List
+        list
             List of records parsed with model provided
         """
         event_source = cast(dict, data).get("eventSource")
-        model_parse_event: Union[Type[KafkaMskEventModel], Type[KafkaSelfManagedEventModel]] = (
+        model_parse_event: type[KafkaMskEventModel | KafkaSelfManagedEventModel] = (
             KafkaMskEventModel if event_source == "aws:kafka" else KafkaSelfManagedEventModel
         )
 

--- a/aws_lambda_powertools/utilities/parser/envelopes/kinesis.py
+++ b/aws_lambda_powertools/utilities/parser/envelopes/kinesis.py
@@ -1,9 +1,13 @@
-import logging
-from typing import Any, Dict, List, Optional, Type, Union, cast
+from __future__ import annotations
 
-from ..models import KinesisDataStreamModel
-from ..types import Model
-from .base import BaseEnvelope
+import logging
+from typing import TYPE_CHECKING, Any, cast
+
+from aws_lambda_powertools.utilities.parser.envelopes.base import BaseEnvelope
+from aws_lambda_powertools.utilities.parser.models import KinesisDataStreamModel
+
+if TYPE_CHECKING:
+    from aws_lambda_powertools.utilities.parser.types import Model
 
 logger = logging.getLogger(__name__)
 
@@ -19,19 +23,19 @@ class KinesisDataStreamEnvelope(BaseEnvelope):
     all items in the list will be parsed as str and not as JSON (and vice versa)
     """
 
-    def parse(self, data: Optional[Union[Dict[str, Any], Any]], model: Type[Model]) -> List[Optional[Model]]:
+    def parse(self, data: dict[str, Any] | Any | None, model: type[Model]) -> list[Model | None]:
         """Parses records found with model provided
 
         Parameters
         ----------
-        data : Dict
+        data : dict
             Lambda event to be parsed
-        model : Type[Model]
+        model : type[Model]
             Data model provided to parse after extracting data using envelope
 
         Returns
         -------
-        List
+        list
             List of records parsed with model provided
         """
         logger.debug(f"Parsing incoming data with Kinesis model {KinesisDataStreamModel}")

--- a/aws_lambda_powertools/utilities/parser/envelopes/kinesis_firehose.py
+++ b/aws_lambda_powertools/utilities/parser/envelopes/kinesis_firehose.py
@@ -1,9 +1,13 @@
-import logging
-from typing import Any, Dict, List, Optional, Type, Union, cast
+from __future__ import annotations
 
-from ..models import KinesisFirehoseModel
-from ..types import Model
-from .base import BaseEnvelope
+import logging
+from typing import TYPE_CHECKING, Any, cast
+
+from aws_lambda_powertools.utilities.parser.envelopes.base import BaseEnvelope
+from aws_lambda_powertools.utilities.parser.models import KinesisFirehoseModel
+
+if TYPE_CHECKING:
+    from aws_lambda_powertools.utilities.parser.types import Model
 
 logger = logging.getLogger(__name__)
 
@@ -21,19 +25,19 @@ class KinesisFirehoseEnvelope(BaseEnvelope):
     https://docs.aws.amazon.com/lambda/latest/dg/services-kinesisfirehose.html
     """
 
-    def parse(self, data: Optional[Union[Dict[str, Any], Any]], model: Type[Model]) -> List[Optional[Model]]:
+    def parse(self, data: dict[str, Any] | Any | None, model: type[Model]) -> list[Model | None]:
         """Parses records found with model provided
 
         Parameters
         ----------
-        data : Dict
+        data : dict
             Lambda event to be parsed
-        model : Type[Model]
+        model : type[Model]
             Data model provided to parse after extracting data using envelope
 
         Returns
         -------
-        List
+        list
             List of records parsed with model provided
         """
         logger.debug(f"Parsing incoming data with Kinesis Firehose model {KinesisFirehoseModel}")

--- a/aws_lambda_powertools/utilities/parser/envelopes/lambda_function_url.py
+++ b/aws_lambda_powertools/utilities/parser/envelopes/lambda_function_url.py
@@ -1,9 +1,13 @@
-import logging
-from typing import Any, Dict, Optional, Type, Union
+from __future__ import annotations
 
-from ..models import LambdaFunctionUrlModel
-from ..types import Model
-from .base import BaseEnvelope
+import logging
+from typing import TYPE_CHECKING, Any
+
+from aws_lambda_powertools.utilities.parser.envelopes.base import BaseEnvelope
+from aws_lambda_powertools.utilities.parser.models import LambdaFunctionUrlModel
+
+if TYPE_CHECKING:
+    from aws_lambda_powertools.utilities.parser.types import Model
 
 logger = logging.getLogger(__name__)
 
@@ -11,14 +15,14 @@ logger = logging.getLogger(__name__)
 class LambdaFunctionUrlEnvelope(BaseEnvelope):
     """Lambda function URL envelope to extract data within body key"""
 
-    def parse(self, data: Optional[Union[Dict[str, Any], Any]], model: Type[Model]) -> Optional[Model]:
+    def parse(self, data: dict[str, Any] | Any | None, model: type[Model]) -> Model | None:
         """Parses data found with model provided
 
         Parameters
         ----------
-        data : Dict
+        data : dict
             Lambda event to be parsed
-        model : Type[Model]
+        model : type[Model]
             Data model provided to parse after extracting data using envelope
 
         Returns

--- a/aws_lambda_powertools/utilities/parser/envelopes/sns.py
+++ b/aws_lambda_powertools/utilities/parser/envelopes/sns.py
@@ -1,9 +1,13 @@
-import logging
-from typing import Any, Dict, List, Optional, Type, Union, cast
+from __future__ import annotations
 
-from ..models import SnsModel, SnsNotificationModel, SqsModel
-from ..types import Model
-from .base import BaseEnvelope
+import logging
+from typing import TYPE_CHECKING, Any, cast
+
+from aws_lambda_powertools.utilities.parser.envelopes.base import BaseEnvelope
+from aws_lambda_powertools.utilities.parser.models import SnsModel, SnsNotificationModel, SqsModel
+
+if TYPE_CHECKING:
+    from aws_lambda_powertools.utilities.parser.types import Model
 
 logger = logging.getLogger(__name__)
 
@@ -18,19 +22,19 @@ class SnsEnvelope(BaseEnvelope):
     all items in the list will be parsed as str and npt as JSON (and vice versa)
     """
 
-    def parse(self, data: Optional[Union[Dict[str, Any], Any]], model: Type[Model]) -> List[Optional[Model]]:
+    def parse(self, data: dict[str, Any] | Any | None, model: type[Model]) -> list[Model | None]:
         """Parses records found with model provided
 
         Parameters
         ----------
-        data : Dict
+        data : dict
             Lambda event to be parsed
-        model : Type[Model]
+        model : type[Model]
             Data model provided to parse after extracting data using envelope
 
         Returns
         -------
-        List
+        list
             List of records parsed with model provided
         """
         logger.debug(f"Parsing incoming data with SNS model {SnsModel}")
@@ -50,19 +54,19 @@ class SnsSqsEnvelope(BaseEnvelope):
     3. Finally, parse provided model against payload extracted
     """
 
-    def parse(self, data: Optional[Union[Dict[str, Any], Any]], model: Type[Model]) -> List[Optional[Model]]:
+    def parse(self, data: dict[str, Any] | Any | None, model: type[Model]) -> list[Model | None]:
         """Parses records found with model provided
 
         Parameters
         ----------
-        data : Dict
+        data : dict
             Lambda event to be parsed
-        model : Type[Model]
+        model : type[Model]
             Data model provided to parse after extracting data using envelope
 
         Returns
         -------
-        List
+        list
             List of records parsed with model provided
         """
         logger.debug(f"Parsing incoming data with SQS model {SqsModel}")

--- a/aws_lambda_powertools/utilities/parser/envelopes/sqs.py
+++ b/aws_lambda_powertools/utilities/parser/envelopes/sqs.py
@@ -1,9 +1,13 @@
-import logging
-from typing import Any, Dict, List, Optional, Type, Union
+from __future__ import annotations
 
-from ..models import SqsModel
-from ..types import Model
-from .base import BaseEnvelope
+import logging
+from typing import TYPE_CHECKING, Any
+
+from aws_lambda_powertools.utilities.parser.envelopes.base import BaseEnvelope
+from aws_lambda_powertools.utilities.parser.models import SqsModel
+
+if TYPE_CHECKING:
+    from aws_lambda_powertools.utilities.parser.types import Model
 
 logger = logging.getLogger(__name__)
 
@@ -18,19 +22,19 @@ class SqsEnvelope(BaseEnvelope):
     all items in the list will be parsed as str and npt as JSON (and vice versa)
     """
 
-    def parse(self, data: Optional[Union[Dict[str, Any], Any]], model: Type[Model]) -> List[Optional[Model]]:
+    def parse(self, data: dict[str, Any] | Any | None, model: type[Model]) -> list[Model | None]:
         """Parses records found with model provided
 
         Parameters
         ----------
-        data : Dict
+        data : dict
             Lambda event to be parsed
-        model : Type[Model]
+        model : type[Model]
             Data model provided to parse after extracting data using envelope
 
         Returns
         -------
-        List
+        list
             List of records parsed with model provided
         """
         logger.debug(f"Parsing incoming data with SQS model {SqsModel}")

--- a/aws_lambda_powertools/utilities/parser/envelopes/vpc_lattice.py
+++ b/aws_lambda_powertools/utilities/parser/envelopes/vpc_lattice.py
@@ -1,9 +1,13 @@
-import logging
-from typing import Any, Dict, Optional, Type, Union
+from __future__ import annotations
 
-from ..models import VpcLatticeModel
-from ..types import Model
-from .base import BaseEnvelope
+import logging
+from typing import TYPE_CHECKING, Any
+
+from aws_lambda_powertools.utilities.parser.envelopes.base import BaseEnvelope
+from aws_lambda_powertools.utilities.parser.models import VpcLatticeModel
+
+if TYPE_CHECKING:
+    from aws_lambda_powertools.utilities.parser.types import Model
 
 logger = logging.getLogger(__name__)
 
@@ -11,19 +15,19 @@ logger = logging.getLogger(__name__)
 class VpcLatticeEnvelope(BaseEnvelope):
     """Amazon VPC Lattice envelope to extract data within body key"""
 
-    def parse(self, data: Optional[Union[Dict[str, Any], Any]], model: Type[Model]) -> Optional[Model]:
+    def parse(self, data: dict[str, Any] | Any | None, model: type[Model]) -> Model | None:
         """Parses data found with model provided
 
         Parameters
         ----------
-        data : Dict
+        data : dict
             Lambda event to be parsed
-        model : Type[Model]
+        model : type[Model]
             Data model provided to parse after extracting data using envelope
 
         Returns
         -------
-        Optional[Model]
+        Model | None
             Parsed detail payload with model provided
         """
         logger.debug(f"Parsing incoming data with VPC Lattice model {VpcLatticeModel}")

--- a/aws_lambda_powertools/utilities/parser/envelopes/vpc_latticev2.py
+++ b/aws_lambda_powertools/utilities/parser/envelopes/vpc_latticev2.py
@@ -1,9 +1,13 @@
-import logging
-from typing import Any, Dict, Optional, Type, Union
+from __future__ import annotations
 
-from ..models import VpcLatticeV2Model
-from ..types import Model
-from .base import BaseEnvelope
+import logging
+from typing import TYPE_CHECKING, Any
+
+from aws_lambda_powertools.utilities.parser.envelopes.base import BaseEnvelope
+from aws_lambda_powertools.utilities.parser.models import VpcLatticeV2Model
+
+if TYPE_CHECKING:
+    from aws_lambda_powertools.utilities.parser.types import Model
 
 logger = logging.getLogger(__name__)
 
@@ -11,19 +15,19 @@ logger = logging.getLogger(__name__)
 class VpcLatticeV2Envelope(BaseEnvelope):
     """Amazon VPC Lattice envelope to extract data within body key"""
 
-    def parse(self, data: Optional[Union[Dict[str, Any], Any]], model: Type[Model]) -> Optional[Model]:
+    def parse(self, data: dict[str, Any] | Any | None, model: type[Model]) -> Model | None:
         """Parses data found with model provided
 
         Parameters
         ----------
-        data : Dict
+        data : dict
             Lambda event to be parsed
-        model : Type[Model]
+        model : type[Model]
             Data model provided to parse after extracting data using envelope
 
         Returns
         -------
-        Optional[Model]
+        Model | None
             Parsed detail payload with model provided
         """
         logger.debug(f"Parsing incoming data with VPC Lattice V2 model {VpcLatticeV2Model}")

--- a/tests/e2e/parser/handlers/handler_with_union_tag.py
+++ b/tests/e2e/parser/handlers/handler_with_union_tag.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
-from typing import Annotated, Literal, Union
+from typing import Literal
 
 from pydantic import BaseModel, Field
+from typing_extensions import Annotated
 
 from aws_lambda_powertools.utilities.parser import event_parser
 from aws_lambda_powertools.utilities.typing import LambdaContext
@@ -24,7 +25,7 @@ class PartialFailureCallback(BaseModel):
     error_msg: str
 
 
-OrderCallback = Annotated[Union[SuccessCallback, ErrorCallback, PartialFailureCallback], Field(discriminator="status")]
+OrderCallback = Annotated[SuccessCallback | ErrorCallback | PartialFailureCallback, Field(discriminator="status")]
 
 
 @event_parser


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
**Issue number:** #4980 

## Summary

### Changes

Add `from __future__ import annotations` to envelopes package

### User experience

Discussed in #4607

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [X] [Meet tenets criteria](https://docs.powertools.aws.dev/lambda/python/#tenets)
* [X] I have performed a self-review of this change
* [X] Changes have been tested
* [ ] Changes are documented
* [X] PR title follows [conventional commit semantics](https://github.com/aws-powertools/powertools-lambda-python/blob/develop/.github/semantic.yml)

<details>
<summary>Is this a breaking change?</summary>

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
