### PR TITLE
refactor(typing): move more types into TYPE_CHECKING

### DIFF
--- a/aws_lambda_powertools/event_handler/openapi/compat.py
+++ b/aws_lambda_powertools/event_handler/openapi/compat.py
@@ -10,18 +10,14 @@ from copy import copy
 
 from dataclasses import dataclass, is_dataclass
 from enum import Enum
-from typing import Any, Deque, FrozenSet, List, Mapping, Sequence, Set, Tuple, Union
+from typing import TYPE_CHECKING, Any, Deque, FrozenSet, List, Mapping, Sequence, Set, Tuple, Union
 
 from typing_extensions import Annotated, Literal, get_origin, get_args
 
 from pydantic import BaseModel, create_model
 from pydantic.fields import FieldInfo
 
-from aws_lambda_powertools.event_handler.openapi.types import (
-    COMPONENT_REF_PREFIX,
-    ModelNameMap,
-    UnionType,
-)
+from aws_lambda_powertools.event_handler.openapi.types import COMPONENT_REF_PREFIX, UnionType
 
 from pydantic import TypeAdapter, ValidationError
 
@@ -34,7 +30,8 @@ from pydantic._internal._utils import lenient_issubclass
 from pydantic.json_schema import GenerateJsonSchema, JsonSchemaValue
 from pydantic_core import PydanticUndefined, PydanticUndefinedType
 
-from aws_lambda_powertools.event_handler.openapi.types import IncEx
+if TYPE_CHECKING:
+    from aws_lambda_powertools.event_handler.openapi.types import IncEx, ModelNameMap
 
 Undefined = PydanticUndefined
 Required = PydanticUndefined

--- a/aws_lambda_powertools/event_handler/openapi/types.py
+++ b/aws_lambda_powertools/event_handler/openapi/types.py
@@ -1,17 +1,19 @@
 from __future__ import annotations
 
 import types
-from enum import Enum
 from typing import TYPE_CHECKING, Any, Callable, Dict, Set, Type, TypedDict, Union
 
 if TYPE_CHECKING:
-    from pydantic import BaseModel  # noqa: F401
+    from enum import Enum
+
+    from pydantic import BaseModel
     from typing_extensions import NotRequired
 
-CacheKey = Union[Callable[..., Any], None]
-IncEx = Union[Set[int], Set[str], Dict[int, Any], Dict[str, Any]]
-TypeModelOrEnum = Union[Type["BaseModel"], Type[Enum]]
-ModelNameMap = Dict[TypeModelOrEnum, str]
+    CacheKey = Union[Callable[..., Any], None]
+    IncEx = Union[Set[int], Set[str], Dict[int, Any], Dict[str, Any]]
+    TypeModelOrEnum = Union[Type[BaseModel], Type[Enum]]
+    ModelNameMap = Dict[TypeModelOrEnum, str]
+
 UnionType = getattr(types, "UnionType", Union)
 
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
**Issue number:** #5029

## Summary

### Changes

Move more types into TYPE_CHECKING.

### User experience

Following up issues reported in #5029.

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [X] [Meet tenets criteria](https://docs.powertools.aws.dev/lambda/python/#tenets)
* [X] I have performed a self-review of this change
* [X] Changes have been tested
* [ ] Changes are documented
* [X] PR title follows [conventional commit semantics](https://github.com/aws-powertools/powertools-lambda-python/blob/develop/.github/semantic.yml)

<details>
<summary>Is this a breaking change?</summary>

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
