### PR TITLE
refactor(validation): add from __future__ import annotations

### DIFF
--- a/aws_lambda_powertools/utilities/validation/base.py
+++ b/aws_lambda_powertools/utilities/validation/base.py
@@ -1,5 +1,6 @@
+from __future__ import annotations
+
 import logging
-from typing import Dict, Optional, Union
 
 import fastjsonschema  # type: ignore
 
@@ -8,16 +9,16 @@ from .exceptions import InvalidSchemaFormatError, SchemaValidationError
 logger = logging.getLogger(__name__)
 
 
-def validate_data_against_schema(data: Union[Dict, str], schema: Dict, formats: Optional[Dict] = None):
+def validate_data_against_schema(data: dict | str, schema: dict, formats: dict | None = None):
     """Validate dict data against given JSON Schema
 
     Parameters
     ----------
-    data : Dict
+    data : dict
         Data set to be validated
-    schema : Dict
+    schema : dict
         JSON Schema to validate against
-    formats: Dict
+    formats: dict
         Custom formats containing a key (e.g. int64) and a value expressed as regex or callback returning bool
 
     Raises

--- a/aws_lambda_powertools/utilities/validation/base.py
+++ b/aws_lambda_powertools/utilities/validation/base.py
@@ -4,7 +4,7 @@ import logging
 
 import fastjsonschema  # type: ignore
 
-from .exceptions import InvalidSchemaFormatError, SchemaValidationError
+from aws_lambda_powertools.utilities.validation.exceptions import InvalidSchemaFormatError, SchemaValidationError
 
 logger = logging.getLogger(__name__)
 

--- a/aws_lambda_powertools/utilities/validation/exceptions.py
+++ b/aws_lambda_powertools/utilities/validation/exceptions.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import Any
 
-from ...exceptions import InvalidEnvelopeExpressionError
+from aws_lambda_powertools.exceptions import InvalidEnvelopeExpressionError
 
 
 class SchemaValidationError(Exception):

--- a/aws_lambda_powertools/utilities/validation/exceptions.py
+++ b/aws_lambda_powertools/utilities/validation/exceptions.py
@@ -1,4 +1,6 @@
-from typing import Any, List, Optional
+from __future__ import annotations
+
+from typing import Any
 
 from ...exceptions import InvalidEnvelopeExpressionError
 
@@ -8,14 +10,14 @@ class SchemaValidationError(Exception):
 
     def __init__(
         self,
-        message: Optional[str] = None,
-        validation_message: Optional[str] = None,
-        name: Optional[str] = None,
-        path: Optional[List] = None,
-        value: Optional[Any] = None,
-        definition: Optional[Any] = None,
-        rule: Optional[str] = None,
-        rule_definition: Optional[Any] = None,
+        message: str | None = None,
+        validation_message: str | None = None,
+        name: str | None = None,
+        path: list | None = None,
+        value: Any | None = None,
+        definition: Any | None = None,
+        rule: str | None = None,
+        rule_definition: Any | None = None,
     ):
         """
 
@@ -29,7 +31,7 @@ class SchemaValidationError(Exception):
         name : str, optional
             name of a path in the data structure
             (e.g. `data.property[index]`)
-        path: List, optional
+        path: list, optional
             `path` as an array in the data structure
             (e.g. `['data', 'property', 'index']`),
         value : Any, optional

--- a/aws_lambda_powertools/utilities/validation/validator.py
+++ b/aws_lambda_powertools/utilities/validation/validator.py
@@ -1,10 +1,11 @@
+from __future__ import annotations
+
 import logging
-from typing import Any, Callable, Dict, Optional, Union
+from typing import Any, Callable
 
+from aws_lambda_powertools.middleware_factory import lambda_handler_decorator
 from aws_lambda_powertools.utilities import jmespath_utils
-
-from ...middleware_factory import lambda_handler_decorator
-from .base import validate_data_against_schema
+from aws_lambda_powertools.utilities.validation.base import validate_data_against_schema
 
 logger = logging.getLogger(__name__)
 
@@ -12,14 +13,14 @@ logger = logging.getLogger(__name__)
 @lambda_handler_decorator
 def validator(
     handler: Callable,
-    event: Union[Dict, str],
+    event: dict | str,
     context: Any,
-    inbound_schema: Optional[Dict] = None,
-    inbound_formats: Optional[Dict] = None,
-    outbound_schema: Optional[Dict] = None,
-    outbound_formats: Optional[Dict] = None,
+    inbound_schema: dict | None = None,
+    inbound_formats: dict | None = None,
+    outbound_schema: dict | None = None,
+    outbound_formats: dict | None = None,
     envelope: str = "",
-    jmespath_options: Optional[Dict] = None,
+    jmespath_options: dict | None = None,
     **kwargs: Any,
 ) -> Any:
     """Lambda handler decorator to validate incoming/outbound data using a JSON Schema
@@ -28,21 +29,21 @@ def validator(
     ----------
     handler : Callable
         Method to annotate on
-    event : Dict
+    event : dict
         Lambda event to be validated
     context : Any
         Lambda context object
-    inbound_schema : Dict
+    inbound_schema : dict
         JSON Schema to validate incoming event
-    outbound_schema : Dict
+    outbound_schema : dict
         JSON Schema to validate outbound event
-    envelope : Dict
+    envelope : dict
         JMESPath expression to filter data against
-    jmespath_options : Dict
+    jmespath_options : dict
         Alternative JMESPath options to be included when filtering expr
-    inbound_formats: Dict
+    inbound_formats: dict
         Custom formats containing a key (e.g. int64) and a value expressed as regex or callback returning bool
-    outbound_formats: Dict
+    outbound_formats: dict
         Custom formats containing a key (e.g. int64) and a value expressed as regex or callback returning bool
 
     Example
@@ -140,10 +141,10 @@ def validator(
 
 def validate(
     event: Any,
-    schema: Dict,
-    formats: Optional[Dict] = None,
-    envelope: Optional[str] = None,
-    jmespath_options: Optional[Dict] = None,
+    schema: dict,
+    formats: dict | None = None,
+    envelope: str | None = None,
+    jmespath_options: dict | None = None,
 ):
     """Standalone function to validate event data using a JSON Schema
 
@@ -151,15 +152,15 @@ def validate(
 
     Parameters
     ----------
-    event : Dict
+    event : dict
         Lambda event to be validated
-    schema : Dict
+    schema : dict
         JSON Schema to validate incoming event
-    envelope : Dict
+    envelope : dict
         JMESPath expression to filter data against
-    jmespath_options : Dict
+    jmespath_options : dict
         Alternative JMESPath options to be included when filtering expr
-    formats: Dict
+    formats: dict
         Custom formats containing a key (e.g. int64) and a value expressed as regex or callback returning bool
 
     Example


### PR DESCRIPTION
and update code according to ruff rules TCH, UP006, UP007, UP037 and FA100.

<!-- markdownlint-disable MD041 MD043 -->
**Issue number:** #4988 

## Summary

### Changes

Add `from __future__ import annotations` to validation package

### User experience

Discussed in #4607

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [X] [Meet tenets criteria](https://docs.powertools.aws.dev/lambda/python/#tenets)
* [X] I have performed a self-review of this change
* [X] Changes have been tested
* [ ] Changes are documented
* [X] PR title follows [conventional commit semantics](https://github.com/aws-powertools/powertools-lambda-python/blob/develop/.github/semantic.yml)

<details>
<summary>Is this a breaking change?</summary>

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
