### PR TITLE
chore(docs): remove layer callout from data masking docs

### DIFF
--- a/docs/utilities/data_masking.md
+++ b/docs/utilities/data_masking.md
@@ -73,8 +73,6 @@ graph LR
 
 ### Install
 
-!!! info "Our Lambda layer does not include the aws-encryption-sdk. Please install it as a dependency in your project to use this utility."
-
 Add `aws-lambda-powertools[datamasking]` as a dependency in your preferred tool: _e.g._, _requirements.txt_, _pyproject.toml_. This will install the [AWS Encryption SDK](https://docs.aws.amazon.com/encryption-sdk/latest/developer-guide/introduction.html){target="_blank"}.
 
 <!-- markdownlint-disable MD013 -->


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
**Issue number:** closes #5376

## Summary

### Changes

> Please provide a summary of what's being changed

This PR removes the callout about the AWS Encryption SDK not being present in the Lambda layer. As of v3 we started including the dependency in our layers.

### User experience

> Please share what the user experience looks like before and after this change

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] [Meet tenets criteria](https://docs.powertools.aws.dev/lambda/python/#tenets)
* [x] I have performed a self-review of this change
* [ ] Changes have been tested
* [x] Changes are documented
* [x] PR title follows [conventional commit semantics](https://github.com/aws-powertools/powertools-lambda-python/blob/develop/.github/semantic.yml)

<details>
<summary>Is this a breaking change?</summary>

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
