### PR TITLE
chore(ci): fix dependency resolution

### DIFF
--- a/examples/event_handler_graphql/src/requirements.txt
+++ b/examples/event_handler_graphql/src/requirements.txt
@@ -1,2 +1,2 @@
 aws-lambda-powertools[tracer]
-requests
+requests>=2.32.0

--- a/tests/performance/data_masking/load_test_data_masking/pt-load-test-stack/function_1024/requirements.txt
+++ b/tests/performance/data_masking/load_test_data_masking/pt-load-test-stack/function_1024/requirements.txt
@@ -1,3 +1,3 @@
-requests
+requests>=2.32.0
 aws-lambda-powertools[tracer]
-aws-encryption-sdk
+aws-encryption-sdk>=3.1.1

--- a/tests/performance/data_masking/load_test_data_masking/pt-load-test-stack/function_128/requirements.txt
+++ b/tests/performance/data_masking/load_test_data_masking/pt-load-test-stack/function_128/requirements.txt
@@ -1,3 +1,3 @@
-requests
+requests>=2.32.0
 aws-lambda-powertools[tracer]
-aws-encryption-sdk
+aws-encryption-sdk>=3.1.1

--- a/tests/performance/data_masking/load_test_data_masking/pt-load-test-stack/function_1769/requirements.txt
+++ b/tests/performance/data_masking/load_test_data_masking/pt-load-test-stack/function_1769/requirements.txt
@@ -1,3 +1,3 @@
-requests
+requests>=2.32.0
 aws-lambda-powertools[tracer]
-aws-encryption-sdk
+aws-encryption-sdk>=3.1.1


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
**Issue number:** #5857 

## Summary

### Changes

Some dependencies like boto3 depend on `urllib` and dependency resolution fails sometimes.

Some other dependencies like `aws-requests-auth` are bringing in `requests` as an optional dependency, but they are not pinning the minimum version of `requests` and are installing `requests==0.14.0` which has a potential CVE. Even this does not affect customers, because it is a development dependency, it is important to fix.

### User experience

No changes for customer experience.

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] [Meet tenets criteria](https://docs.powertools.aws.dev/lambda/python/#tenets)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented
* [x] PR title follows [conventional commit semantics](https://github.com/aws-powertools/powertools-lambda-python/blob/develop/.github/semantic.yml)

<details>
<summary>Is this a breaking change?</summary>

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
