### PR TITLE
refactor(event_handler): add type annotations for `resolve` function

### DIFF
--- a/aws_lambda_powertools/event_handler/api_gateway.py
+++ b/aws_lambda_powertools/event_handler/api_gateway.py
@@ -1999,7 +1999,7 @@ class ApiGatewayResolver(BaseRouter):
 
         return register_resolver
 
-    def resolve(self, event, context) -> dict[str, Any]:
+    def resolve(self, event: dict[str, Any], context: LambdaContext) -> dict[str, Any]:
         """Resolves the response based on the provide event and decorator routes
 
         ## Internals


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
**Issue number: #5600**

## Summary

### Changes

- Add type annotations for arguments in the `ApiGatewayResolver.resolve` function.

### User experience

- Static type checkers can see the correct type that is expected by the function when calling it.

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] [Meet tenets criteria](https://docs.powertools.aws.dev/lambda/python/#tenets)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [ ] Changes are documented
* [x] PR title follows [conventional commit semantics](https://github.com/aws-powertools/powertools-lambda-python/blob/develop/.github/semantic.yml)

<details>
<summary>Is this a breaking change?</summary>

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
