### PR TITLE
chore(ci): Add dump of govcloud layer info in verify step

### DIFF
--- a/.github/workflows/layer_govcloud.yml
+++ b/.github/workflows/layer_govcloud.yml
@@ -109,8 +109,8 @@ jobs:
           name: ${{ matrix.layer }}_${{ matrix.arch }}.json
       - name: Verify Layer Signature
         run: |
-          SHA=$(jq -r '.Content.CodeSha256' ${{ matrix.layer }}_${{ matrix.arch }}.json)
-          test $(openssl dgst -sha256 -binary ${{ matrix.layer }}_${{ matrix.arch }}.zip | openssl enc -base64) == $SHA && echo "SHA OK: ${SHA}" || exit 1 
+          SHA=$(jq -r '.Content.CodeSha256' '${{ matrix.layer }}_${{ matrix.arch }}.json')
+          test "$(openssl dgst -sha256 -binary ${{ matrix.layer }}_${{ matrix.arch }}.zip | openssl enc -base64)" == "$SHA" && echo "SHA OK: ${SHA}" || exit 1 
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502 # v4.0.2
         with:
@@ -123,28 +123,29 @@ jobs:
           LAYER_VERSION=$(aws --region us-gov-east-1 lambda publish-layer-version \
             --layer-name ${{ matrix.layer }}-${{ matrix.arch }} \
             --zip-file fileb://./${{ matrix.layer }}_${{ matrix.arch }}.zip \
-            --compatible-runtimes $(jq -r ".CompatibleRuntimes[0]" ${{ matrix.layer }}_${{ matrix.arch }}.json) \
-            --compatible-architectures $(jq -r ".CompatibleArchitectures[0]" ${{ matrix.layer }}_${{ matrix.arch }}.json) \
+            --compatible-runtimes "$(jq -r '.CompatibleRuntimes[0]' '${{ matrix.layer }}_${{ matrix.arch }}.json')" \
+            --compatible-architectures "$(jq  -r '.CompatibleArchitectures[0]' '${{ matrix.layer }}_${{ matrix.arch }}.json')" \
             --license-info "MIT-0" \
-            --description "$(jq -r '.Description' ${{ matrix.layer }}_${{ matrix.arch }}.json)" \
+            --description "$(jq -r '.Description' '${{ matrix.layer }}_${{ matrix.arch }}.json')" \
             --query 'Version' \
             --output text)
+
           echo "LAYER_VERSION=$LAYER_VERSION" >> "$GITHUB_OUTPUT"
 
           aws --region us-gov-east-1 lambda add-layer-version-permission \
-            --layer-name ${{ matrix.layer }}-${{ matrix.arch }} \
+            --layer-name '${{ matrix.layer }}-${{ matrix.arch }}' \
             --statement-id 'PublicLayer' \
             --action lambda:GetLayerVersion \
             --principal '*' \
-            --version-number $LAYER_VERSION
+            --version-number "$LAYER_VERSION"
       - name: Verify Layer
         env:
           LAYER_VERSION: ${{ steps.create-layer.outputs.LAYER_VERSION }}
         run: |
-          REMOTE_SHA=$(aws --region us-gov-east-1 lambda get-layer-version-by-arn --arn arn:aws-us-gov:lambda:us-gov-east-1:${{ secrets.AWS_ACCOUNT_ID }}:layer:${{ matrix.layer }}-${{ matrix.arch }}:${{ env.LAYER_VERSION }} --query 'Content.CodeSha256' --output text)
-          SHA=$(jq -r '.Content.CodeSha256' ${{ matrix.layer }}_${{ matrix.arch }}.json)
-          test $REMOTE_SHA == $SHA && echo "SHA OK: ${SHA}" || exit 1 
-          aws --region us-gov-east-1 lambda get-layer-version-by-arn --arn arn:aws-us-gov:lambda:us-gov-east-1:${{ secrets.AWS_ACCOUNT_ID }}:layer:${{ matrix.layer }}-${{ matrix.arch }}:${{ env.LAYER_VERSION }} --output text
+          REMOTE_SHA=$(aws --region us-gov-east-1 lambda get-layer-version-by-arn --arn 'arn:aws-us-gov:lambda:us-gov-east-1:${{ secrets.AWS_ACCOUNT_ID }}:layer:${{ matrix.layer }}-${{ matrix.arch }}:${{ env.LAYER_VERSION }}' --query 'Content.CodeSha256' --output text)
+          SHA=$(jq -r '.Content.CodeSha256' '${{ matrix.layer }}_${{ matrix.arch }}.json')
+          test "$REMOTE_SHA" == "$SHA "&& echo "SHA OK: ${SHA}" || exit 1 
+          aws --region us-gov-east-1 lambda get-layer-version-by-arn --arn 'arn:aws-us-gov:lambda:us-gov-east-1:${{ secrets.AWS_ACCOUNT_ID }}:layer:${{ matrix.layer }}-${{ matrix.arch }}:${{ env.LAYER_VERSION }}' --output text
 
   copy_west:
     name: Copy (West)
