### PR TITLE
refactor(event_handler): add from __future__ import annotations

### DIFF
--- a/aws_lambda_powertools/event_handler/appsync.py
+++ b/aws_lambda_powertools/event_handler/appsync.py
@@ -1,8 +1,12 @@
+from __future__ import annotations
+
 import logging
-from typing import Any, Callable, Optional, Type, TypeVar
+from typing import TYPE_CHECKING, Any, Callable, TypeVar
 
 from aws_lambda_powertools.utilities.data_classes import AppSyncResolverEvent
-from aws_lambda_powertools.utilities.typing import LambdaContext
+
+if TYPE_CHECKING:
+    from aws_lambda_powertools.utilities.typing import LambdaContext
 
 logger = logging.getLogger(__name__)
 
@@ -17,7 +21,7 @@ class BaseRouter:
     def __init__(self):
         self._resolvers: dict = {}
 
-    def resolver(self, type_name: str = "*", field_name: Optional[str] = None):
+    def resolver(self, type_name: str = "*", field_name: str | None = None):
         """Registers the resolver for field_name
 
         Parameters
@@ -83,7 +87,7 @@ class AppSyncResolver(BaseRouter):
         self,
         event: dict,
         context: LambdaContext,
-        data_model: Type[AppSyncResolverEvent] = AppSyncResolverEvent,
+        data_model: type[AppSyncResolverEvent] = AppSyncResolverEvent,
     ) -> Any:
         """Resolve field_name
 
@@ -189,12 +193,12 @@ class AppSyncResolver(BaseRouter):
         self,
         event: dict,
         context: LambdaContext,
-        data_model: Type[AppSyncResolverEvent] = AppSyncResolverEvent,
+        data_model: type[AppSyncResolverEvent] = AppSyncResolverEvent,
     ) -> Any:
         """Implicit lambda handler which internally calls `resolve`"""
         return self.resolve(event, context, data_model)
 
-    def include_router(self, router: "Router") -> None:
+    def include_router(self, router: Router) -> None:
         """Adds all resolvers defined in a router
 
         Parameters

--- a/aws_lambda_powertools/event_handler/bedrock_agent.py
+++ b/aws_lambda_powertools/event_handler/bedrock_agent.py
@@ -1,5 +1,6 @@
-from re import Match
-from typing import Any, Callable, Dict, List, Optional
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, Callable
 
 from typing_extensions import override
 
@@ -9,8 +10,12 @@ from aws_lambda_powertools.event_handler.api_gateway import (
     ProxyEventType,
     ResponseBuilder,
 )
-from aws_lambda_powertools.event_handler.openapi.types import OpenAPIResponse
-from aws_lambda_powertools.utilities.data_classes import BedrockAgentEvent
+
+if TYPE_CHECKING:
+    from re import Match
+
+    from aws_lambda_powertools.event_handler.openapi.types import OpenAPIResponse
+    from aws_lambda_powertools.utilities.data_classes import BedrockAgentEvent
 
 
 class BedrockResponseBuilder(ResponseBuilder):
@@ -21,7 +26,7 @@ class BedrockResponseBuilder(ResponseBuilder):
     """
 
     @override
-    def build(self, event: BedrockAgentEvent, *args) -> Dict[str, Any]:
+    def build(self, event: BedrockAgentEvent, *args) -> dict[str, Any]:
         """Build the full response dict to be returned by the lambda"""
         self._route(event, None)
 
@@ -91,16 +96,16 @@ class BedrockAgentResolver(ApiGatewayResolver):
         self,
         rule: str,
         description: str,
-        cors: Optional[bool] = None,
+        cors: bool | None = None,
         compress: bool = False,
-        cache_control: Optional[str] = None,
-        summary: Optional[str] = None,
-        responses: Optional[Dict[int, OpenAPIResponse]] = None,
+        cache_control: str | None = None,
+        summary: str | None = None,
+        responses: dict[int, OpenAPIResponse] | None = None,
         response_description: str = _DEFAULT_OPENAPI_RESPONSE_DESCRIPTION,
-        tags: Optional[List[str]] = None,
-        operation_id: Optional[str] = None,
+        tags: list[str] | None = None,
+        operation_id: str | None = None,
         include_in_schema: bool = True,
-        middlewares: Optional[List[Callable[..., Any]]] = None,
+        middlewares: list[Callable[..., Any]] | None = None,
     ) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
         security = None
 
@@ -126,16 +131,16 @@ class BedrockAgentResolver(ApiGatewayResolver):
         self,
         rule: str,
         description: str,
-        cors: Optional[bool] = None,
+        cors: bool | None = None,
         compress: bool = False,
-        cache_control: Optional[str] = None,
-        summary: Optional[str] = None,
-        responses: Optional[Dict[int, OpenAPIResponse]] = None,
+        cache_control: str | None = None,
+        summary: str | None = None,
+        responses: dict[int, OpenAPIResponse] | None = None,
         response_description: str = _DEFAULT_OPENAPI_RESPONSE_DESCRIPTION,
