### PR TITLE
fix(parser): make size and etag optional for LifecycleExpiration events in S3

### DIFF
--- a/aws_lambda_powertools/utilities/parser/models/s3.py
+++ b/aws_lambda_powertools/utilities/parser/models/s3.py
@@ -103,8 +103,10 @@ class S3RecordModel(BaseModel):
     def validate_s3_object(cls, values):
         event_name = values.get("eventName")
         s3_object = values.get("s3").get("object")
-        if "ObjectRemoved" not in event_name and (s3_object.get("size") is None or s3_object.get("eTag") is None):
-            raise ValueError("S3Object.size and S3Object.eTag are required for non-ObjectRemoved events")
+        if ":Delete" not in event_name and (s3_object.get("size") is None or s3_object.get("eTag") is None):
+            raise ValueError(
+                "Size and eTag fields are required for all events except ObjectRemoved:* and LifecycleExpiration:*.",
+            )
         return values
 
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
**Issue number:** #5129 

## Summary

### Changes

This PR addresses an issue with parsing S3 `LifecycleExpiration:*` payload for S3 events. Before this PR the `size` and `etag` fields are optional for `ObjectRemoved` events only.

### User experience

> Please share what the user experience looks like before and after this change

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] [Meet tenets criteria](https://docs.powertools.aws.dev/lambda/python/#tenets)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented
* [x] PR title follows [conventional commit semantics](https://github.com/aws-powertools/powertools-lambda-python/blob/develop/.github/semantic.yml)

<details>
<summary>Is this a breaking change?</summary>

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