@@ -177,8 +178,8 @@ jobs:
           name: ${{ matrix.layer }}_${{ matrix.arch }}.json
       - name: Verify Layer Signature
         run: |
-          SHA=$(jq -r '.Content.CodeSha256' ${{ matrix.layer }}_${{ matrix.arch }}.json)
-          test $(openssl dgst -sha256 -binary ${{ matrix.layer }}_${{ matrix.arch }}.zip | openssl enc -base64) == $SHA && echo "SHA OK: ${SHA}" || exit 1 
+          SHA=$(jq -r '.Content.CodeSha256' '${{ matrix.layer }}_${{ matrix.arch }}.json')
+          test "$(openssl dgst -sha256 -binary ${{ matrix.layer }}_${{ matrix.arch }}.zip | openssl enc -base64)" == "$SHA" && echo "SHA OK: ${SHA}" || exit 1 
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502 # v4.0.2
         with:
@@ -191,26 +192,26 @@ jobs:
           LAYER_VERSION=$(aws --region us-gov-west-1 lambda publish-layer-version \
             --layer-name ${{ matrix.layer }}-${{ matrix.arch }} \
             --zip-file fileb://./${{ matrix.layer }}_${{ matrix.arch }}.zip \
-            --compatible-runtimes $(jq -r ".CompatibleRuntimes[0]" ${{ matrix.layer }}_${{ matrix.arch }}.json) \
-            --compatible-architectures $(jq  -r ".CompatibleArchitectures[0]" ${{ matrix.layer }}_${{ matrix.arch }}.json) \
+            --compatible-runtimes "$(jq -r '.CompatibleRuntimes[0]' '${{ matrix.layer }}_${{ matrix.arch }}.json')" \
+            --compatible-architectures "$(jq  -r '.CompatibleArchitectures[0]' '${{ matrix.layer }}_${{ matrix.arch }}.json')" \
             --license-info "MIT-0" \
-            --description "$(jq -r '.Description' ${{ matrix.layer }}_${{ matrix.arch }}.json)" \
+            --description "$(jq -r '.Description' '${{ matrix.layer }}_${{ matrix.arch }}.json')" \
             --query 'Version' \
             --output text)
 
           echo "LAYER_VERSION=$LAYER_VERSION" >> "$GITHUB_OUTPUT"
 
           aws --region us-gov-west-1 lambda add-layer-version-permission \
-            --layer-name ${{ matrix.layer }}-${{ matrix.arch }} \
+            --layer-name '${{ matrix.layer }}-${{ matrix.arch }}' \
             --statement-id 'PublicLayer' \
             --action lambda:GetLayerVersion \
             --principal '*' \
-            --version-number $LAYER_VERSION
+            --version-number "$LAYER_VERSION"
       - name: Verify Layer
         env:
           LAYER_VERSION: ${{ steps.create-layer.outputs.LAYER_VERSION }}
         run: |
