### PR TITLE
refactor(typing): enable TCH, UP and FA100 ruff rules

### DIFF
--- a/aws_lambda_powertools/__init__.py
+++ b/aws_lambda_powertools/__init__.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 """Top-level package for Lambda Python Powertools."""
 
 from pathlib import Path

--- a/aws_lambda_powertools/event_handler/api_gateway.py
+++ b/aws_lambda_powertools/event_handler/api_gateway.py
@@ -1870,7 +1870,7 @@ class ApiGatewayResolver(BaseRouter):
 
         def register_resolver(func: Callable):
             methods = (method,) if isinstance(method, str) else method
-            logger.debug(f"Adding route using rule {rule} and methods: {','.join((m.upper() for m in methods))}")
+            logger.debug(f"Adding route using rule {rule} and methods: {','.join(m.upper() for m in methods)}")
 
             cors_enabled = self._cors_enabled if cors is None else cors
 

--- a/aws_lambda_powertools/event_handler/bedrock_agent.py
+++ b/aws_lambda_powertools/event_handler/bedrock_agent.py
@@ -109,7 +109,7 @@ class BedrockAgentResolver(ApiGatewayResolver):
     ) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
         security = None
 
-        return super(BedrockAgentResolver, self).get(
+        return super().get(
             rule,
             cors,
             compress,

--- a/aws_lambda_powertools/event_handler/openapi/params.py
+++ b/aws_lambda_powertools/event_handler/openapi/params.py
@@ -328,7 +328,7 @@ class Path(Param):
         if default is not ...:
             raise AssertionError("Path parameters cannot have a default value")
 
-        super(Path, self).__init__(
+        super().__init__(
             default=default,
             default_factory=default_factory,
             annotation=annotation,

--- a/aws_lambda_powertools/event_handler/openapi/types.py
+++ b/aws_lambda_powertools/event_handler/openapi/types.py
@@ -2,10 +2,12 @@ from __future__ import annotations
 
 import types
 from enum import Enum
-from typing import Any, Callable, Dict, Set, Type, TypedDict, Union
+from typing import TYPE_CHECKING, Any, Callable, Dict, Set, Type, TypedDict, Union
 
 from pydantic import BaseModel
-from typing_extensions import NotRequired
+
+if TYPE_CHECKING:
+    from typing_extensions import NotRequired
 
 CacheKey = Union[Callable[..., Any], None]
 IncEx = Union[Set[int], Set[str], Dict[int, Any], Dict[str, Any]]

--- a/aws_lambda_powertools/logging/types.py
+++ b/aws_lambda_powertools/logging/types.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
-from typing import Any, Dict, TypedDict, Union
+from typing import TYPE_CHECKING, Any, Dict, TypedDict, Union
 
-from typing_extensions import NotRequired, TypeAlias
+if TYPE_CHECKING:
+    from typing_extensions import NotRequired, TypeAlias
 
 
 class PowertoolsLogRecord(TypedDict):

--- a/aws_lambda_powertools/metrics/provider/cloudwatch_emf/types.py
+++ b/aws_lambda_powertools/metrics/provider/cloudwatch_emf/types.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
-from typing import TypedDict
+from typing import TYPE_CHECKING, TypedDict
 
-from typing_extensions import NotRequired
+if TYPE_CHECKING:
+    from typing_extensions import NotRequired
 
 
 class CloudWatchEMFMetric(TypedDict):

--- a/aws_lambda_powertools/shared/cache_dict.py
+++ b/aws_lambda_powertools/shared/cache_dict.py
@@ -25,7 +25,7 @@ class LRUDict(OrderedDict):
             del self[oldest]
 
     def get(self, key, *args, **kwargs):
-        item = super(LRUDict, self).get(key, *args, **kwargs)
+        item = super().get(key, *args, **kwargs)
         if item:
             self.move_to_end(key=key)
         return item

--- a/aws_lambda_powertools/shared/lazy_import.py
+++ b/aws_lambda_powertools/shared/lazy_import.py
@@ -32,7 +32,7 @@ class LazyLoader(types.ModuleType):
         self._local_name = local_name
         self._parent_module_globals = parent_module_globals
 
-        super(LazyLoader, self).__init__(name)
+        super().__init__(name)
 
     def _load(self):
         # Import the target module and insert it into the parent's namespace

--- a/aws_lambda_powertools/utilities/__init__.py
+++ b/aws_lambda_powertools/utilities/__init__.py
@@ -1,3 +1,1 @@
-# -*- coding: utf-8 -*-
-
 """General utilities for Powertools"""

--- a/aws_lambda_powertools/utilities/batch/__init__.py
+++ b/aws_lambda_powertools/utilities/batch/__init__.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 """
 Batch processing utility
 """

--- a/aws_lambda_powertools/utilities/batch/base.py
+++ b/aws_lambda_powertools/utilities/batch/base.py
@@ -1,7 +1,7 @@
-# -*- coding: utf-8 -*-
 """
 Batch processing utilities
 """
+
 from __future__ import annotations
 
 import asyncio

--- a/aws_lambda_powertools/utilities/batch/exceptions.py
+++ b/aws_lambda_powertools/utilities/batch/exceptions.py
@@ -34,7 +34,7 @@ class BatchProcessingError(BaseBatchProcessingError):
         super().__init__(msg, child_exceptions)
 
     def __str__(self):
-        parent_exception_str = super(BatchProcessingError, self).__str__()
+        parent_exception_str = super().__str__()
         return self.format_exceptions(parent_exception_str)
 
 

--- a/aws_lambda_powertools/utilities/data_classes/kinesis_firehose_event.py
+++ b/aws_lambda_powertools/utilities/data_classes/kinesis_firehose_event.py
@@ -5,11 +5,12 @@ import json
 import warnings
 from dataclasses import dataclass, field
 from functools import cached_property
-from typing import Any, Callable, ClassVar, Iterator
-
-from typing_extensions import Literal
+from typing import TYPE_CHECKING, Any, Callable, ClassVar, Iterator
 
 from aws_lambda_powertools.utilities.data_classes.common import DictWrapper
+
+if TYPE_CHECKING:
+    from typing_extensions import Literal
 
 
 @dataclass(repr=False, order=False, frozen=True)

--- a/aws_lambda_powertools/utilities/feature_flags/feature_flags.py
+++ b/aws_lambda_powertools/utilities/feature_flags/feature_flags.py
@@ -14,12 +14,11 @@ from aws_lambda_powertools.utilities.feature_flags.comparators import (
     compare_time_range,
 )
 from aws_lambda_powertools.utilities.feature_flags.exceptions import ConfigurationStoreError
-from aws_lambda_powertools.utilities.feature_flags.types import P, T
 
 if TYPE_CHECKING:
     from aws_lambda_powertools.logging import Logger
     from aws_lambda_powertools.utilities.feature_flags.base import StoreProvider
-    from aws_lambda_powertools.utilities.feature_flags.types import JSONType
+    from aws_lambda_powertools.utilities.feature_flags.types import JSONType, P, T
 
 
 RULE_ACTION_MAPPING = {

--- a/aws_lambda_powertools/utilities/idempotency/persistence/dynamodb.py
+++ b/aws_lambda_powertools/utilities/idempotency/persistence/dynamodb.py
@@ -123,7 +123,7 @@ class DynamoDBPersistenceLayer(BasePersistenceLayer):
 
         self._deserializer = TypeDeserializer()
 
-        super(DynamoDBPersistenceLayer, self).__init__()
+        super().__init__()
 
     def _get_key(self, idempotency_key: str) -> dict:
         """Build primary key attribute simple or composite based on params.

--- a/aws_lambda_powertools/utilities/idempotency/persistence/redis.py
+++ b/aws_lambda_powertools/utilities/idempotency/persistence/redis.py
@@ -310,7 +310,7 @@ class RedisCachePersistenceLayer(BasePersistenceLayer):
         self.validation_key_attr = validation_key_attr
         self._json_serializer = json.dumps
         self._json_deserializer = json.loads
-        super(RedisCachePersistenceLayer, self).__init__()
+        super().__init__()
         self._orphan_lock_timeout = min(10, self.expires_after_seconds)
 
     def _get_expiry_second(self, expiry_timestamp: int | None = None) -> int:

--- a/aws_lambda_powertools/utilities/parameters/__init__.py
+++ b/aws_lambda_powertools/utilities/parameters/__init__.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 """
 Parameter retrieval and caching utility
 """

--- a/aws_lambda_powertools/utilities/typing/__init__.py
+++ b/aws_lambda_powertools/utilities/typing/__init__.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 """
 Typing for developer ease in the IDE
 """

--- a/aws_lambda_powertools/utilities/typing/lambda_client_context.py
+++ b/aws_lambda_powertools/utilities/typing/lambda_client_context.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
@@ -9,7 +8,7 @@ if TYPE_CHECKING:
     )
 
 
-class LambdaClientContext(object):
+class LambdaClientContext:
     _client: LambdaClientContextMobileClient
     _custom: dict[str, Any]
     _env: dict[str, Any]

--- a/aws_lambda_powertools/utilities/typing/lambda_client_context_mobile_client.py
+++ b/aws_lambda_powertools/utilities/typing/lambda_client_context_mobile_client.py
@@ -1,7 +1,4 @@
-# -*- coding: utf-8 -*-
-
-
-class LambdaClientContextMobileClient(object):
+class LambdaClientContextMobileClient:
     """Mobile Client context that's provided to Lambda by the client application."""
 
     _installation_id: str

--- a/aws_lambda_powertools/utilities/typing/lambda_cognito_identity.py
+++ b/aws_lambda_powertools/utilities/typing/lambda_cognito_identity.py
@@ -1,7 +1,4 @@
-# -*- coding: utf-8 -*-
-
-
-class LambdaCognitoIdentity(object):
+class LambdaCognitoIdentity:
     """Information about the Amazon Cognito identity that authorized the request."""
 
     _cognito_identity_id: str

--- a/aws_lambda_powertools/utilities/typing/lambda_context.py
+++ b/aws_lambda_powertools/utilities/typing/lambda_context.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 from __future__ import annotations
 
 from typing import TYPE_CHECKING
@@ -12,7 +11,7 @@ if TYPE_CHECKING:
     )
 
 
-class LambdaContext(object):
+class LambdaContext:
     """The LambdaContext static object can be used to ease the development by providing the IDE type hints.
 
     Example

--- a/docs/utilities/batch.md
+++ b/docs/utilities/batch.md
@@ -502,7 +502,7 @@ Use the context manager to access a list of all returned values from your `recor
 
 === "Accessing raw processed messages"
 
-    ```python hl_lines="29-36"
+    ```python hl_lines="28-35"
     --8<-- "examples/batch_processing/src/context_manager_access.py"
     ```
 

--- a/examples/batch_processing/src/context_manager_access.py
+++ b/examples/batch_processing/src/context_manager_access.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import json
-from typing import List, Tuple
 
 from typing_extensions import Literal
 
@@ -28,7 +27,7 @@ def record_handler(record: SQSRecord):
 def lambda_handler(event, context: LambdaContext):
     batch = event["Records"]  # (1)!
     with processor(records=batch, handler=record_handler):
-        processed_messages: List[Tuple] = processor.process()
+        processed_messages: list[tuple] = processor.process()
 
     for message in processed_messages:
         status: Literal["success", "fail"] = message[0]

--- a/examples/idempotency/src/bring_your_own_persistent_store.py
+++ b/examples/idempotency/src/bring_your_own_persistent_store.py
@@ -36,7 +36,7 @@ class MyOwnPersistenceLayer(BasePersistenceLayer):
         self.status_attr = status_attr
         self.data_attr = data_attr
         self.validation_key_attr = validation_key_attr
-        super(MyOwnPersistenceLayer, self).__init__()
+        super().__init__()
 
     def _item_to_data_record(self, item: Dict[str, Any]) -> DataRecord:
         """

--- a/ruff.toml
+++ b/ruff.toml
@@ -23,7 +23,9 @@ lint.select = [
     "Q",   # flake8-quotes - https://beta.ruff.rs/docs/rules/#flake8-quotes-q
     "PTH", # flake8-use-pathlib - https://beta.ruff.rs/docs/rules/#flake8-use-pathlib-pth
     "T10", # flake8-debugger https://beta.ruff.rs/docs/rules/#flake8-debugger-t10
+    "TCH", # flake8-type-checking - https://docs.astral.sh/ruff/rules/#flake8-type-checking-tch
     "TD",  # flake8-todo - https://beta.ruff.rs/docs/rules/#flake8-todos-td
+    "UP",  # pyupgrade - https://docs.astral.sh/ruff/rules/#pyupgrade-up
     "W",   # pycodestyle warning - https://beta.ruff.rs/docs/rules/#warning-w
 ]
 
@@ -36,7 +38,6 @@ lint.ignore = [
     "B904",    # raise-without-from-inside-except - disabled temporarily
     "PLC1901", # Compare-to-empty-string - disabled temporarily
     "PYI024",
-    "FA100",   # Enable this rule when drop support to Python 3.7
 ]
 
 # Exclude files and directories
@@ -58,6 +59,7 @@ exclude = [
 # Maximum line length
 line-length = 120
 
+target-version = "py38"
 
 fix = true
 lint.fixable = ["I", "COM812", "W"]
@@ -81,6 +83,9 @@ max-statements = 70
 [lint.isort]
 split-on-trailing-comma = true
 
+[lint.flake8-type-checking]
+runtime-evaluated-base-classes = ["pydantic.BaseModel"]
+
 [lint.per-file-ignores]
 # Ignore specific rules for specific files
 "tests/e2e/utils/data_builder/__init__.py" = ["F401"]
@@ -90,6 +95,6 @@ split-on-trailing-comma = true
 "aws_lambda_powertools/event_handler/openapi/compat.py" = ["F401"]
 # Maintenance: we're keeping EphemeralMetrics code in case of Hyrum's law so we can quickly revert it
 "aws_lambda_powertools/metrics/metrics.py" = ["ERA001"]
-"examples/*" = ["FA100"]
-"tests/*" = ["FA100"]
+"examples/*" = ["FA100", "TCH"]
+"tests/*" = ["FA100", "TCH"]
 "aws_lambda_powertools/utilities/parser/models/*" = ["FA100"]

--- a/tests/e2e/parser/handlers/handler_with_union_tag.py
+++ b/tests/e2e/parser/handlers/handler_with_union_tag.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from typing import Literal, Union
 
 from pydantic import BaseModel, Field

--- a/tests/functional/data_masking/test_aws_encryption_sdk.py
+++ b/tests/functional/data_masking/test_aws_encryption_sdk.py
@@ -1,9 +1,7 @@
-from __future__ import annotations
-
 import base64
 import functools
 import json
-from typing import Any, Callable
+from typing import Any, Callable, Union
 
 import pytest
 from aws_encryption_sdk.identifiers import Algorithm
@@ -24,7 +22,7 @@ class FakeEncryptionKeyProvider(BaseProvider):
     ) -> None:
         super().__init__(json_serializer, json_deserializer)
 
-    def encrypt(self, data: bytes | str, **kwargs) -> str:
+    def encrypt(self, data: Union[bytes, str], **kwargs) -> str:
         encoded_data: str = self.json_serializer(data)
         ciphertext = base64.b64encode(encoded_data.encode("utf-8")).decode()
         return ciphertext

--- a/tests/functional/event_handler/test_openapi_serialization.py
+++ b/tests/functional/event_handler/test_openapi_serialization.py
@@ -48,7 +48,7 @@ def test_openapi_serialize_other(gw_event):
     app = APIGatewayRestResolver(enable_validation=True, serializer=serializer)
 
     # GIVEN a custom class
-    class CustomClass(object):
+    class CustomClass:
         __slots__ = []
 
     # GIVEN a handler that returns an instance of that class

--- a/tests/functional/idempotency/persistence/test_redis_layer.py
+++ b/tests/functional/idempotency/persistence/test_redis_layer.py
@@ -100,7 +100,7 @@ class MockRedis(MockRedisBase):
         self.closed = False
         self.mock_latency_ms = mock_latency_ms
         self.nx_lock = Lock()
-        super(MockRedis, self).__init__()
+        super().__init__()
 
     # check_closed is called before every mock redis operation
     def check_closed(self):

--- a/tests/functional/idempotency/test_idempotency.py
+++ b/tests/functional/idempotency/test_idempotency.py
@@ -1179,7 +1179,7 @@ def test_handler_raise_idempotency_key_error(persistence_store: DynamoDBPersiste
 class MockPersistenceLayer(BasePersistenceLayer):
     def __init__(self, expected_idempotency_key: str):
         self.expected_idempotency_key = expected_idempotency_key
-        super(MockPersistenceLayer, self).__init__()
+        super().__init__()
 
     def _put_record(self, data_record: DataRecord) -> None:
         assert data_record.idempotency_key == self.expected_idempotency_key

--- a/tests/functional/idempotency/utils.py
+++ b/tests/functional/idempotency/utils.py
@@ -1,8 +1,6 @@
-from __future__ import annotations
-
 import hashlib
 import json
-from typing import Any, Dict
+from typing import Any, Dict, Optional
 
 from botocore import stub
 from pytest import FixtureRequest
@@ -90,7 +88,7 @@ def build_idempotency_put_item_response_stub(
     expiration: int,
     status: str,
     request: FixtureRequest,
-    validation_data: Any | None,
+    validation_data: Optional[Any],
 ):
     response = {
         "Item": {

--- a/tests/functional/metrics/test_metrics_cloudwatch_emf.py
+++ b/tests/functional/metrics/test_metrics_cloudwatch_emf.py
@@ -1,10 +1,8 @@
-from __future__ import annotations
-
 import datetime
 import json
 import warnings
 from collections import namedtuple
-from typing import Dict, List
+from typing import Dict, List, Optional, Union
 
 import pytest
 
@@ -34,7 +32,7 @@ def serialize_metrics(
     metrics: List[Dict],
     dimensions: List[Dict],
     namespace: str,
-    metadatas: List[Dict] | None = None,
+    metadatas: Optional[List[Dict]] = None,
 ) -> CloudWatchEMFOutput:
     """Helper function to build EMF object from a list of metrics, dimensions"""
     my_metrics = AmazonCloudWatchEMFProvider(namespace=namespace)
@@ -56,8 +54,8 @@ def serialize_single_metric(
     metric: Dict,
     dimension: Dict,
     namespace: str,
-    metadata: Dict | None = None,
-    timestamp: int | datetime.datetime | None = None,
+    metadata: Optional[Dict] = None,
+    timestamp: Union[int, datetime.datetime, None] = None,
 ) -> CloudWatchEMFOutput:
     """Helper function to build EMF object from a given metric, dimension and namespace"""
     my_metrics = AmazonCloudWatchEMFProvider(namespace=namespace)

--- a/tests/functional/metrics/test_metrics_provider.py
+++ b/tests/functional/metrics/test_metrics_provider.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import json
 from typing import Any, List
 

--- a/tests/functional/parser/test_parser.py
+++ b/tests/functional/parser/test_parser.py
@@ -12,7 +12,7 @@ from aws_lambda_powertools.utilities.parser import (
 from aws_lambda_powertools.utilities.typing import LambdaContext
 
 
-@pytest.mark.parametrize("invalid_value", [None, bool(), [], (), object])
+@pytest.mark.parametrize("invalid_value", [None, False, [], (), object])
 def test_parser_unsupported_event(dummy_schema, invalid_value):
     @event_parser(model=dummy_schema)
     def handle_no_envelope(event: Dict, _: LambdaContext):
@@ -75,7 +75,7 @@ def test_pydanticv2_validation():
     assert event_parsed.version == int(event_raw["version"])
 
 
-@pytest.mark.parametrize("invalid_schema", [str, bool(), [], ()])
+@pytest.mark.parametrize("invalid_schema", [str, False, [], ()])
 def test_parser_with_invalid_schema_type(dummy_event, invalid_schema):
     @event_parser(model=invalid_schema)
     def handle_no_envelope(event: Dict, _: LambdaContext):

--- a/tests/functional/test_logger_powertools_formatter.py
+++ b/tests/functional/test_logger_powertools_formatter.py
@@ -257,7 +257,7 @@ def test_log_dict_xray_is_updated_when_tracing_id_changes(stdout, monkeypatch, s
 
     logger.info("foo bar")
 
-    log_dict, log_dict_2 = [json.loads(line.strip()) for line in stdout.getvalue().split("\n") if line]
+    log_dict, log_dict_2 = (json.loads(line.strip()) for line in stdout.getvalue().split("\n") if line)
 
     # THEN `xray_trace_id`` key should be different in both invocations
     assert log_dict["xray_trace_id"] == trace_id

--- a/tests/functional/test_utilities_parameters.py
+++ b/tests/functional/test_utilities_parameters.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import base64
 import json
 import random
@@ -7,7 +5,7 @@ import string
 import uuid
 from datetime import datetime, timedelta
 from io import BytesIO
-from typing import Any, Dict, List, Tuple
+from typing import Any, Dict, List, Optional, Tuple, Union
 
 import boto3
 import pytest
@@ -53,7 +51,10 @@ def mock_binary_value() -> str:
     return "ZXlKaGJHY2lPaUpJVXpJMU5pSXNJblI1Y0NJNklrcFhWQ0o5LmV5SnpkV0lpT2lJeE1qTTBOVFkzT0Rrd0lpd2libUZ0WlNJNklrcHZhRzRnUkc5bElpd2lhV0YwSWpveE5URTJNak01TURJeWZRLlNmbEt4d1JKU01lS0tGMlFUNGZ3cE1lSmYzNlBPazZ5SlZfYWRRc3N3NWMK"  # noqa: E501
 
 
-def build_get_parameters_stub(params: Dict[str, Any], invalid_parameters: List[str] | None = None) -> Dict[str, List]:
+def build_get_parameters_stub(
+    params: Dict[str, Any],
+    invalid_parameters: Optional[List[str]] = None,
+) -> Dict[str, List]:
     invalid_parameters = invalid_parameters or []
     version = random.randrange(1, 1000)
     return {
@@ -2217,7 +2218,7 @@ def test_get_parameters_by_name(monkeypatch, mock_name, mock_value, config):
         def __init__(self, boto_config: Config = config, **kwargs):
             super().__init__(boto_config=boto_config, **kwargs)
 
-        def get_parameters_by_name(self, *args, **kwargs) -> Dict[str, str] | Dict[str, bytes] | Dict[str, dict]:
+        def get_parameters_by_name(self, *args, **kwargs) -> Union[Dict[str, str], Dict[str, bytes], Dict[str, dict]]:
             return {mock_name: mock_value}
 
     monkeypatch.setitem(parameters.base.DEFAULT_PROVIDERS, "ssm", TestProvider())
@@ -2453,7 +2454,7 @@ def test_get_parameters_by_name_new(monkeypatch, mock_name, mock_value, config):
         def __init__(self, boto_config: Config = config, **kwargs):
             super().__init__(boto_config=boto_config, **kwargs)
 
-        def get_parameters_by_name(self, *args, **kwargs) -> Dict[str, str] | Dict[str, bytes] | Dict[str, dict]:
+        def get_parameters_by_name(self, *args, **kwargs) -> Union[Dict[str, str], Dict[str, bytes], Dict[str, dict]]:
             return {mock_name: mock_value}
 
     monkeypatch.setattr(parameters.ssm, "DEFAULT_PROVIDERS", {})

--- a/tests/functional/validator/test_validator.py
+++ b/tests/functional/validator/test_validator.py
@@ -69,7 +69,7 @@ def test_validate_accept_schema_custom_format(
     )
 
 
-@pytest.mark.parametrize("invalid_format", [None, bool(), {}, [], object])
+@pytest.mark.parametrize("invalid_format", [None, False, {}, [], object])
 def test_validate_invalid_custom_format(
     eventbridge_schema_registry_cloudtrail_v2_s3,
     eventbridge_cloudtrail_s3_head_object_event,

--- a/tests/unit/parser/test_vpc_latticev2.py
+++ b/tests/unit/parser/test_vpc_latticev2.py
@@ -34,7 +34,7 @@ def test_vpc_lattice_v2_event():
     assert model.request_context.service_arn == raw_event["requestContext"]["serviceArn"]
     assert model.request_context.target_group_arn == raw_event["requestContext"]["targetGroupArn"]
     assert model.request_context.time_epoch == float(raw_event["requestContext"]["timeEpoch"])
-    convert_time = int((model.request_context.time_epoch_as_datetime.timestamp() * 1000))
+    convert_time = int(model.request_context.time_epoch_as_datetime.timestamp() * 1000)
     event_converted_time = round(int(raw_event["requestContext"]["timeEpoch"]) / 1000)
     assert convert_time == event_converted_time
     assert model.request_context.identity.source_vpc_arn == raw_event["requestContext"]["identity"]["sourceVpcArn"]

--- a/tests/unit/test_tracing.py
+++ b/tests/unit/test_tracing.py
@@ -447,7 +447,7 @@ def test_tracer_yield_from_nested_context_manager(mocker, provider_stub, in_subs
     tracer = Tracer(provider=provider, service="booking")
 
     # WHEN capture_method decorator is used on a context manager nesting another context manager
-    class NestedContextManager(object):
+    class NestedContextManager:
         def __enter__(self):
             self._value = {"result": "test result"}
             return self._value


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
**Issue number:** #5016

## Summary

### Changes

Enable TCH, UP and FA100 rules in the Ruff linter.

### User experience

Discussed in #4607

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [X] [Meet tenets criteria](https://docs.powertools.aws.dev/lambda/python/#tenets)
* [X] I have performed a self-review of this change
* [X] Changes have been tested
* [ ] Changes are documented
* [X] PR title follows [conventional commit semantics](https://github.com/aws-powertools/powertools-lambda-python/blob/develop/.github/semantic.yml)

<details>
<summary>Is this a breaking change?</summary>

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
