### PR TITLE
chore(ci): replace closed-issue-message action with powertools action

### DIFF
--- a/.github/workflows/on_closed_issues.yml
+++ b/.github/workflows/on_closed_issues.yml
@@ -21,7 +21,7 @@ jobs:
       permissions:
           issues: write  # comment on issues
       steps:
-          - uses: aws-actions/closed-issue-message@80edfc24bdf1283400eb04d20a8a605ae8bf7d48
+          - uses: aws-powertools/actions/.github/actions/close-issue-message@428c1934f4b22c0984ff4a39b66c2f70765bbed6
             with:
                 repo-token: "${{ secrets.GITHUB_TOKEN }}"
                 message: |


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
**Issue number:** closes #5636

## Summary

### Changes

> Please provide a summary of what's being changed

This PR updates the workflow that runs when an issue is closed to use an action from our own shared repository (aws-powertools/actions) rather than a 3rd party one.

The new action uses the `gh` CLI to perform the action rather than a custom script.

### User experience

> Please share what the user experience looks like before and after this change

You can see the action in action [here](https://github.com/aws-powertools/powertools-lambda-typescript/issues/3353#issuecomment-2498805942)

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] [Meet tenets criteria](https://docs.powertools.aws.dev/lambda/python/#tenets)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [ ] Changes are documented
* [x] PR title follows [conventional commit semantics](https://github.com/aws-powertools/powertools-lambda-python/blob/develop/.github/semantic.yml)

<details>
<summary>Is this a breaking change?</summary>

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