-          REMOTE_SHA=$(aws --region us-gov-west-1 lambda get-layer-version-by-arn --arn arn:aws-us-gov:lambda:us-gov-west-1:${{ secrets.AWS_ACCOUNT_ID }}:layer:${{ matrix.layer }}-${{ matrix.arch }}:${{ env.LAYER_VERSION }} --query 'Content.CodeSha256' --output text)
-          SHA=$(jq -r '.Content.CodeSha256' ${{ matrix.layer }}_${{ matrix.arch }}.json)
-          test $REMOTE_SHA == $SHA && echo "SHA OK: ${SHA}" || exit 1 
-          aws --region us-gov-west-1 lambda get-layer-version-by-arn --arn arn:aws-us-gov:lambda:us-gov-west-1:${{ secrets.AWS_ACCOUNT_ID }}:layer:${{ matrix.layer }}-${{ matrix.arch }}:${{ env.LAYER_VERSION }} --output text
+          REMOTE_SHA=$(aws --region us-gov-west-1 lambda get-layer-version-by-arn --arn 'arn:aws-us-gov:lambda:us-gov-west-1:${{ secrets.AWS_ACCOUNT_ID }}:layer:${{ matrix.layer }}-${{ matrix.arch }}:${{ env.LAYER_VERSION }}' --query 'Content.CodeSha256' --output text)
+          SHA=$(jq -r '.Content.CodeSha256' '${{ matrix.layer }}_${{ matrix.arch }}.json')
+          test "$REMOTE_SHA" == "$SHA "&& echo "SHA OK: ${SHA}" || exit 1 
+          aws --region us-gov-west-1 lambda get-layer-version-by-arn --arn 'arn:aws-us-gov:lambda:us-gov-west-1:${{ secrets.AWS_ACCOUNT_ID }}:layer:${{ matrix.layer }}-${{ matrix.arch }}:${{ env.LAYER_VERSION }}' --output text

--- a/.github/workflows/layer_govcloud.yml
+++ b/.github/workflows/layer_govcloud.yml
@@ -16,22 +16,20 @@ on:
         options:
           - Gamma
           - Prod
-        default: Gamma
         required: true
       version:
         description: Layer version to duplicate
-        type: number
+        type: string
         required: true
   workflow_call:
     inputs:
       environment:
         description: Deployment environment
         type: string
-        default: Gamma
         required: true
       version:
         description: Layer version to duplicate
-        type: number
+        type: string
         required: true
 
 name: Layer Deployment (GovCloud)
@@ -146,6 +144,7 @@ jobs:
           REMOTE_SHA=$(aws --region us-gov-east-1 lambda get-layer-version-by-arn --arn arn:aws-us-gov:lambda:us-gov-east-1:${{ secrets.AWS_ACCOUNT_ID }}:layer:${{ matrix.layer }}-${{ matrix.arch }}:${{ env.LAYER_VERSION }} --query 'Content.CodeSha256' --output text)
           SHA=$(jq -r '.Content.CodeSha256' ${{ matrix.layer }}_${{ matrix.arch }}.json)
           test $REMOTE_SHA == $SHA && echo "SHA OK: ${SHA}" || exit 1 
+          aws --region us-gov-east-1 lambda get-layer-version-by-arn --arn arn:aws-us-gov:lambda:us-gov-east-1:${{ secrets.AWS_ACCOUNT_ID }}:layer:${{ matrix.layer }}-${{ matrix.arch }}:${{ env.LAYER_VERSION }} --output text
 
   copy_west:
     name: Copy (West)
@@ -214,3 +213,4 @@ jobs:
           REMOTE_SHA=$(aws --region us-gov-west-1 lambda get-layer-version-by-arn --arn arn:aws-us-gov:lambda:us-gov-west-1:${{ secrets.AWS_ACCOUNT_ID }}:layer:${{ matrix.layer }}-${{ matrix.arch }}:${{ env.LAYER_VERSION }} --query 'Content.CodeSha256' --output text)
           SHA=$(jq -r '.Content.CodeSha256' ${{ matrix.layer }}_${{ matrix.arch }}.json)
           test $REMOTE_SHA == $SHA && echo "SHA OK: ${SHA}" || exit 1 
+          aws --region us-gov-west-1 lambda get-layer-version-by-arn --arn arn:aws-us-gov:lambda:us-gov-west-1:${{ secrets.AWS_ACCOUNT_ID }}:layer:${{ matrix.layer }}-${{ matrix.arch }}:${{ env.LAYER_VERSION }} --output text