-        tags: Optional[List[str]] = None,
-        operation_id: Optional[str] = None,
+        tags: list[str] | None = None,
+        operation_id: str | None = None,
         include_in_schema: bool = True,
-        middlewares: Optional[List[Callable[..., Any]]] = None,
+        middlewares: list[Callable[..., Any]] | None = None,
     ):
         security = None
 
@@ -161,16 +166,16 @@ class BedrockAgentResolver(ApiGatewayResolver):
         self,
         rule: str,
         description: str,
-        cors: Optional[bool] = None,
+        cors: bool | None = None,
         compress: bool = False,
-        cache_control: Optional[str] = None,
-        summary: Optional[str] = None,
-        responses: Optional[Dict[int, OpenAPIResponse]] = None,
+        cache_control: str | None = None,
+        summary: str | None = None,
+        responses: dict[int, OpenAPIResponse] | None = None,
         response_description: str = _DEFAULT_OPENAPI_RESPONSE_DESCRIPTION,
-        tags: Optional[List[str]] = None,
-        operation_id: Optional[str] = None,
+        tags: list[str] | None = None,
+        operation_id: str | None = None,
         include_in_schema: bool = True,
-        middlewares: Optional[List[Callable[..., Any]]] = None,
+        middlewares: list[Callable[..., Any]] | None = None,
     ):
         security = None
 
@@ -196,16 +201,16 @@ class BedrockAgentResolver(ApiGatewayResolver):
         self,
         rule: str,
         description: str,
-        cors: Optional[bool] = None,
+        cors: bool | None = None,
         compress: bool = False,
-        cache_control: Optional[str] = None,
-        summary: Optional[str] = None,
-        responses: Optional[Dict[int, OpenAPIResponse]] = None,
+        cache_control: str | None = None,
+        summary: str | None = None,
+        responses: dict[int, OpenAPIResponse] | None = None,
         response_description: str = _DEFAULT_OPENAPI_RESPONSE_DESCRIPTION,
-        tags: Optional[List[str]] = None,
-        operation_id: Optional[str] = None,
+        tags: list[str] | None = None,
+        operation_id: str | None = None,
         include_in_schema: bool = True,
-        middlewares: Optional[List[Callable]] = None,
+        middlewares: list[Callable] | None = None,
     ):
         security = None
 
@@ -231,16 +236,16 @@ class BedrockAgentResolver(ApiGatewayResolver):
         self,
         rule: str,
         description: str,
-        cors: Optional[bool] = None,
+        cors: bool | None = None,
         compress: bool = False,
-        cache_control: Optional[str] = None,
-        summary: Optional[str] = None,
-        responses: Optional[Dict[int, OpenAPIResponse]] = None,
+        cache_control: str | None = None,
+        summary: str | None = None,
+        responses: dict[int, OpenAPIResponse] | None = None,
         response_description: str = _DEFAULT_OPENAPI_RESPONSE_DESCRIPTION,
-        tags: Optional[List[str]] = None,
-        operation_id: Optional[str] = None,
+        tags: list[str] | None = None,
+        operation_id: str | None = None,
         include_in_schema: bool = True,
-        middlewares: Optional[List[Callable[..., Any]]] = None,
+        middlewares: list[Callable[..., Any]] | None = None,
     ):
         security = None
 
@@ -261,10 +266,10 @@ class BedrockAgentResolver(ApiGatewayResolver):
         )
 
     @override
-    def _convert_matches_into_route_keys(self, match: Match) -> Dict[str, str]:
+    def _convert_matches_into_route_keys(self, match: Match) -> dict[str, str]:
         # In Bedrock Agents, all the parameters come inside the "parameters" key, not on the apiPath
         # So we have to search for route parameters in the parameters key
-        parameters: Dict[str, str] = {}
+        parameters: dict[str, str] = {}
         if match.groupdict() and self.current_event.parameters:
             parameters = {parameter["name"]: parameter["value"] for parameter in self.current_event.parameters}
         return parameters

--- a/aws_lambda_powertools/event_handler/lambda_function_url.py
+++ b/aws_lambda_powertools/event_handler/lambda_function_url.py
@@ -1,11 +1,15 @@
-from typing import Callable, Dict, List, Optional, Pattern, Union
+from __future__ import annotations
 
-from aws_lambda_powertools.event_handler import CORSConfig
+from typing import TYPE_CHECKING, Callable, Pattern
+
 from aws_lambda_powertools.event_handler.api_gateway import (
     ApiGatewayResolver,
     ProxyEventType,
 )
-from aws_lambda_powertools.utilities.data_classes import LambdaFunctionUrlEvent
+
+if TYPE_CHECKING:
+    from aws_lambda_powertools.event_handler import CORSConfig
+    from aws_lambda_powertools.utilities.data_classes import LambdaFunctionUrlEvent
 
 
 class LambdaFunctionUrlResolver(ApiGatewayResolver):
