### PR TITLE
chore(ci): fix imports to build Lambda layer

### DIFF
--- a/layer_v3/layer/layer_stack.py
+++ b/layer_v3/layer/layer_stack.py
@@ -15,8 +15,7 @@ from aws_cdk import (
 from aws_cdk.aws_lambda import Architecture, CfnLayerVersionPermission, Runtime
 from aws_cdk.aws_ssm import StringParameter
 from constructs import Construct
-
-from ..layer_constructors.layer_stack import LambdaPowertoolsLayerPythonV3
+from layer_constructors.layer_stack import LambdaPowertoolsLayerPythonV3
 
 
 @jsii.implements(IAspect)


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
**Issue number:** https://github.com/aws-powertools/powertools-lambda-python/issues/5554

## Summary

### Changes

fix imports to build Lambda layer

### User experience

> Please share what the user experience looks like before and after this change

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] [Meet tenets criteria](https://docs.powertools.aws.dev/lambda/python/#tenets)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented
* [x] PR title follows [conventional commit semantics](https://github.com/aws-powertools/powertools-lambda-python/blob/develop/.github/semantic.yml)

<details>
<summary>Is this a breaking change?</summary>

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
