### PR TITLE
fix(event_handler): fixes typo in variable name `fronzen_openapi_extensions`

### DIFF
--- a/aws_lambda_powertools/event_handler/api_gateway.py
+++ b/aws_lambda_powertools/event_handler/api_gateway.py
@@ -2521,7 +2521,7 @@ class Router(BaseRouter):
             frozen_responses = _FrozenDict(responses) if responses else None
             frozen_tags = frozenset(tags) if tags else None
             frozen_security = _FrozenListDict(security) if security else None
-            fronzen_openapi_extensions = _FrozenDict(openapi_extensions) if openapi_extensions else None
+            frozen_openapi_extensions = _FrozenDict(openapi_extensions) if openapi_extensions else None
 
             route_key = (
                 rule,
@@ -2537,7 +2537,7 @@ class Router(BaseRouter):
                 operation_id,
                 include_in_schema,
                 frozen_security,
-                fronzen_openapi_extensions,
+                frozen_openapi_extensions,
                 deprecated,
             )
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
**Issue number:** #5927

## Summary

### Changes

This pull request fixes a typo in the code. The word `fronzen_openapi_extensions` was corrected to `frozen_openapi_extensions`.

### User experience

Before: The typo `fronzen_openapi_extensions` was present in the code, which might cause confusion.  
After: The typo has been corrected to `frozen_openapi_extensions`, improving code readability and consistency.

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] [Meet tenets criteria](https://docs.powertools.aws.dev/lambda/python/#tenets)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented
* [x] PR title follows [conventional commit semantics](https://github.com/aws-powertools/powertools-lambda-python/blob/develop/.github/semantic.yml)

<details>
<summary>Is this a breaking change?</summary>

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
