### PR TITLE
docs(parser): improve documentation with Pydantic best practices

### DIFF
--- a/docs/utilities/parser.md
+++ b/docs/utilities/parser.md
@@ -259,7 +259,7 @@ If you run using a test event `{"message": "hello universe"}` you should expect 
 
 `model_validator` can help when you have a complex validation mechanism. For example finding whether data has been omitted or comparing field values.
 
-???+ tip For users of `root_validator` (deprecated as of version 3.0.0), it is recommended to use `model_validator` instead.
+!!! tip "If you are still using the deprecated `root_validator` function, switch to `model_validator` for the latest Pydantic functionality."
 
 ```python title="model_validator.py" hl_lines="1 12-17"
 --8<-- "examples/parser/src/model_validator.py"

--- a/docs/utilities/parser.md
+++ b/docs/utilities/parser.md
@@ -259,6 +259,8 @@ If you run using a test event `{"message": "hello universe"}` you should expect 
 
 `model_validator` can help when you have a complex validation mechanism. For example finding whether data has been omitted or comparing field values.
 
+???+ tip For users of `root_validator` (deprecated as of version 3.0.0), it is recommended to use `model_validator` instead.
+
 ```python title="model_validator.py" hl_lines="1 12-17"
 --8<-- "examples/parser/src/model_validator.py"
 ```


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
**Issue number:** #5926 

## Summary

`root_validator` (deprecated as of version 3.0.0) but the doc is outdated, the `root_validator` doc still appears on [3.2.0](https://docs.powertools.aws.dev/lambda/python/3.2.0/utilities/parser/#bringing-your-own-envelope).

### Changes

If customers are migrating their library from version 2, refer to the latest documentation for updated methods compatible with `root_validator`

### User experience

N/A

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] [Meet tenets criteria](https://docs.powertools.aws.dev/lambda/python/#tenets)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented
* [x] PR title follows [conventional commit semantics](https://github.com/aws-powertools/powertools-lambda-python/blob/develop/.github/semantic.yml)

<details>
<summary>Is this a breaking change?</summary>
nope

**RFC issue number**:

Checklist:

* [ x ] Migration process documented
* [ x ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
