### PR TITLE
refactor(batch): add from __future__ import annotations

### DIFF
--- a/aws_lambda_powertools/utilities/batch/decorators.py
+++ b/aws_lambda_powertools/utilities/batch/decorators.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import warnings
-from typing import Any, Awaitable, Callable, Dict, List
+from typing import TYPE_CHECKING, Any, Awaitable, Callable
 
 from typing_extensions import deprecated
 
@@ -12,9 +12,11 @@ from aws_lambda_powertools.utilities.batch import (
     BatchProcessor,
     EventType,
 )
-from aws_lambda_powertools.utilities.batch.types import PartialItemFailureResponse
-from aws_lambda_powertools.utilities.typing import LambdaContext
 from aws_lambda_powertools.warnings import PowertoolsDeprecationWarning
+
+if TYPE_CHECKING:
+    from aws_lambda_powertools.utilities.batch.types import PartialItemFailureResponse
+    from aws_lambda_powertools.utilities.typing import LambdaContext
 
 
 @lambda_handler_decorator
@@ -24,7 +26,7 @@ from aws_lambda_powertools.warnings import PowertoolsDeprecationWarning
 )
 def async_batch_processor(
     handler: Callable,
-    event: Dict,
+    event: dict,
     context: LambdaContext,
     record_handler: Callable[..., Awaitable[Any]],
     processor: AsyncBatchProcessor,
@@ -40,7 +42,7 @@ def async_batch_processor(
     ----------
     handler: Callable
         Lambda's handler
-    event: Dict
+    event: dict
         Lambda's Event
     context: LambdaContext
         Lambda's Context
@@ -92,7 +94,7 @@ def async_batch_processor(
 )
 def batch_processor(
     handler: Callable,
-    event: Dict,
+    event: dict,
     context: LambdaContext,
     record_handler: Callable,
     processor: BatchProcessor,
@@ -108,7 +110,7 @@ def batch_processor(
     ----------
     handler: Callable
         Lambda's handler
-    event: Dict
+    event: dict
         Lambda's Event
     context: LambdaContext
         Lambda's Context
@@ -154,7 +156,7 @@ def batch_processor(
 
 
 def process_partial_response(
-    event: Dict,
+    event: dict,
     record_handler: Callable,
     processor: BasePartialBatchProcessor,
     context: LambdaContext | None = None,
@@ -164,7 +166,7 @@ def process_partial_response(
 
     Parameters
     ----------
-    event: Dict
+    event: dict
         Lambda's original event
     record_handler: Callable
         Callable to process each record from the batch
@@ -202,7 +204,7 @@ def process_partial_response(
     * Async batch processors. Use `async_process_partial_response` instead.
     """
     try:
-        records: List[Dict] = event.get("Records", [])
+        records: list[dict] = event.get("Records", [])
     except AttributeError:
         event_types = ", ".join(list(EventType.__members__))
         docs = "https://docs.powertools.aws.dev/lambda/python/latest/utilities/batch/#processing-messages-from-sqs"  # noqa: E501 # long-line
@@ -218,7 +220,7 @@ def process_partial_response(
 
 
 def async_process_partial_response(
-    event: Dict,
+    event: dict,
     record_handler: Callable,
     processor: AsyncBatchProcessor,
     context: LambdaContext | None = None,
@@ -228,7 +230,7 @@ def async_process_partial_response(
 
     Parameters
     ----------
-    event: Dict
+    event: dict
         Lambda's original event
     record_handler: Callable
         Callable to process each record from the batch
@@ -266,7 +268,7 @@ def async_process_partial_response(
     * Sync batch processors. Use `process_partial_response` instead.
     """
     try:
-        records: List[Dict] = event.get("Records", [])
+        records: list[dict] = event.get("Records", [])
     except AttributeError:
         event_types = ", ".join(list(EventType.__members__))
         docs = "https://docs.powertools.aws.dev/lambda/python/latest/utilities/batch/#processing-messages-from-sqs"  # noqa: E501 # long-line

--- a/aws_lambda_powertools/utilities/batch/exceptions.py
+++ b/aws_lambda_powertools/utilities/batch/exceptions.py
@@ -6,13 +6,13 @@ from __future__ import annotations
 
 import traceback
 from types import TracebackType
-from typing import List, Optional, Tuple, Type
+from typing import Optional, Tuple
 
-ExceptionInfo = Tuple[Optional[Type[BaseException]], Optional[BaseException], Optional[TracebackType]]
+ExceptionInfo = Tuple[Optional[type[BaseException]], Optional[BaseException], Optional[TracebackType]]
 
 
 class BaseBatchProcessingError(Exception):
-    def __init__(self, msg="", child_exceptions: List[ExceptionInfo] | None = None):
+    def __init__(self, msg="", child_exceptions: list[ExceptionInfo] | None = None):
         super().__init__(msg)
         self.msg = msg
         self.child_exceptions = child_exceptions or []
@@ -30,7 +30,7 @@ class BaseBatchProcessingError(Exception):
 class BatchProcessingError(BaseBatchProcessingError):
     """When all batch records failed to be processed"""
 
-    def __init__(self, msg="", child_exceptions: List[ExceptionInfo] | None = None):
+    def __init__(self, msg="", child_exceptions: list[ExceptionInfo] | None = None):
         super().__init__(msg, child_exceptions)
 
     def __str__(self):

--- a/aws_lambda_powertools/utilities/batch/exceptions.py
+++ b/aws_lambda_powertools/utilities/batch/exceptions.py
@@ -6,9 +6,9 @@ from __future__ import annotations
 
 import traceback
 from types import TracebackType
-from typing import Optional, Tuple
+from typing import Optional, Tuple, Type
 
-ExceptionInfo = Tuple[Optional[type[BaseException]], Optional[BaseException], Optional[TracebackType]]
+ExceptionInfo = Tuple[Optional[Type[BaseException]], Optional[BaseException], Optional[TracebackType]]
 
 
 class BaseBatchProcessingError(Exception):

--- a/aws_lambda_powertools/utilities/batch/sqs_fifo_partial_processor.py
+++ b/aws_lambda_powertools/utilities/batch/sqs_fifo_partial_processor.py
@@ -1,12 +1,16 @@
+from __future__ import annotations
+
 import logging
-from typing import Optional, Set
+from typing import TYPE_CHECKING
 
 from aws_lambda_powertools.utilities.batch import BatchProcessor, EventType, ExceptionInfo, FailureResponse
 from aws_lambda_powertools.utilities.batch.exceptions import (
     SQSFifoCircuitBreakerError,
     SQSFifoMessageGroupCircuitBreakerError,
 )
-from aws_lambda_powertools.utilities.batch.types import BatchSqsTypeModel
+
+if TYPE_CHECKING:
+    from aws_lambda_powertools.utilities.batch.types import BatchSqsTypeModel
 
 logger = logging.getLogger(__name__)
 
@@ -62,13 +66,13 @@ class SqsFifoPartialProcessor(BatchProcessor):
         None,
     )
 
-    def __init__(self, model: Optional["BatchSqsTypeModel"] = None, skip_group_on_error: bool = False):
+    def __init__(self, model: BatchSqsTypeModel | None = None, skip_group_on_error: bool = False):
         """
         Initialize the SqsFifoProcessor.
 
         Parameters
         ----------
-        model: Optional["BatchSqsTypeModel"]
+        model: BatchSqsTypeModel | None
             An optional model for batch processing.
         skip_group_on_error: bool
             Determines whether to exclusively skip messages from the MessageGroupID that encountered processing failures
@@ -77,7 +81,7 @@ class SqsFifoPartialProcessor(BatchProcessor):
         """
         self._skip_group_on_error: bool = skip_group_on_error
         self._current_group_id = None
-        self._failed_group_ids: Set[str] = set()
+        self._failed_group_ids: set[str] = set()
         super().__init__(EventType.SQS, model)
 
     def _process_record(self, record):

--- a/aws_lambda_powertools/utilities/batch/types.py
+++ b/aws_lambda_powertools/utilities/batch/types.py
@@ -1,5 +1,7 @@
+from __future__ import annotations
+
 import sys
-from typing import List, Optional, Type, TypedDict, Union
+from typing import Optional, TypedDict, Union
 
 has_pydantic = "pydantic" in sys.modules
 
@@ -12,9 +14,9 @@ if has_pydantic:  # pragma: no cover
     )
 
     BatchTypeModels = Optional[
-        Union[Type[SqsRecordModel], Type[DynamoDBStreamRecordModel], Type[KinesisDataStreamRecordModel]]
+        Union[type[SqsRecordModel], type[DynamoDBStreamRecordModel], type[KinesisDataStreamRecordModel]]
     ]
-    BatchSqsTypeModel = Optional[Type[SqsRecordModel]]
+    BatchSqsTypeModel = Optional[type[SqsRecordModel]]
 else:  # pragma: no cover
     BatchTypeModels = "BatchTypeModels"  # type: ignore
     BatchSqsTypeModel = "BatchSqsTypeModel"  # type: ignore
@@ -25,4 +27,4 @@ class PartialItemFailures(TypedDict):
 
 
 class PartialItemFailureResponse(TypedDict):
-    batchItemFailures: List[PartialItemFailures]
+    batchItemFailures: list[PartialItemFailures]

--- a/aws_lambda_powertools/utilities/batch/types.py
+++ b/aws_lambda_powertools/utilities/batch/types.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import sys
-from typing import Optional, TypedDict, Union
+from typing import Optional, Type, TypedDict, Union
 
 has_pydantic = "pydantic" in sys.modules
 
@@ -14,9 +14,9 @@ if has_pydantic:  # pragma: no cover
     )
 
     BatchTypeModels = Optional[
-        Union[type[SqsRecordModel], type[DynamoDBStreamRecordModel], type[KinesisDataStreamRecordModel]]
+        Union[Type[SqsRecordModel], Type[DynamoDBStreamRecordModel], Type[KinesisDataStreamRecordModel]]
     ]
-    BatchSqsTypeModel = Optional[type[SqsRecordModel]]
+    BatchSqsTypeModel = Optional[Type[SqsRecordModel]]
 else:  # pragma: no cover
     BatchTypeModels = "BatchTypeModels"  # type: ignore
     BatchSqsTypeModel = "BatchSqsTypeModel"  # type: ignore


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
**Issue number:** #4994 

## Summary

### Changes

Add `from __future__ import annotations` to batch package

### User experience

Discussed in #4607

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [X] [Meet tenets criteria](https://docs.powertools.aws.dev/lambda/python/#tenets)
* [X] I have performed a self-review of this change
* [X] Changes have been tested
* [ ] Changes are documented
* [X] PR title follows [conventional commit semantics](https://github.com/aws-powertools/powertools-lambda-python/blob/develop/.github/semantic.yml)

<details>
<summary>Is this a breaking change?</summary>

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
