### PR TITLE
chore(ci): Bump CDK version to build layers and fix imports

### DIFF
--- a/layer_v3/layer/layer_stack.py
+++ b/layer_v3/layer/layer_stack.py
@@ -16,7 +16,7 @@ from aws_cdk.aws_lambda import Architecture, CfnLayerVersionPermission, Runtime
 from aws_cdk.aws_ssm import StringParameter
 from constructs import Construct
 
-from layer_v3.layer_constructors.layer_stack import LambdaPowertoolsLayerPythonV3
+from ..layer_constructors.layer_stack import LambdaPowertoolsLayerPythonV3
 
 
 @jsii.implements(IAspect)

--- a/layer_v3/layer_constructors/layer_stack.py
+++ b/layer_v3/layer_constructors/layer_stack.py
@@ -8,7 +8,7 @@ from aws_cdk import aws_lambda as lambda_
 if TYPE_CHECKING:
     from constructs import Construct
 
-from layer_v3.layer_constructors.helpers import construct_build_args
+from .helpers import construct_build_args
 
 
 class LambdaPowertoolsLayerPythonV3(lambda_.LayerVersion):

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,14 +11,15 @@
         "package-lock.json": "^1.0.0"
       },
       "devDependencies": {
-        "aws-cdk": "^2.166.0"
+        "aws-cdk": "^2.167.0"
       }
     },
     "node_modules/aws-cdk": {
-      "version": "2.166.0",
-      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.166.0.tgz",
-      "integrity": "sha512-AvwYXJt92lMlp0pB49HJtlvyWFZUBcX4DliIV3JfLngLpAlwVHQtvzPbL8qCvxHwZ3CIzJ1wKEth8QzdYmyOPQ==",
+      "version": "2.167.0",
+      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.167.0.tgz",
+      "integrity": "sha512-Hrz8sc7BYJSL+hF3el9jidUwfVAYxZ/TuMDngXHnqqUNsxPLBOG2xWzVVto0YezJkQImvWYrc2IDlDgkcNRTaw==",
       "dev": true,
+      "license": "Apache-2.0",
       "bin": {
         "cdk": "bin/cdk"
       },

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "aws-lambda-powertools-python-e2e",
   "version": "1.0.0",
   "devDependencies": {
-    "aws-cdk": "^2.166.0"
+    "aws-cdk": "^2.167.0"
   },
   "dependencies": {
     "package-lock.json": "^1.0.0"


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
**Issue number:** #5554 

## Summary

### Changes

Bump CDK version to build layers

### User experience

> Please share what the user experience looks like before and after this change

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] [Meet tenets criteria](https://docs.powertools.aws.dev/lambda/python/#tenets)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented
* [x] PR title follows [conventional commit semantics](https://github.com/aws-powertools/powertools-lambda-python/blob/develop/.github/semantic.yml)

<details>
<summary>Is this a breaking change?</summary>

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
