### PR TITLE
feat(parser): add AWS Transfer Family model

### DIFF
--- a/aws_lambda_powertools/utilities/parser/models/__init__.py
+++ b/aws_lambda_powertools/utilities/parser/models/__init__.py
@@ -109,6 +109,7 @@ from .ses import (
 )
 from .sns import SnsModel, SnsNotificationModel, SnsRecordModel
 from .sqs import SqsAttributesModel, SqsModel, SqsMsgAttributeModel, SqsRecordModel
+from .transfer_family import TransferFamily
 from .vpc_lattice import VpcLatticeModel
 from .vpc_latticev2 import VpcLatticeV2Model
 
@@ -179,6 +180,7 @@ __all__ = [
     "SqsAttributesModel",
     "S3SqsEventNotificationModel",
     "S3SqsEventNotificationRecordModel",
+    "TransferFamily",
     "APIGatewayProxyEventModel",
     "APIGatewayEventRequestContext",
     "APIGatewayEventAuthorizer",

--- a/aws_lambda_powertools/utilities/parser/models/transfer_family.py
+++ b/aws_lambda_powertools/utilities/parser/models/transfer_family.py
@@ -1,0 +1,12 @@
+from typing import Literal, Optional
+
+from pydantic import BaseModel, Field
+from pydantic.networks import IPvAnyAddress
+
+
+class TransferFamily(BaseModel):
+    username: str
+    password: Optional[str] = None
+    protocol: Literal["SFTP", "FTP", "FTPS"]
+    server_id: str = Field(..., alias="serverId")
+    source_ip: IPvAnyAddress = Field(..., alias="sourceIp")

--- a/docs/utilities/parser.md
+++ b/docs/utilities/parser.md
@@ -108,8 +108,8 @@ The example above uses `SqsModel`. Other built-in models can be found below.
 | **ApiGatewayAuthorizerRequest**             | Lambda Event Source payload for Amazon API Gateway Lambda Authorizer with Request     |
 | **APIGatewayProxyEventV2Model**             | Lambda Event Source payload for Amazon API Gateway v2 payload                         |
 | **ApiGatewayAuthorizerRequestV2**           | Lambda Event Source payload for Amazon API Gateway v2 Lambda Authorizer               |
-| **APIGatewayWebSocketMessageEventModel** | Lambda Event Source payload for Amazon API Gateway WebSocket API message body         |
-| **APIGatewayWebSocketConnectEventModel** | Lambda Event Source payload for Amazon API Gateway WebSocket API $connect message     |
+| **APIGatewayWebSocketMessageEventModel**    | Lambda Event Source payload for Amazon API Gateway WebSocket API message body         |
+| **APIGatewayWebSocketConnectEventModel**    | Lambda Event Source payload for Amazon API Gateway WebSocket API $connect message     |
 | **APIGatewayWebSocketDisconnectEventModel** | Lambda Event Source payload for Amazon API Gateway WebSocket API $disconnect message  |
 | **BedrockAgentEventModel**                  | Lambda Event Source payload for Bedrock Agents                                        |
 | **CloudFormationCustomResourceCreateModel** | Lambda Event Source payload for AWS CloudFormation `CREATE` operation                 |
@@ -132,6 +132,7 @@ The example above uses `SqsModel`. Other built-in models can be found below.
 | **SesModel**                                | Lambda Event Source payload for Amazon Simple Email Service                           |
 | **SnsModel**                                | Lambda Event Source payload for Amazon Simple Notification Service                    |
 | **SqsModel**                                | Lambda Event Source payload for Amazon SQS                                            |
+| **TransferFamily**                          | Lambda Event Source payload for AWS Transfer Family custom identity provider          |
 | **VpcLatticeModel**                         | Lambda Event Source payload for Amazon VPC Lattice                                    |
 | **VpcLatticeV2Model**                       | Lambda Event Source payload for Amazon VPC Lattice v2 payload                         |
 

--- a/tests/events/TransferFamily.json
+++ b/tests/events/TransferFamily.json
@@ -1,0 +1,7 @@
+{
+    "username": "value",
+    "password": "value",
+    "protocol": "SFTP",
+    "serverId": "s-abcd123456",
+    "sourceIp": "192.168.0.100"
+}

--- a/tests/unit/parser/_pydantic/test_aws_transfer_family.py
+++ b/tests/unit/parser/_pydantic/test_aws_transfer_family.py
@@ -1,0 +1,25 @@
+from aws_lambda_powertools.utilities.parser.models import TransferFamily
+from tests.functional.utils import load_event
+
+
+def test_aws_transfer_family_model():
+    raw_event = load_event("TransferFamily.json")
+    parsed_event = TransferFamily(**raw_event)
+
+    assert parsed_event.username == raw_event["username"]
+    assert parsed_event.password == raw_event["password"]
+    assert parsed_event.protocol == raw_event["protocol"]
+    assert parsed_event.server_id == raw_event["serverId"]
+    assert str(parsed_event.source_ip) == raw_event["sourceIp"]
+
+
+def test_aws_transfer_family_model_without_password():
+    raw_event = load_event("TransferFamily.json")
+    del raw_event["password"]
+    parsed_event = TransferFamily(**raw_event)
+
+    assert parsed_event.username == raw_event["username"]
+    assert parsed_event.password is None
+    assert parsed_event.protocol == raw_event["protocol"]
+    assert parsed_event.server_id == raw_event["serverId"]
+    assert str(parsed_event.source_ip) == raw_event["sourceIp"]


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
**Issue number:** #5903 

## Summary

### Changes

This PR adds a model to parser AWS Transfer Family events for FTP, FTPS, SFTP

### User experience

```python
from aws_lambda_powertools.utilities.parser import parse
from aws_lambda_powertools.utilities.parser.models import TransferFamily
from aws_lambda_powertools.utilities.typing import LambdaContext


def lambda_handler(event: TransferFamily, context: LambdaContext) -> list:
    parsed_event = parse(model=TransferFamily, event=event)

    ...

```
## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] [Meet tenets criteria](https://docs.powertools.aws.dev/lambda/python/#tenets)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented
* [x] PR title follows [conventional commit semantics](https://github.com/aws-powertools/powertools-lambda-python/blob/develop/.github/semantic.yml)

<details>
<summary>Is this a breaking change?</summary>

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
