### PR TITLE
fix(logger): child logger must respect log level

### DIFF
--- a/aws_lambda_powertools/logging/logger.py
+++ b/aws_lambda_powertools/logging/logger.py
@@ -285,7 +285,11 @@ class Logger:
         #   b) different sampling mechanisms
         #   c) multiple messages from being logged as handlers can be duplicated
         is_logger_preconfigured = getattr(self._logger, LOGGER_ATTRIBUTE_PRECONFIGURED, False)
-        if self.child or is_logger_preconfigured:
+        if self.child:
+            self.setLevel(log_level)
+            return
+
+        if is_logger_preconfigured:
             return
 
         self.setLevel(log_level)

--- a/tests/functional/logger/required_dependencies/test_logger.py
+++ b/tests/functional/logger/required_dependencies/test_logger.py
@@ -1217,3 +1217,18 @@ def test_append_context_keys_with_formatter(stdout, service_name):
     # THEN the context keys should not persist
     current_keys = logger.get_current_keys()
     assert current_keys == {}
+
+
+def test_logger_change_level_child_logger(stdout, service_name):
+    # GIVEN a new Logger and child Logger
+    logger = Logger(service=service_name, stream=stdout)
+    child_logger = Logger(service=service_name, child=True, stream=stdout, level="DEBUG")
+
+    # WHEN we emit logs for both in DEBUG level
+    logger.debug("PARENT")
+    child_logger.debug("CHILD")
+
+    # THEN only child log must emit log due to level
+    logs = list(stdout.getvalue().strip().split("\n"))
+    assert len(logs) == 1
+    assert "service" in logs[0]


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
**Issue number:** #5949 

## Summary

### Changes

This PR addresses an issue where child loggers are unable to set different log levels from their parent loggers. 

Currently, when creating a child logger using Powertools, the log level set for the child logger is not respected. This limits the ability to have different parts of an application log at different levels of verbosity.

## Changes
- Modified the `Logger` class initialization to check if it's a child logger
- If it's a child logger, set the log level as specified in the constructor
- Add tests

## Example
```python
from aws_lambda_powertools import Logger

parent_logger = Logger(service="payment", level="INFO")
child_logger = Logger(service="payment", child=True, level="DEBUG")

parent_logger.debug("This won't be logged")  # Won't be logged (INFO level)
child_logger.debug("This will be logged")    # Will be logged (DEBUG level)
```

## Backwards Compatibility
This change is backwards compatible. Existing code using Powertools loggers will continue to work as before, with the added benefit of respecting log levels for child loggers when explicitly set.

### User experience

> Please share what the user experience looks like before and after this change

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] [Meet tenets criteria](https://docs.powertools.aws.dev/lambda/python/#tenets)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented
* [x] PR title follows [conventional commit semantics](https://github.com/aws-powertools/powertools-lambda-python/blob/develop/.github/semantic.yml)

<details>
<summary>Is this a breaking change?</summary>

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
