### PR TITLE
chore(layers): add pydantic-settings package to v3 Layer

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -3027,6 +3027,26 @@ files = [
 typing-extensions = ">=4.6.0,<4.7.0 || >4.7.0"
 
 [[package]]
+name = "pydantic-settings"
+version = "2.6.1"
+description = "Settings management using Pydantic"
+optional = true
+python-versions = ">=3.8"
+files = [
+    {file = "pydantic_settings-2.6.1-py3-none-any.whl", hash = "sha256:7fb0637c786a558d3103436278a7c4f1cfd29ba8973238a50c5bb9a55387da87"},
+    {file = "pydantic_settings-2.6.1.tar.gz", hash = "sha256:e0f92546d8a9923cb8941689abf85d6601a8c19a23e97a34b2964a2e3f813ca0"},
+]
+
+[package.dependencies]
+pydantic = ">=2.7.0"
+python-dotenv = ">=0.21.0"
+
+[package.extras]
+azure-key-vault = ["azure-identity (>=1.16.0)", "azure-keyvault-secrets (>=4.8.0)"]
+toml = ["tomli (>=2.0.1)"]
+yaml = ["pyyaml (>=6.0.1)"]
+
+[[package]]
 name = "pygments"
 version = "2.18.0"
 description = "Pygments is a syntax highlighting package written in Python."
@@ -3214,6 +3234,20 @@ files = [
 
 [package.dependencies]
 six = ">=1.5"
+
+[[package]]
+name = "python-dotenv"
+version = "1.0.1"
+description = "Read key-value pairs from a .env file and set them as environment variables"
+optional = true
+python-versions = ">=3.8"
+files = [
+    {file = "python-dotenv-1.0.1.tar.gz", hash = "sha256:e324ee90a023d808f1959c46bcbc04446a10ced277783dc6ee09987c37ec10ca"},
+    {file = "python_dotenv-1.0.1-py3-none-any.whl", hash = "sha256:f7b63ef50f1b690dddf550d03497b66d609393b40b564ed0d674909a68ebf16a"},
+]
+
+[package.extras]
+cli = ["click (>=5.0)"]
 
 [[package]]
 name = "pytz"
@@ -4336,7 +4370,7 @@ test = ["big-O", "importlib-resources", "jaraco.functools", "jaraco.itertools", 
 type = ["pytest-mypy"]
 
 [extras]
-all = ["aws-encryption-sdk", "aws-xray-sdk", "fastjsonschema", "jsonpath-ng", "pydantic"]
+all = ["aws-encryption-sdk", "aws-xray-sdk", "fastjsonschema", "jsonpath-ng", "pydantic", "pydantic-settings"]
 aws-sdk = ["boto3"]
 datadog = ["datadog-lambda"]
 datamasking = ["aws-encryption-sdk", "jsonpath-ng"]
@@ -4348,4 +4382,4 @@ validation = ["fastjsonschema"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.8,<4.0.0"
-content-hash = "eb923ee8fa0e3fc589847a643e937029bcf2f3c33e2428fa3fd59a1d52d6f4e1"
+content-hash = "20e7c28f583119829ce5bd1af4130fd5409764d7fa84be47fafa9238a76e8055"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,7 @@ typing-extensions = "^4.11.0"
 aws-xray-sdk = { version = "^2.8.0", optional = true }
 fastjsonschema = { version = "^2.14.5", optional = true }
 pydantic = { version = "^2.4.0", optional = true }
+pydantic-settings = {version = "^2.6.1", optional = true}
 boto3 = { version = "^1.34.32", optional = true }
 redis = { version = ">=4.4,<6.0", optional = true }
 datadog-lambda = { version = ">=4.77,<7.0", optional = true }
@@ -96,6 +97,7 @@ tracer = ["aws-xray-sdk"]
 redis = ["redis"]
 all = [
   "pydantic",
+  "pydantic-settings",
   "aws-xray-sdk",
   "fastjsonschema",
   "aws-encryption-sdk",


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
**Issue number:** https://github.com/aws-powertools/powertools-lambda-python/issues/5508

## Summary
This PR adds `pydantic-settings` to simplify the migration from v2 to v3 for users building Lambda functions exclusively with Powertools layers, without the need for additional pip installations.

### Changes
- Adds `pydantic-settings` as an optional package and includes it in all extra dependencies.

### User experience

Before this change, users had to rewrite code using `pydantic-settings` with `os` to read environment variables, or stick with the v2 layer to use the `BaseSettings` class from Pydantic v1. With this update, however, users can now migrate smoothly from v2 to v3 without any changes to code that relies on `pydantic-settings`.

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] [Meet tenets criteria](https://docs.powertools.aws.dev/lambda/python/#tenets)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [ ] Changes are documented
* [x] PR title follows [conventional commit semantics](https://github.com/aws-powertools/powertools-lambda-python/blob/develop/.github/semantic.yml)

<details>
<summary>Is this a breaking change?</summary>

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
