### PR TITLE
feat(event_handler): Ensure Bedrock Agents resolver works with Pydantic v2

### DIFF
--- a/aws_lambda_powertools/event_handler/bedrock_agent.py
+++ b/aws_lambda_powertools/event_handler/bedrock_agent.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 from typing import TYPE_CHECKING, Any, Callable
 
 from typing_extensions import override
@@ -10,10 +11,12 @@ from aws_lambda_powertools.event_handler.api_gateway import (
     ProxyEventType,
     ResponseBuilder,
 )
+from aws_lambda_powertools.event_handler.openapi.constants import DEFAULT_API_VERSION, DEFAULT_OPENAPI_VERSION
 
 if TYPE_CHECKING:
     from re import Match
 
+    from aws_lambda_powertools.event_handler.openapi.models import Contact, License, SecurityScheme, Server, Tag
     from aws_lambda_powertools.event_handler.openapi.types import OpenAPIResponse
     from aws_lambda_powertools.utilities.data_classes import BedrockAgentEvent
 
@@ -273,3 +276,107 @@ class BedrockAgentResolver(ApiGatewayResolver):
         if match.groupdict() and self.current_event.parameters:
             parameters = {parameter["name"]: parameter["value"] for parameter in self.current_event.parameters}
         return parameters
+
+    @override
+    def get_openapi_json_schema(
+        self,
+        *,
+        title: str = "Powertools API",
+        version: str = DEFAULT_API_VERSION,
+        openapi_version: str = DEFAULT_OPENAPI_VERSION,
+        summary: str | None = None,
+        description: str | None = None,
+        tags: list[Tag | str] | None = None,
+        servers: list[Server] | None = None,
+        terms_of_service: str | None = None,
+        contact: Contact | None = None,
+        license_info: License | None = None,
+        security_schemes: dict[str, SecurityScheme] | None = None,
+        security: list[dict[str, list[str]]] | None = None,
+    ) -> str:
+        """
+        Returns the OpenAPI schema as a JSON serializable dict.
+        Since Bedrock Agents only support OpenAPI 3.0.0, we convert OpenAPI 3.1.0 schemas
+        and enforce 3.0.0 compatibility for seamless integration.
+
+        Parameters
+        ----------
+        title: str
+            The title of the application.
+        version: str
+            The version of the OpenAPI document (which is distinct from the OpenAPI Specification version or the API
+        openapi_version: str, default = "3.0.0"
+            The version of the OpenAPI Specification (which the document uses).
+        summary: str, optional
+            A short summary of what the application does.
+        description: str, optional
+            A verbose explanation of the application behavior.
+        tags: list[Tag, str], optional
+            A list of tags used by the specification with additional metadata.
+        servers: list[Server], optional
+            An array of Server Objects, which provide connectivity information to a target server.
+        terms_of_service: str, optional
+            A URL to the Terms of Service for the API. MUST be in the format of a URL.
+        contact: Contact, optional
+            The contact information for the exposed API.
+        license_info: License, optional
+            The license information for the exposed API.
+        security_schemes: dict[str, SecurityScheme]], optional
+            A declaration of the security schemes available to be used in the specification.
+        security: list[dict[str, list[str]]], optional
+            A declaration of which security mechanisms are applied globally across the API.
+
+        Returns
+        -------
+        str
+            The OpenAPI schema as a JSON serializable dict.
+        """
+        from aws_lambda_powertools.event_handler.openapi.compat import model_json
+
+        schema = super().get_openapi_schema(
+            title=title,
+            version=version,
+            openapi_version=openapi_version,
+            summary=summary,
+            description=description,
+            tags=tags,
+            servers=servers,
+            terms_of_service=terms_of_service,
+            contact=contact,
+            license_info=license_info,
+            security_schemes=security_schemes,
+            security=security,
+        )
+        schema.openapi = "3.0.3"
+
+        # Transform OpenAPI 3.1 into 3.0
+        def inner(yaml_dict):
+            if isinstance(yaml_dict, dict):
+                if "anyOf" in yaml_dict and isinstance((anyOf := yaml_dict["anyOf"]), list):
+                    for i, item in enumerate(anyOf):
+                        if isinstance(item, dict) and item.get("type") == "null":
+                            anyOf.pop(i)
+                            yaml_dict["nullable"] = True
+                if "examples" in yaml_dict:
+                    examples = yaml_dict["examples"]
+                    del yaml_dict["examples"]
+                    if isinstance(examples, list) and len(examples):
+                        yaml_dict["example"] = examples[0]
+                for value in yaml_dict.values():
+                    inner(value)
+            elif isinstance(yaml_dict, list):
+                for item in yaml_dict:
+                    inner(item)
+
+        model = json.loads(
+            model_json(
+                schema,
+                by_alias=True,
+                exclude_none=True,
+                indent=2,
+            ),
+        )
+
+        inner(model)
+
+        return json.dumps(model)


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
**Issue number:** #4196 

## Summary

### Changes

This PR addresses the compatibility issue between Bedrock Agents and the OpenAPI schemas generated by Pydantic v2. Bedrock Agents only accepts OpenAPI version 3.0, whereas Pydantic v2 generates schemas that are valid for OpenAPI 3.1.

## Changes

- Added functionality to convert OpenAPI 3.1 schemas to 3.0 compatible versions
- Enforced OpenAPI 3.0.3 schema output for Bedrock Agent compatibility
- Override `get_openapi_json_schema` method in the `BedrockAgentResolver` class to handle the conversion process and make it strict to BedrockAgent resolver.

### User experience

```python
from time import time
from typing import Optional

from aws_lambda_powertools import Logger
from aws_lambda_powertools.event_handler import BedrockAgentResolver
from aws_lambda_powertools.utilities.typing import LambdaContext

logger = Logger()
app = BedrockAgentResolver()


@app.get("/current_time", description="Gets the current time in seconds")
def current_time() -> Optional[int]:
    return int(time())


@logger.inject_lambda_context
def lambda_handler(event: dict, context: LambdaContext):
    return app.resolve(event, context)


if __name__ == "__main__": 
    print(app.get_openapi_json_schema())
```

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] [Meet tenets criteria](https://docs.powertools.aws.dev/lambda/python/#tenets)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented
* [x] PR title follows [conventional commit semantics](https://github.com/aws-powertools/powertools-lambda-python/blob/develop/.github/semantic.yml)

<details>
<summary>Is this a breaking change?</summary>

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
