### PR TITLE
fix(layer): reverting SSM parameter name

### DIFF
--- a/layer_v3/app.py
+++ b/layer_v3/app.py
@@ -10,7 +10,7 @@ app = cdk.App()
 POWERTOOLS_VERSION: str = app.node.try_get_context("version")
 PYTHON_VERSION: str = app.node.try_get_context("pythonVersion")
 PYTHON_VERSION_NORMALIZED = PYTHON_VERSION.replace(".", "")
-SSM_PARAM_LAYER_ARN: str = f"/layers/powertools-layer-v3-{PYTHON_VERSION_NORMALIZED}-x86_64-arn"
+SSM_PARAM_LAYER_ARN: str = f"/layers/powertools-layer-v3-{PYTHON_VERSION_NORMALIZED}-x86-arn"
 SSM_PARAM_LAYER_ARM64_ARN: str = f"/layers/powertools-layer-v3-{PYTHON_VERSION_NORMALIZED}-arm64-arn"
 
 # Validate context variables


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
**Issue number:** #5339 

## Summary

### Changes

We need to revert the name change for internal parameter names for the Canary stack. In CloudFormation, the Canary stack represents a changeset when deploying, and we'll need to remove all the Canary stacks in all regions to use the new parameter name. These parameter names are used internally within our CloudFormation templates and are not exposed to end customers.

### User experience

> Please share what the user experience looks like before and after this change

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] [Meet tenets criteria](https://docs.powertools.aws.dev/lambda/python/#tenets)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented
* [x] PR title follows [conventional commit semantics](https://github.com/aws-powertools/powertools-lambda-python/blob/develop/.github/semantic.yml)

<details>
<summary>Is this a breaking change?</summary>

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
