### PR TITLE
docs(logger): fix typo for the INFO log_level example

### DIFF
--- a/docs/core/logger.md
+++ b/docs/core/logger.md
@@ -298,7 +298,7 @@ We support the following log levels:
 | `ERROR`    | 40            | `logging.ERROR`    |
 | `CRITICAL` | 50            | `logging.CRITICAL` |
 
-If you want to access the numeric value of the current log level, you can use the `log_level` property. For example, if the current log level is `INFO`, `logger.log_level` property will return `10`.
+If you want to access the numeric value of the current log level, you can use the `log_level` property. For example, if the current log level is `INFO`, `logger.log_level` property will return `20`.
 
 === "setting_log_level_constructor.py"
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
**Issue number:** #5037

## Summary

Fix typo for the INFO log_level example

### Changes

This fixes a typo in the log_level example that could mislead people in using this property in their code.

### User experience

Before: wrong information in example
After: correct information in example

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] [Meet tenets criteria](https://docs.powertools.aws.dev/lambda/python/#tenets)
* [X] I have performed a self-review of this change
* [ ] Changes have been tested
* [x] Changes are documented
* [X] PR title follows [conventional commit semantics](https://github.com/aws-powertools/powertools-lambda-python/blob/develop/.github/semantic.yml)

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
