### PR TITLE
docs(api): migrating the validation utility to mkdocstrings

### DIFF
--- a/aws_lambda_powertools/utilities/validation/__init__.py
+++ b/aws_lambda_powertools/utilities/validation/__init__.py
@@ -1,5 +1,7 @@
 """
 Simple validator to enforce incoming/outgoing event conforms with JSON Schema
+!!! abstract "Usage Documentation"
+    [`Validation`](../utilities/validation.md)
 """
 
 from .exceptions import (

--- a/aws_lambda_powertools/utilities/validation/exceptions.py
+++ b/aws_lambda_powertools/utilities/validation/exceptions.py
@@ -19,7 +19,7 @@ class SchemaValidationError(Exception):
         rule: str | None = None,
         rule_definition: Any | None = None,
     ):
-        """
+        """When serialization fail schema validation
 
         Parameters
         ----------

--- a/docs/api_doc/validation.md
+++ b/docs/api_doc/validation.md
@@ -1,0 +1,2 @@
+<!-- markdownlint-disable MD043 MD041 -->
+::: aws_lambda_powertools.utilities.validation

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -62,6 +62,8 @@ nav:
           #     - Overview: contributing/tracks/overview.md
           #     - Casual to regular contributor: contributing/tracks/casual_regular_contributor.md
           #     - Customer to advocate: contributing/tracks/customer_advocate.md
+  - API Documentation:
+      - Validation: api_doc/validation.md
 
 theme:
   name: material
@@ -144,22 +146,19 @@ plugins:
           import:
             - https://docs.python.org/3/objects.inv
           options:
-            # General
-            allow_inspection: true
-            show_source: true
-            show_bases: true
             # Headings
-            heading_level: 2
-            #show_root_heading: false
+            #heading_level: 2
+            #show_root_heading: true
             #show_root_toc_entry: true
             #show_root_full_path: true
             #show_root_members_full_path: false
             #show_object_full_path: false
-            #show_category_heading: true
+            show_category_heading: false
             # Members
-            filters: ["!^_[^_]"]
+            filters: ["!^_"]
             group_by_category: true
-            show_submodules: false
+            members_order: alphabetical
+            show_submodules: true
             # Docstrings
             docstring_style: numpy
             docstring_options:
@@ -168,10 +167,10 @@ plugins:
             merge_init_into_class: true
             show_if_no_docstring: false
             # Signature
-            annotations_path: brief
             show_signature: true
             show_signature_annotations: true
             separate_signature: true
+            summary: true
 
 extra_css:
   - stylesheets/extra.css


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
**Issue number:** #5958 

## Summary

### Changes

Migrating the validation utility to mkdocstrings

### User experience

![image](https://github.com/user-attachments/assets/c2d5c720-eade-4237-aed3-7beeccc321c4)

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] [Meet tenets criteria](https://docs.powertools.aws.dev/lambda/python/#tenets)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented
* [x] PR title follows [conventional commit semantics](https://github.com/aws-powertools/powertools-lambda-python/blob/develop/.github/semantic.yml)

<details>
<summary>Is this a breaking change?</summary>

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
