### PR TITLE
docs(home): fix date typo and shorten message.

### DIFF
--- a/docs/overrides/main.html
+++ b/docs/overrides/main.html
@@ -1,15 +1,15 @@
 {% extends "base.html" %}
 
 {% block announce %}
-On March 25st, 2025 v2 of Powertools for AWS Lambda (Python) <a
-  href="https://github.com/aws-powertools/powertools-lambda-python/issues/5239" target="_blank">will reach
+On March 25th 2025, v2 reaches <a href="https://github.com/aws-powertools/powertools-lambda-python/issues/5239"
+  target="_blank">
   End-of-Life</a>. We recommend you to <a href="https://docs.powertools.aws.dev/lambda/python/latest/upgrade/"
   target="_blank">upgrade to v3</a>.
 {% endblock %}
 
 {% block outdated %}
-  You're not viewing the latest version.
-  <a href="{{ '../' ~ base_url }}">
-    <strong>Click here to go to latest.</strong>
-  </a>
+You're not viewing the latest version.
+<a href="{{ '../' ~ base_url }}">
+  <strong>Click here to go to latest.</strong>
+</a>
 {% endblock %}


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
**Issue number:** #5239

## Summary

Fixes typo in homepage banner on when v2 will reach EOL.

### Changes

> Please provide a summary of what's being changed

### User experience

> Please share what the user experience looks like before and after this change

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] [Meet tenets criteria](https://docs.powertools.aws.dev/lambda/python/#tenets)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [ ] Changes are documented
* [x] PR title follows [conventional commit semantics](https://github.com/aws-powertools/powertools-lambda-python/blob/develop/.github/semantic.yml)

<details>
<summary>Is this a breaking change?</summary>

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
