### PR TITLE
fix(event_handler): add tests for PEP 563 compatibility with OpenAPI

### DIFF
--- a/tests/e2e/event_handler/handlers/openapi_handler_with_pep563.py
+++ b/tests/e2e/event_handler/handlers/openapi_handler_with_pep563.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+from pydantic import BaseModel, Field
+
+from aws_lambda_powertools.event_handler import (
+    APIGatewayRestResolver,
+)
+
+
+class Todo(BaseModel):
+    id: int = Field(examples=[1])
+    title: str = Field(examples=["Example 1"])
+    priority: float = Field(examples=[0.5])
+    completed: bool = Field(examples=[True])
+
+
+app = APIGatewayRestResolver(enable_validation=True)
+
+
+@app.get("/openapi_schema_with_pep563")
+def openapi_schema():
+    return app.get_openapi_json_schema(
+        title="Powertools e2e API",
+        version="1.0.0",
+        description="This is a sample Powertools e2e API",
+        openapi_extensions={"x-amazon-apigateway-gateway-responses": {"DEFAULT_4XX"}},
+    )
+
+
+@app.get("/")
+def handler() -> Todo:
+    return Todo(id=0, title="", priority=0.0, completed=False)
+
+
+def lambda_handler(event, context):
+    return app.resolve(event, context)

--- a/tests/e2e/event_handler/infrastructure.py
+++ b/tests/e2e/event_handler/infrastructure.py
@@ -18,7 +18,13 @@ class EventHandlerStack(BaseInfrastructure):
         functions = self.create_lambda_functions(function_props={"timeout": Duration.seconds(10)})
 
         self._create_alb(function=[functions["AlbHandler"], functions["AlbHandlerWithBodyNone"]])
-        self._create_api_gateway_rest(function=[functions["ApiGatewayRestHandler"], functions["OpenapiHandler"]])
+        self._create_api_gateway_rest(
+            function=[
+                functions["ApiGatewayRestHandler"],
+                functions["OpenapiHandler"],
+                functions["OpenapiHandlerWithPep563"],
+            ],
+        )
         self._create_api_gateway_http(function=functions["ApiGatewayHttpHandler"])
         self._create_lambda_function_url(function=functions["LambdaFunctionUrlHandler"])
 
@@ -91,6 +97,9 @@ class EventHandlerStack(BaseInfrastructure):
 
         openapi_schema = apigw.root.add_resource("openapi_schema")
         openapi_schema.add_method("GET", apigwv1.LambdaIntegration(function[1], proxy=True))
+
+        openapi_schema = apigw.root.add_resource("openapi_schema_with_pep563")
+        openapi_schema.add_method("GET", apigwv1.LambdaIntegration(function[2], proxy=True))
 
         CfnOutput(self.stack, "APIGatewayRestUrl", value=apigw.url)
 

--- a/tests/e2e/event_handler/test_openapi.py
+++ b/tests/e2e/event_handler/test_openapi.py
@@ -25,3 +25,20 @@ def test_get_openapi_schema(apigw_rest_endpoint):
     assert "Powertools e2e API" in response.text
     assert "x-amazon-apigateway-gateway-responses" in response.text
     assert response.status_code == 200
+
+
+def test_get_openapi_schema_with_pep563(apigw_rest_endpoint):
+    # GIVEN
+    url = f"{apigw_rest_endpoint}openapi_schema_with_pep563"
+
+    # WHEN
+    response = data_fetcher.get_http_response(
+        Request(
+            method="GET",
+            url=url,
+        ),
+    )
+
+    assert "Powertools e2e API" in response.text
+    assert "x-amazon-apigateway-gateway-responses" in response.text
+    assert response.status_code == 200

