### PR TITLE
feat(event_source): add CodeDeploy Lifecycle Hook event

### DIFF
--- a/aws_lambda_powertools/utilities/data_classes/__init__.py
+++ b/aws_lambda_powertools/utilities/data_classes/__init__.py
@@ -19,7 +19,7 @@ from .cloud_watch_custom_widget_event import CloudWatchDashboardCustomWidgetEven
 from .cloud_watch_logs_event import CloudWatchLogsEvent
 from .cloudformation_custom_resource_event import CloudFormationCustomResourceEvent
 from .code_deploy_lifecycle_hook_event import (
-    CodeDeployLifeCycleHookLambdaEvent,
+    CodeDeployLifecycleHookEvent,
 )
 from .code_pipeline_job_event import CodePipelineJobEvent
 from .connect_contact_flow_event import ConnectContactFlowEvent

--- a/aws_lambda_powertools/utilities/data_classes/__init__.py
+++ b/aws_lambda_powertools/utilities/data_classes/__init__.py
@@ -62,7 +62,7 @@ __all__ = [
     "CloudWatchAlarmMetricStat",
     "CloudWatchDashboardCustomWidgetEvent",
     "CloudWatchLogsEvent",
-    "CodeDeployLifeCycleHookLambdaEvent",
+    "CodeDeployLifecycleHookEvent",
     "CodePipelineJobEvent",
     "ConnectContactFlowEvent",
     "DynamoDBStreamEvent",

--- a/aws_lambda_powertools/utilities/data_classes/__init__.py
+++ b/aws_lambda_powertools/utilities/data_classes/__init__.py
@@ -18,6 +18,9 @@ from .cloud_watch_alarm_event import (
 from .cloud_watch_custom_widget_event import CloudWatchDashboardCustomWidgetEvent
 from .cloud_watch_logs_event import CloudWatchLogsEvent
 from .cloudformation_custom_resource_event import CloudFormationCustomResourceEvent
+from .code_deploy_lifecycle_hook_event import (
+    CodeDeployLifeCycleHookLambdaEvent,
+)
 from .code_pipeline_job_event import CodePipelineJobEvent
 from .connect_contact_flow_event import ConnectContactFlowEvent
 from .dynamo_db_stream_event import DynamoDBStreamEvent
@@ -59,6 +62,7 @@ __all__ = [
     "CloudWatchAlarmMetricStat",
     "CloudWatchDashboardCustomWidgetEvent",
     "CloudWatchLogsEvent",
+    "CodeDeployLifeCycleHookLambdaEvent",
     "CodePipelineJobEvent",
     "ConnectContactFlowEvent",
     "DynamoDBStreamEvent",

--- a/aws_lambda_powertools/utilities/data_classes/code_deploy_lifecycle_hook_event.py
+++ b/aws_lambda_powertools/utilities/data_classes/code_deploy_lifecycle_hook_event.py
@@ -1,0 +1,13 @@
+from aws_lambda_powertools.utilities.data_classes.common import DictWrapper
+
+
+class CodeDeployLifeCycleHookLambdaEvent(DictWrapper):
+    @property
+    def deployment_id(self) -> str:
+        """The unique ID of the calling CodeDeploy Deployment."""
+        return self["DeploymentId"]
+
+    @property
+    def lifecycle_event_hook_execution_id(self) -> str:
+        """The unique ID of a deployments lifecycle hook."""
+        return self["LifecycleEventHookExecutionId"]

--- a/aws_lambda_powertools/utilities/data_classes/code_deploy_lifecycle_hook_event.py
+++ b/aws_lambda_powertools/utilities/data_classes/code_deploy_lifecycle_hook_event.py
@@ -1,7 +1,7 @@
 from aws_lambda_powertools.utilities.data_classes.common import DictWrapper
 
 
-class CodeDeployLifeCycleHookLambdaEvent(DictWrapper):
+class CodeDeployLifecycleHookEvent(DictWrapper):
     @property
     def deployment_id(self) -> str:
         """The unique ID of the calling CodeDeploy Deployment."""

--- a/docs/utilities/data_classes.md
+++ b/docs/utilities/data_classes.md
@@ -90,6 +90,7 @@ Log Data Event for Troubleshooting
 | [CloudWatch Alarm State Change Action](#cloudwatch-alarm-state-change-action) | `CloudWatchAlarmEvent`                             |
 | [CloudWatch Dashboard Custom Widget](#cloudwatch-dashboard-custom-widget)     | `CloudWatchDashboardCustomWidgetEvent`             |
 | [CloudWatch Logs](#cloudwatch-logs)                                           | `CloudWatchLogsEvent`                              |
+| [CodeDeploy Lifecycle Hook](#codedeploy-lifecycle-hook)                       | `CodeDeployLifecycleHookEvent`                     |
 | [CodePipeline Job Event](#codepipeline-job)                                   | `CodePipelineJobEvent`                             |
 | [Cognito User Pool](#cognito-user-pool)                                       | Multiple available under `cognito_user_pool_event` |
 | [Connect Contact Flow](#connect-contact-flow)                                 | `ConnectContactFlowEvent`                          |
@@ -613,6 +614,30 @@ Alternatively, you can use `extract_cloudwatch_logs_from_record` to seamless int
     @batch_processor(record_handler=record_handler, processor=processor)
     def lambda_handler(event, context):
         return processor.response()
+    ```
+
+### CodeDeploy LifeCycle Hook
+
+CodeDeploy triggers Lambdas with this event when defined in
+[AppSpec definitions](https://docs.aws.amazon.com/codedeploy/latest/userguide/reference-appspec-file-structure-hooks.html)
+to test applications at different stages of deployment.
+
+
+=== "app.py"
+    ```python
+    from aws_lambda_powertools import Logger
+    from aws_lambda_powertools.utilities.data_classes import (
+        event_source,
+        CodeDeployLifeCycleHookEvent,
+    )
+
+    logger = Logger()
+
+    def lambda_handler(
+        event: CodeDeployLifeCycleHookEvent, context: LambdaContext
+    ) -> None:
+        deployment_id = event.deployment_id
+        lifecycle_event_hook_execution_id = event.lifecycle_event_hook_execution_id
     ```
 
 ### CodePipeline Job

--- a/docs/utilities/data_classes.md
+++ b/docs/utilities/data_classes.md
@@ -634,7 +634,7 @@ to test applications at different stages of deployment.
     logger = Logger()
 
     def lambda_handler(
-        event: CodeDeployLifeCycleHookEvent, context: LambdaContext
+        event: CodeDeployLifecycleHookEvent, context: LambdaContext
     ) -> None:
         deployment_id = event.deployment_id
         lifecycle_event_hook_execution_id = event.lifecycle_event_hook_execution_id

--- a/docs/utilities/data_classes.md
+++ b/docs/utilities/data_classes.md
@@ -628,7 +628,7 @@ to test applications at different stages of deployment.
     from aws_lambda_powertools import Logger
     from aws_lambda_powertools.utilities.data_classes import (
         event_source,
-        CodeDeployLifeCycleHookEvent,
+        CodeDeployLifecycleHookEvent,
     )
 
     logger = Logger()

--- a/tests/events/codeDeployLifecycleHookEvent.json
+++ b/tests/events/codeDeployLifecycleHookEvent.json
@@ -1,0 +1,4 @@
+{
+    "DeploymentId": "d-ABCDEF",
+    "LifecycleEventHookExecutionId": "xxxxxxxxxxxxxxxxxxxxxxxx"
+}

--- a/tests/unit/data_classes/required_dependencies/test_code_deploy_lifecycle_hook_event.py
+++ b/tests/unit/data_classes/required_dependencies/test_code_deploy_lifecycle_hook_event.py
@@ -14,7 +14,7 @@ from tests.functional.utils import load_event
 )
 def test_code_deploy_lifecycle_hook_event(event_file):
     raw_event = load_event(event_file)
-    parsed_event = CodeDeployLifeCycleHookLambdaEvent(raw_event)
+    parsed_event = CodeDeployLifecycleHookEvent(raw_event)
 
     assert parsed_event.deployment_id == raw_event["DeploymentId"]
     assert parsed_event.lifecycle_event_hook_execution_id == raw_event["LifecycleEventHookExecutionId"]

--- a/tests/unit/data_classes/required_dependencies/test_code_deploy_lifecycle_hook_event.py
+++ b/tests/unit/data_classes/required_dependencies/test_code_deploy_lifecycle_hook_event.py
@@ -1,7 +1,7 @@
 import pytest
 
 from aws_lambda_powertools.utilities.data_classes import (
-    CodeDeployLifeCycleHookLambdaEvent,
+    CodeDeployLifecycleHookEvent,
 )
 from tests.functional.utils import load_event
 

--- a/tests/unit/data_classes/required_dependencies/test_code_deploy_lifecycle_hook_event.py
+++ b/tests/unit/data_classes/required_dependencies/test_code_deploy_lifecycle_hook_event.py
@@ -1,0 +1,20 @@
+import pytest
+
+from aws_lambda_powertools.utilities.data_classes import (
+    CodeDeployLifeCycleHookLambdaEvent,
+)
+from tests.functional.utils import load_event
+
+
+@pytest.mark.parametrize(
+    "event_file",
+    [
+        "codeDeployLifecycleHookEvent.json",
+    ],
+)
+def test_code_deploy_lifecycle_hook_event(event_file):
+    raw_event = load_event(event_file)
+    parsed_event = CodeDeployLifeCycleHookLambdaEvent(raw_event)
+
+    assert parsed_event.deployment_id == raw_event["DeploymentId"]
+    assert parsed_event.lifecycle_event_hook_execution_id == raw_event["LifecycleEventHookExecutionId"]


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
**Issue number:** #5171 

## Summary

This is a simple change to implement the lambda event type `CodeDeployLifeCycleHookLambdaEvent`. 

This event only provides `DeploymentId` and `LifecycleEventHookExecutionId` (at least in my experience)

### Changes

This adds a new DictWrapper inherited class to define the properties passed by CodeDeployment.


### User experience

This allows users to use the new class as an event type in their lambda handler
```python
from aws_lambda_powertools.utilities.data_classes import (
  event_source,
  CodeDeployLifeCycleHookEvent,
)

def lambda_handler(
    event: CodeDeployLifeCycleHookEvent, context: LambdaContext
) -> None:
  ...
```

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] [Meet tenets criteria](https://docs.powertools.aws.dev/lambda/python/#tenets)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented
* [x] PR title follows [conventional commit semantics](https://github.com/aws-powertools/powertools-lambda-python/blob/develop/.github/semantic.yml)

<details>
<summary>Is this a breaking change?</summary>
This is new functionality and is not a breaking change.
</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