@@ -48,10 +52,10 @@ class LambdaFunctionUrlResolver(ApiGatewayResolver):
 
     def __init__(
         self,
-        cors: Optional[CORSConfig] = None,
-        debug: Optional[bool] = None,
-        serializer: Optional[Callable[[Dict], str]] = None,
-        strip_prefixes: Optional[List[Union[str, Pattern]]] = None,
+        cors: CORSConfig | None = None,
+        debug: bool | None = None,
+        serializer: Callable[[dict], str] | None = None,
+        strip_prefixes: list[str | Pattern] | None = None,
         enable_validation: bool = False,
     ):
         super().__init__(

--- a/aws_lambda_powertools/event_handler/router.py
+++ b/aws_lambda_powertools/event_handler/router.py
@@ -1,10 +1,16 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 from aws_lambda_powertools.event_handler.api_gateway import Router
-from aws_lambda_powertools.utilities.data_classes import (
-    ALBEvent,
-    APIGatewayProxyEvent,
-    APIGatewayProxyEventV2,
-    LambdaFunctionUrlEvent,
-)
+
+if TYPE_CHECKING:
+    from aws_lambda_powertools.utilities.data_classes import (
+        ALBEvent,
+        APIGatewayProxyEvent,
+        APIGatewayProxyEventV2,
+        LambdaFunctionUrlEvent,
+    )
 
 
 class APIGatewayRouter(Router):

--- a/aws_lambda_powertools/event_handler/util.py
+++ b/aws_lambda_powertools/event_handler/util.py
@@ -1,4 +1,6 @@
-from typing import Any, Mapping, Optional
+from __future__ import annotations
+
+from typing import Any, Mapping
 
 
 class _FrozenDict(dict):
@@ -16,7 +18,7 @@ class _FrozenDict(dict):
         return hash(frozenset(self.keys()))
 
 
-def extract_origin_header(resolved_headers: Mapping[str, Any]) -> Optional[str]:
+def extract_origin_header(resolved_headers: Mapping[str, Any]) -> str | None:
     """
     Extracts the 'origin' or 'Origin' header from the provided resolver headers.
 
@@ -26,7 +28,7 @@ def extract_origin_header(resolved_headers: Mapping[str, Any]) -> Optional[str]:
         resolved_headers (Mapping): A dictionary containing the headers.
 
     Returns:
-        Optional[str]: The value(s) of the origin header or None.
+        str | None: The value(s) of the origin header or None.
     """
     resolved_header = resolved_headers.get("origin")
     if isinstance(resolved_header, list):

--- a/aws_lambda_powertools/event_handler/vpc_lattice.py
+++ b/aws_lambda_powertools/event_handler/vpc_lattice.py
@@ -1,11 +1,15 @@
-from typing import Callable, Dict, List, Optional, Pattern, Union
+from __future__ import annotations
 
-from aws_lambda_powertools.event_handler import CORSConfig
+from typing import TYPE_CHECKING, Callable, Pattern
+
 from aws_lambda_powertools.event_handler.api_gateway import (
     ApiGatewayResolver,
     ProxyEventType,
 )
-from aws_lambda_powertools.utilities.data_classes import VPCLatticeEvent, VPCLatticeEventV2
+
+if TYPE_CHECKING:
+    from aws_lambda_powertools.event_handler import CORSConfig
+    from aws_lambda_powertools.utilities.data_classes import VPCLatticeEvent, VPCLatticeEventV2
 
 
 class VPCLatticeResolver(ApiGatewayResolver):
@@ -44,10 +48,10 @@ class VPCLatticeResolver(ApiGatewayResolver):
 
     def __init__(
         self,
-        cors: Optional[CORSConfig] = None,
-        debug: Optional[bool] = None,
-        serializer: Optional[Callable[[Dict], str]] = None,
-        strip_prefixes: Optional[List[Union[str, Pattern]]] = None,
+        cors: CORSConfig | None = None,
+        debug: bool | None = None,
+        serializer: Callable[[dict], str] | None = None,
+        strip_prefixes: list[str | Pattern] | None = None,
         enable_validation: bool = False,
     ):
         """Amazon VPC Lattice resolver"""
@@ -93,10 +97,10 @@ class VPCLatticeV2Resolver(ApiGatewayResolver):
 
     def __init__(
         self,
-        cors: Optional[CORSConfig] = None,
-        debug: Optional[bool] = None,
-        serializer: Optional[Callable[[Dict], str]] = None,
-        strip_prefixes: Optional[List[Union[str, Pattern]]] = None,
+        cors: CORSConfig | None = None,
+        debug: bool | None = None,
+        serializer: Callable[[dict], str] | None = None,
+        strip_prefixes: list[str | Pattern] | None = None,
         enable_validation: bool = False,
     ):
         """Amazon VPC Lattice resolver"""


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
**Issue number:** #4995 

## Summary

### Changes

Add `from __future__ import annotations` to event_handler package

### User experience

Discussed in #4607

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [X] [Meet tenets criteria](https://docs.powertools.aws.dev/lambda/python/#tenets)
* [X] I have performed a self-review of this change
* [X] Changes have been tested
* [ ] Changes are documented
* [X] PR title follows [conventional commit semantics](https://github.com/aws-powertools/powertools-lambda-python/blob/develop/.github/semantic.yml)

<details>
<summary>Is this a breaking change?</summary>

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