--- a/tests/functional/event_handler/_pydantic/test_openapi_with_pep563.py
+++ b/tests/functional/event_handler/_pydantic/test_openapi_with_pep563.py
@@ -1,0 +1,120 @@
+from __future__ import annotations
+
+from pydantic import BaseModel, Field
+from typing_extensions import Annotated
+
+from aws_lambda_powertools.event_handler.api_gateway import APIGatewayRestResolver
+from aws_lambda_powertools.event_handler.openapi.models import (
+    ParameterInType,
+    Schema,
+)
+from aws_lambda_powertools.event_handler.openapi.params import (
+    Body,
+    Query,
+)
+
+JSON_CONTENT_TYPE = "application/json"
+
+
+class Todo(BaseModel):
+    id: int = Field(examples=[1])
+    title: str = Field(examples=["Example 1"])
+    priority: float = Field(examples=[0.5])
+    completed: bool = Field(examples=[True])
+
+
+def test_openapi_with_pep563_and_input_model():
+    app = APIGatewayRestResolver()
+
+    @app.get("/users", summary="Get Users", operation_id="GetUsers", description="Get paginated users", tags=["Users"])
+    def handler(
+        count: Annotated[
+            int,
+            Query(gt=0, lt=100, examples=["Example 1"]),
+        ] = 1,
+    ):
+        print(count)
+        raise NotImplementedError()
+
+    schema = app.get_openapi_schema()
+
+    get = schema.paths["/users"].get
+    assert len(get.parameters) == 1
+    assert get.summary == "Get Users"
+    assert get.operationId == "GetUsers"
+    assert get.description == "Get paginated users"
+    assert get.tags == ["Users"]
+
+    parameter = get.parameters[0]
+    assert parameter.required is False
+    assert parameter.name == "count"
+    assert parameter.in_ == ParameterInType.query
+    assert parameter.schema_.type == "integer"
+    assert parameter.schema_.default == 1
+    assert parameter.schema_.title == "Count"
+    assert parameter.schema_.exclusiveMinimum == 0
+    assert parameter.schema_.exclusiveMaximum == 100
+    assert len(parameter.schema_.examples) == 1
+    assert parameter.schema_.examples[0] == "Example 1"
+
+
+def test_openapi_with_pep563_and_output_model():
+
+    app = APIGatewayRestResolver()
+
+    @app.get("/")
+    def handler() -> Todo:
+        return Todo(id=0, title="", priority=0.0, completed=False)
+
+    schema = app.get_openapi_schema()
+    assert "Todo" in schema.components.schemas
+    todo_schema = schema.components.schemas["Todo"]
+    assert isinstance(todo_schema, Schema)
+
+    assert "id" in todo_schema.properties
+    id_property = todo_schema.properties["id"]
+    assert id_property.examples == [1]
+
+    assert "title" in todo_schema.properties
+    title_property = todo_schema.properties["title"]
+    assert title_property.examples == ["Example 1"]
+
+    assert "priority" in todo_schema.properties
+    priority_property = todo_schema.properties["priority"]
+    assert priority_property.examples == [0.5]
+
+    assert "completed" in todo_schema.properties
+    completed_property = todo_schema.properties["completed"]
+    assert completed_property.examples == [True]
+
+
+def test_openapi_with_pep563_and_annotated_body():
+
+    app = APIGatewayRestResolver()
+
+    @app.post("/todo")
+    def create_todo(
+        todo_create_request: Annotated[Todo, Body(title="New Todo")],
+    ) -> dict:
+        return {"message": f"Created todo {todo_create_request.title}"}
+
+    schema = app.get_openapi_schema()
+    assert "Todo" in schema.components.schemas
+    todo_schema = schema.components.schemas["Todo"]
+    assert isinstance(todo_schema, Schema)
+
+    assert "id" in todo_schema.properties
+    id_property = todo_schema.properties["id"]
+    assert id_property.examples == [1]
+
+    assert "title" in todo_schema.properties
+    title_property = todo_schema.properties["title"]
+    assert title_property.examples == ["Example 1"]
+
+    assert "priority" in todo_schema.properties
+    priority_property = todo_schema.properties["priority"]
+    assert priority_property.examples == [0.5]
+
+    assert "completed" in todo_schema.properties
+    completed_property = todo_schema.properties["completed"]
+    assert completed_property.examples == [True]


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
**Issue number:** #5098 

## Summary

### Changes

This pull request add tests to make sure that OpenAPI is working when data validation feature of event resolvers and the use of `from __future__ import annotations`, as introduced by **PEP 563** (Postponed Evaluation of Annotations).  

**Some additional information**
1. This [PR](https://github.com/aws-powertools/powertools-lambda-python/pull/5885) fix a bug when getting types from `__globals__`.
2. **Runtime Optimization:** There was a need to import annotations to ensure type definitions are ignored at runtime, aligning with PEP 563's goals.  
3. We advice to use Pydantic 2.10+ at least.

While this PR make sure this is working, I'm working in additional PR's to make sure Powertools is full compatible with Pydantic 2.10+.

### User experience

Before this PR the following code could fail with:

```
pydantic.errors.PydanticUserError: `TypeAdapter[typing.Annotated[ForwardRef('Input'), Query(PydanticUndefined)]]` is not fully defined; you should define `typing.Annotated[ForwardRef('Input'), Query(PydanticUndefined)]` and all referenced types, then call `.rebuild()` on the instance.
```

```python
from __future__ import annotations

import json
from typing import TYPE_CHECKING

from aws_lambda_powertools.event_handler import APIGatewayRestResolver
from pydantic import BaseModel

if TYPE_CHECKING:
    # Actual use case imports boto stubs
    # These are giant pyi files that shouldn't be shipped at runtime
    from typing import Iterable


class Input(BaseModel):
    email: str

class Output(BaseModel):
    response: str

app = APIGatewayRestResolver(enable_validation=True)


@app.post("/hello")
def hello(event: Input) -> Output:
    return Output(response=f"Hello {event.email}")


def func(a: Iterable[int]): ...


event = {
    "path": "/hello",
    "httpMethod": "POST",
    "requestContext": {
        "requestId": "227b78aa-779d-47d4-a48e-ce62120393b8",
    },
    "body": json.dumps(
        {
            "email": "hello@test.com",
        }
    ),
}

print(app.resolve(event, {}))
```
## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] [Meet tenets criteria](https://docs.powertools.aws.dev/lambda/python/#tenets)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented
* [x] PR title follows [conventional commit semantics](https://github.com/aws-powertools/powertools-lambda-python/blob/develop/.github/semantic.yml)

<details>
<summary>Is this a breaking change?</summary>

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
