### PR TITLE
refactor(typing): add from __future__ import annotations

### DIFF
--- a/aws_lambda_powertools/utilities/typing/lambda_client_context.py
+++ b/aws_lambda_powertools/utilities/typing/lambda_client_context.py
@@ -1,15 +1,18 @@
 # -*- coding: utf-8 -*-
-from typing import Any, Dict
+from __future__ import annotations
 
-from aws_lambda_powertools.utilities.typing.lambda_client_context_mobile_client import (
-    LambdaClientContextMobileClient,
-)
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from aws_lambda_powertools.utilities.typing.lambda_client_context_mobile_client import (
+        LambdaClientContextMobileClient,
+    )
 
 
 class LambdaClientContext(object):
     _client: LambdaClientContextMobileClient
-    _custom: Dict[str, Any]
-    _env: Dict[str, Any]
+    _custom: dict[str, Any]
+    _env: dict[str, Any]
 
     @property
     def client(self) -> LambdaClientContextMobileClient:
@@ -17,11 +20,11 @@ class LambdaClientContext(object):
         return self._client
 
     @property
-    def custom(self) -> Dict[str, Any]:
+    def custom(self) -> dict[str, Any]:
         """A dict of custom values set by the mobile client application."""
         return self._custom
 
     @property
-    def env(self) -> Dict[str, Any]:
+    def env(self) -> dict[str, Any]:
         """A dict of environment information provided by the AWS SDK."""
         return self._env

--- a/aws_lambda_powertools/utilities/typing/lambda_context.py
+++ b/aws_lambda_powertools/utilities/typing/lambda_context.py
@@ -1,10 +1,15 @@
 # -*- coding: utf-8 -*-
-from aws_lambda_powertools.utilities.typing.lambda_client_context import (
-    LambdaClientContext,
-)
-from aws_lambda_powertools.utilities.typing.lambda_cognito_identity import (
-    LambdaCognitoIdentity,
-)
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from aws_lambda_powertools.utilities.typing.lambda_client_context import (
+        LambdaClientContext,
+    )
+    from aws_lambda_powertools.utilities.typing.lambda_cognito_identity import (
+        LambdaCognitoIdentity,
+    )
 
 
 class LambdaContext(object):
@@ -14,10 +19,10 @@ class LambdaContext(object):
     -------
     **A Lambda function using LambdaContext**
 
-        >>> from typing import Any, Dict
+        >>> from typing import Any
         >>> from aws_lambda_powertools.utilities.typing import LambdaContext
         >>>
-        >>> def handler(event: Dict[str, Any], context: LambdaContext) -> Dict[str, Any]:
+        >>> def handler(event: dict[str, Any], context: LambdaContext) -> dict[str, Any]:
         >>>     # Insert business logic
         >>>     return event
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
**Issue number:** #4986 

## Summary

### Changes

Add `from __future__ import annotations` to typing package

### User experience

Discussed in #4607

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [X] [Meet tenets criteria](https://docs.powertools.aws.dev/lambda/python/#tenets)
* [X] I have performed a self-review of this change
* [X] Changes have been tested
* [ ] Changes are documented
* [X] PR title follows [conventional commit semantics](https://github.com/aws-powertools/powertools-lambda-python/blob/develop/.github/semantic.yml)

<details>
<summary>Is this a breaking change?</summary>

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
