### PR TITLE
chore(layers): balance Python 3.13 layers in GovCloud partition

### DIFF
--- a/.github/workflows/layer_govcloud_python313.yml
+++ b/.github/workflows/layer_govcloud_python313.yml
@@ -1,0 +1,205 @@
+# GovCloud Layer Publish
+# ---
+# This workflow publishes a specific layer version in an AWS account based on the environment input.
+#
+# Using a matrix, we pull each architecture and python version of the layer and store them as artifacts
+# we upload them to each of the GovCloud AWS accounts.
+#
+# A number of safety checks are performed to ensure safety.
+
+on:
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: Deployment environment
+        type: choice
+        options:
+          - Gamma
+          - Prod
+        required: true
+      version:
+        description: Layer version to duplicate
+        type: string
+        required: true
+  workflow_call:
+    inputs:
+      environment:
+        description: Deployment environment
+        type: string
+        required: true
+      version:
+        description: Layer version to duplicate
+        type: string
+        required: true
+
+name: Layer Deployment (GovCloud) - Temporary for Python 3.13
+run-name: Layer Deployment (GovCloud) - ${{ inputs.environment }}
+
+jobs:
+  download:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    strategy:
+      matrix:
+        layer:
+          - AWSLambdaPowertoolsPythonV3-python313
+        arch:
+          - arm64
+          - x86_64
+    environment: Prod (Readonly)
+    steps:
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502 # v4.0.2
+        with:
+          role-to-assume: ${{ secrets.AWS_IAM_ROLE }}
+          aws-region: us-east-1
+          mask-aws-account-id: true
+      - name: Grab Zip
+        run: |
+          aws --region us-east-1 lambda get-layer-version-by-arn --arn arn:aws:lambda:us-east-1:017000801446:layer:${{ matrix.layer }}-${{ matrix.arch }}:${{ inputs.version }} --query 'Content.Location' | xargs curl -L -o ${{ matrix.layer }}_${{ matrix.arch }}.zip
+          aws --region us-east-1 lambda get-layer-version-by-arn --arn arn:aws:lambda:us-east-1:017000801446:layer:${{ matrix.layer }}-${{ matrix.arch }}:${{ inputs.version }} > ${{ matrix.layer }}_${{ matrix.arch }}.json
+      - name: Store Zip
+        uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
+        with:
+          name: ${{ matrix.layer }}_${{ matrix.arch }}.zip
+          path: ${{ matrix.layer }}_${{ matrix.arch }}.zip
+          retention-days: 1
+          if-no-files-found: error
+      - name: Store Metadata
+        uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
+        with:
+          name: ${{ matrix.layer }}_${{ matrix.arch }}.json
+          path: ${{ matrix.layer }}_${{ matrix.arch }}.json
+          retention-days: 1
+          if-no-files-found: error
+
+  copy_east:
+    name: Copy (East)
+    needs: download
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    strategy:
+      matrix:
+        layer:
+          - AWSLambdaPowertoolsPythonV3-python313
+        arch:
+          - arm64
+          - x86_64
+    environment: GovCloud ${{ inputs.environment }} (East)
+    steps:
+      - name: Download Zip
+        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
+        with:
+          name: ${{ matrix.layer }}_${{ matrix.arch }}.zip
+      - name: Download Metadata
+        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
+        with:
+          name: ${{ matrix.layer }}_${{ matrix.arch }}.json
+      - name: Verify Layer Signature
+        run: |
+          SHA=$(jq -r '.Content.CodeSha256' '${{ matrix.layer }}_${{ matrix.arch }}.json')
+          test "$(openssl dgst -sha256 -binary ${{ matrix.layer }}_${{ matrix.arch }}.zip | openssl enc -base64)" == "$SHA" && echo "SHA OK: ${SHA}" || exit 1
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502 # v4.0.2
+        with:
+          role-to-assume: ${{ secrets.AWS_IAM_ROLE }}
+          aws-region: us-gov-east-1
+          mask-aws-account-id: true
+      - name: Create Layer
+        id: create-layer
+        run: |
+          LAYER_VERSION=$(aws --region us-gov-east-1 lambda publish-layer-version \
+            --layer-name ${{ matrix.layer }}-${{ matrix.arch }} \
+            --zip-file fileb://./${{ matrix.layer }}_${{ matrix.arch }}.zip \
+            --compatible-runtimes "$(jq -r '.CompatibleRuntimes[0]' '${{ matrix.layer }}_${{ matrix.arch }}.json')" \
+            --compatible-architectures "$(jq  -r '.CompatibleArchitectures[0]' '${{ matrix.layer }}_${{ matrix.arch }}.json')" \
+            --license-info "MIT-0" \
+            --description "$(jq -r '.Description' '${{ matrix.layer }}_${{ matrix.arch }}.json')" \
+            --query 'Version' \
+            --output text)
+
+          echo "LAYER_VERSION=$LAYER_VERSION" >> "$GITHUB_OUTPUT"
+
+          aws --region us-gov-east-1 lambda add-layer-version-permission \
+            --layer-name '${{ matrix.layer }}-${{ matrix.arch }}' \
+            --statement-id 'PublicLayer' \
+            --action lambda:GetLayerVersion \
+            --principal '*' \
+            --version-number "$LAYER_VERSION"
+      - name: Verify Layer
+        env:
+          LAYER_VERSION: ${{ steps.create-layer.outputs.LAYER_VERSION }}
+        run: |
+          REMOTE_SHA=$(aws --region us-gov-east-1 lambda get-layer-version-by-arn --arn 'arn:aws-us-gov:lambda:us-gov-east-1:${{ secrets.AWS_ACCOUNT_ID }}:layer:${{ matrix.layer }}-${{ matrix.arch }}:${{ env.LAYER_VERSION }}' --query 'Content.CodeSha256' --output text)
+          SHA=$(jq -r '.Content.CodeSha256' '${{ matrix.layer }}_${{ matrix.arch }}.json')
+          test "$REMOTE_SHA" == "$SHA" && echo "SHA OK: ${SHA}" || exit 1
+          aws --region us-gov-east-1 lambda get-layer-version-by-arn --arn 'arn:aws-us-gov:lambda:us-gov-east-1:${{ secrets.AWS_ACCOUNT_ID }}:layer:${{ matrix.layer }}-${{ matrix.arch }}:${{ env.LAYER_VERSION }}' --output table
+
+  copy_west:
+    name: Copy (West)
+    needs: download
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    strategy:
+      matrix:
+        layer:
+          - AWSLambdaPowertoolsPythonV3-python313
+        arch:
+          - arm64
+          - x86_64
+    environment:
+      name: GovCloud ${{ inputs.environment }} (West)
+    steps:
+      - name: Download Zip
+        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
+        with:
+          name: ${{ matrix.layer }}_${{ matrix.arch }}.zip
+      - name: Download Metadata
+        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
+        with:
+          name: ${{ matrix.layer }}_${{ matrix.arch }}.json
+      - name: Verify Layer Signature
+        run: |
+          SHA=$(jq -r '.Content.CodeSha256' '${{ matrix.layer }}_${{ matrix.arch }}.json')
+          test "$(openssl dgst -sha256 -binary ${{ matrix.layer }}_${{ matrix.arch }}.zip | openssl enc -base64)" == "$SHA" && echo "SHA OK: ${SHA}" || exit 1
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502 # v4.0.2
+        with:
+          role-to-assume: ${{ secrets.AWS_IAM_ROLE }}
+          aws-region: us-gov-west-1
+          mask-aws-account-id: true
+      - name: Create Layer
+        id: create-layer
+        run: |
+          LAYER_VERSION=$(aws --region us-gov-west-1 lambda publish-layer-version \
+            --layer-name ${{ matrix.layer }}-${{ matrix.arch }} \
+            --zip-file fileb://./${{ matrix.layer }}_${{ matrix.arch }}.zip \
+            --compatible-runtimes "$(jq -r '.CompatibleRuntimes[0]' '${{ matrix.layer }}_${{ matrix.arch }}.json')" \
+            --compatible-architectures "$(jq  -r '.CompatibleArchitectures[0]' '${{ matrix.layer }}_${{ matrix.arch }}.json')" \
+            --license-info "MIT-0" \
+            --description "$(jq -r '.Description' '${{ matrix.layer }}_${{ matrix.arch }}.json')" \
+            --query 'Version' \
+            --output text)
+
+          echo "LAYER_VERSION=$LAYER_VERSION" >> "$GITHUB_OUTPUT"
+
+          aws --region us-gov-west-1 lambda add-layer-version-permission \
+            --layer-name '${{ matrix.layer }}-${{ matrix.arch }}' \
+            --statement-id 'PublicLayer' \
+            --action lambda:GetLayerVersion \
+            --principal '*' \
+            --version-number "$LAYER_VERSION"
+      - name: Verify Layer
+        env:
+          LAYER_VERSION: ${{ steps.create-layer.outputs.LAYER_VERSION }}
+        run: |
+          REMOTE_SHA=$(aws --region us-gov-west-1 lambda get-layer-version-by-arn --arn 'arn:aws-us-gov:lambda:us-gov-west-1:${{ secrets.AWS_ACCOUNT_ID }}:layer:${{ matrix.layer }}-${{ matrix.arch }}:${{ env.LAYER_VERSION }}' --query 'Content.CodeSha256' --output text)
+          SHA=$(jq -r '.Content.CodeSha256' '${{ matrix.layer }}_${{ matrix.arch }}.json')
+          test "$REMOTE_SHA" == "$SHA" && echo "SHA OK: ${SHA}" || exit 1
+          aws --region us-gov-west-1 lambda get-layer-version-by-arn --arn 'arn:aws-us-gov:lambda:us-gov-west-1:${{ secrets.AWS_ACCOUNT_ID }}:layer:${{ matrix.layer }}-${{ matrix.arch }}:${{ env.LAYER_VERSION }}' --output table


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
**Issue number:** #5578 

## Summary

### Changes

We have released a new Python 3.13 runtime and we need to balance the layers in GovCloud for this new runtime. Layers for Python 3.13 are currently at version 1 in that partition but should be at version 4.

This is a temporary workflow.

### User experience

> Please share what the user experience looks like before and after this change

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] [Meet tenets criteria](https://docs.powertools.aws.dev/lambda/python/#tenets)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented
* [x] PR title follows [conventional commit semantics](https://github.com/aws-powertools/powertools-lambda-python/blob/develop/.github/semantic.yml)

<details>
<summary>Is this a breaking change?</summary>

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
