### PR TITLE
fix(event_handler): fix forward references resolution in OpenAPI

### DIFF
--- a/aws_lambda_powertools/event_handler/openapi/dependant.py
+++ b/aws_lambda_powertools/event_handler/openapi/dependant.py
@@ -106,7 +106,7 @@ def get_typed_signature(call: Callable[..., Any]) -> inspect.Signature:
     signature = inspect.signature(call)
 
     # Gets the global namespace for the call. This is used to resolve forward references.
-    globalns = getattr(call, "__global__", {})
+    globalns = getattr(call, "__globals__", {})
 
     typed_params = [
         inspect.Parameter(


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
**Issue number: #5884**

## Summary

### Changes

Fix type resolution for forward references in `Annotated` type hints to correctly handle body parameters in API Gateway handlers. Currently, when using quoted type annotations with `Annotated` and `Body`, parameters are incorrectly treated as query parameters instead of body parameters due to improper globals resolution in `get_typed_signature()`.

The fix updates the globals retrieval logic to properly resolve forward references in type annotations.

### User experience

**Before:**
```python
@app.post("/users")
def create_user(
    user_create_request: 'Annotated[UserCreate, Body()]',
) -> dict:
    return {"message": "success"}
```
Results in a 422 error treating `user_create_request` as a missing query parameter, even when the JSON body is correctly provided.

**After:**
```python
# Same code works as expected
```
Correctly identifies the parameter as a body parameter and properly validates the incoming JSON request body.

## Checklist

* [x] [Meet tenets criteria](https://docs.powertools.aws.dev/lambda/python/#tenets)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [ ] Changes are documented
* [x] PR title follows [conventional commit semantics](https://github.com/aws-powertools/powertools-lambda-python/blob/develop/.github/semantic.yml)

<details>
<summary>Is this a breaking change?</summary>

No, this is a bug fix that restores expected functionality for forward references in type annotations.

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.

