### PR TITLE
feat(idempotency): simplify access to expiration time in `DataRecord` class

### DIFF
--- a/aws_lambda_powertools/utilities/idempotency/persistence/datarecord.py
+++ b/aws_lambda_powertools/utilities/idempotency/persistence/datarecord.py
@@ -92,3 +92,24 @@ class DataRecord:
             previous response data deserialized
         """
         return json.loads(self.response_data) if self.response_data else None
+
+    def get_expiration_datetime(self) -> datetime.datetime | None:
+        """
+        Converts the expiry timestamp to a datetime object.
+
+        This method checks if an expiry timestamp exists and converts it to a
+        datetime object. If no timestamp is present, it returns None.
+
+        Returns:
+        -------
+        datetime.datetime | None
+            A datetime object representing the expiration time, or None if no expiry timestamp is set.
+
+        Note:
+        ----
+        The returned datetime object is timezone-naive and assumes the timestamp
+        is in the system's local timezone. Lambda default timezone is UTC.
+        """
+        if self.expiry_timestamp:
+            return datetime.datetime.fromtimestamp(int(self.expiry_timestamp))
+        return None

--- a/examples/idempotency/src/working_with_response_hook.py
+++ b/examples/idempotency/src/working_with_response_hook.py
@@ -1,4 +1,3 @@
-import datetime
 import uuid
 from typing import Dict
 
@@ -20,11 +19,10 @@ def my_response_hook(response: Dict, idempotent_data: DataRecord) -> Dict:
     # Return inserted Header data into the Idempotent Response
     response["x-idempotent-key"] = idempotent_data.idempotency_key
 
-    # expiry_timestamp could be None so include if set
-    expiry_timestamp = idempotent_data.expiry_timestamp
+    # expiry_timestamp can be None so include if set
+    expiry_timestamp = idempotent_data.get_expiration_datetime()
     if expiry_timestamp:
-        expiry_time = datetime.datetime.fromtimestamp(int(expiry_timestamp))
-        response["x-idempotent-expiration"] = expiry_time.isoformat()
+        response["x-idempotent-expiration"] = expiry_timestamp.isoformat()
 
     # Must return the response here
     return response

--- a/tests/functional/idempotency/test_idempotency.py
+++ b/tests/functional/idempotency/test_idempotency.py
@@ -2045,6 +2045,7 @@ def test_idempotent_lambda_already_completed_response_hook_is_called(
     def idempotent_response_hook(response: Any, idempotent_data: DataRecord) -> Any:
         """Modify the response provided by adding a new key"""
         response["idempotent_response"] = True
+        response["idempotent_expiration"] = idempotent_data.get_expiration_datetime()
 
         return response
 
@@ -2070,6 +2071,7 @@ def test_idempotent_lambda_already_completed_response_hook_is_called(
 
     # Then idempotent_response value will be added to the response
     assert lambda_resp["idempotent_response"]
+    assert lambda_resp["idempotent_expiration"] == datetime.datetime.fromtimestamp(int(timestamp_future))
 
     stubber.assert_no_pending_responses()
     stubber.deactivate()


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
**Issue number:** #4818 

## Summary

### Changes

This PR introduces a new method to simplify access to expiration times for idempotent operations. It streamlines the process of retrieving and working with expiration timestamps in the Idempotency record.

### User experience

**BEFORE**
```python
def my_response_hook(response: Dict, idempotent_data: DataRecord) -> Dict:
    # Return inserted Header data into the Idempotent Response
    response["x-idempotent-key"] = idempotent_data.idempotency_key

    # expiry_timestamp could be None so include if set
    expiry_timestamp = idempotent_data.expiry_timestamp
    if expiry_timestamp:
        expiry_time = datetime.datetime.fromtimestamp(int(expiry_timestamp))
        response["x-idempotent-expiration"] = expiry_time.isoformat()

    # Must return the response here
    return response
```

**AFTER**
```python
def my_response_hook(response: Dict, idempotent_data: DataRecord) -> Dict:
    # Return inserted Header data into the Idempotent Response
    response["x-idempotent-key"] = idempotent_data.idempotency_key

    # expiry_timestamp can be None so include if set
    expiry_timestamp = idempotent_data.get_expiration_datetime()
    if expiry_timestamp:
        response["x-idempotent-expiration"] = expiry_timestamp.isoformat()

    # Must return the response here
    return response
```

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] [Meet tenets criteria](https://docs.powertools.aws.dev/lambda/python/#tenets)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented
* [x] PR title follows [conventional commit semantics](https://github.com/aws-powertools/powertools-lambda-python/blob/develop/.github/semantic.yml)

<details>
<summary>Is this a breaking change?</summary>

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