--- a/.github/workflows/layer_govcloud_verify.yml
+++ b/.github/workflows/layer_govcloud_verify.yml
@@ -1,0 +1,111 @@
+# GovCloud Layer Verification
+# ---
+# This workflow queries the GovCloud layer info in production only
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: Layer version to duplicate
+        type: string
+        required: true
+  workflow_call:
+    inputs:
+      version:
+        description: Layer version to duplicate
+        type: string
+        required: true
+
+name: Layer Verification (GovCloud)
+run-name: Layer Verification (GovCloud)
+
+jobs:
+  commercial:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    strategy:
+      matrix:
+        layer:
+          - AWSLambdaPowertoolsPythonV3-python38
+          - AWSLambdaPowertoolsPythonV3-python39
+          - AWSLambdaPowertoolsPythonV3-python310
+          - AWSLambdaPowertoolsPythonV3-python311
+          - AWSLambdaPowertoolsPythonV3-python312
+        arch:
+          - arm64
+          - x86_64
+    environment: Prod (Readonly)
+    steps:
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502 # v4.0.2
+        with:
+          role-to-assume: ${{ secrets.AWS_IAM_ROLE }}
+          aws-region: us-east-1
+          mask-aws-account-id: true
+      - name: Output ${{ matrix.layer }}-${{ matrix.arch }}
+        run: |
+          aws --region us-east-1 lambda get-layer-version-by-arn --arn arn:aws:lambda:us-east-1:017000801446:layer:${{ matrix.layer }}-${{ matrix.arch }}:${{ inputs.version }} --output text
+
+  gov_east:
+    name: Verify (East)
+    needs: commercial
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    strategy:
+      matrix:
+        layer:
+          - AWSLambdaPowertoolsPythonV3-python38
+          - AWSLambdaPowertoolsPythonV3-python39
+          - AWSLambdaPowertoolsPythonV3-python310
+          - AWSLambdaPowertoolsPythonV3-python311
+          - AWSLambdaPowertoolsPythonV3-python312
+        arch:
+          - arm64
+          - x86_64
+    environment: GovCloud Prod (East)
+    steps:
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502 # v4.0.2
+        with:
+          role-to-assume: ${{ secrets.AWS_IAM_ROLE }}
+          aws-region: us-gov-east-1
+          mask-aws-account-id: true
+      - name: Verify Layer ${{ matrix.layer }}-${{ matrix.arch }}
+        id: verify-layer
+        run: |
+          aws --region us-gov-east-1 lambda get-layer-version-by-arn --arn 'arn:aws-us-gov:lambda:us-gov-east-1:${{ secrets.AWS_ACCOUNT_ID }}:layer:${{ matrix.layer }}-${{ matrix.arch }}:${{ inputs.version }}' --output text
+
+  gov_west:
+    name: Verify (West)
+    needs: commercial
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    strategy:
+      matrix:
+        layer:
+          - AWSLambdaPowertoolsPythonV3-python38
+          - AWSLambdaPowertoolsPythonV3-python39
+          - AWSLambdaPowertoolsPythonV3-python310
+          - AWSLambdaPowertoolsPythonV3-python311
+          - AWSLambdaPowertoolsPythonV3-python312
+        arch:
+          - arm64
+          - x86_64
+    environment: GovCloud Prod (West)
+    steps:
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502 # v4.0.2
+        with:
+          role-to-assume: ${{ secrets.AWS_IAM_ROLE }}
+          aws-region: us-gov-east-1
+          mask-aws-account-id: true
+      - name: Verify Layer ${{ matrix.layer }}-${{ matrix.arch }}
+        id: verify-layer
+        run: |
+          aws --region us-gov-west-1 lambda get-layer-version-by-arn --arn 'arn:aws-us-gov:lambda:us-gov-west-1:${{ secrets.AWS_ACCOUNT_ID }}:layer:${{ matrix.layer }}-${{ matrix.arch }}:${{ inputs.version }}' --output text

--- a/.github/workflows/layer_govcloud_verify.yml
+++ b/.github/workflows/layer_govcloud_verify.yml
@@ -12,7 +12,7 @@ on:
   workflow_call:
     inputs:
       version:
-        description: Layer version to duplicate
+        description: Layer version to verify information
         type: string
         required: true
 

--- a/.github/workflows/layer_govcloud_verify.yml
+++ b/.github/workflows/layer_govcloud_verify.yml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: Layer version to duplicate
+        description: Layer version to verify information
         type: string
         required: true
   workflow_call:


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
**Issue number:** #5384 

## Summary

### Changes

> Please provide a summary of what's being changed

Adds a verification step as agreed in the runbook

### User experience

> Please share what the user experience looks like before and after this change

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [X] [Meet tenets criteria](https://docs.powertools.aws.dev/lambda/python/#tenets)
* [X] I have performed a self-review of this change
* [X] Changes have been tested
* [X] Changes are documented
* [X] PR title follows [conventional commit semantics](https://github.com/aws-powertools/powertools-lambda-python/blob/develop/.github/semantic.yml)

<details>
<summary>Is this a breaking change?</summary>

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
