### PR TITLE
docs(api): migrating the streaming utility to mkdocstrings

### DIFF
--- a/aws_lambda_powertools/utilities/streaming/__init__.py
+++ b/aws_lambda_powertools/utilities/streaming/__init__.py
@@ -1,3 +1,9 @@
+"""
+The streaming utility handles datasets larger than the available memory as streaming data.
+!!! abstract "Usage Documentation"
+    [`Streaming`](../utilities/streaming.md)
+"""
+
 from aws_lambda_powertools.utilities.streaming.s3_object import S3Object
 
 __all__ = ["S3Object"]

--- a/aws_lambda_powertools/utilities/typing/__init__.py
+++ b/aws_lambda_powertools/utilities/typing/__init__.py
@@ -1,5 +1,7 @@
 """
 Typing for developer ease in the IDE
+!!! abstract "Usage Documentation"
+    [`Typing`](../utilities/typing.md)
 """
 
 from .lambda_context import LambdaContext

--- a/docs/api_doc/streaming.md
+++ b/docs/api_doc/streaming.md
@@ -1,0 +1,5 @@
+<!-- markdownlint-disable MD043 MD041 -->
+::: aws_lambda_powertools.utilities.streaming.s3_object
+::: aws_lambda_powertools.utilities.streaming.transformations.csv
+::: aws_lambda_powertools.utilities.streaming.transformations.gzip
+::: aws_lambda_powertools.utilities.streaming.transformations.zip

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -63,6 +63,7 @@ nav:
           #     - Casual to regular contributor: contributing/tracks/casual_regular_contributor.md
           #     - Customer to advocate: contributing/tracks/customer_advocate.md
   - API Documentation:
+      - Streaming: api_doc/streaming.md
       - Typing: api_doc/typing.md
       - Validation: api_doc/validation.md
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
**Issue number:** #5974 

## Summary

### Changes

Update streaming utility comments and docstrings to add support for mkdocstrings.

### User experience

![image](https://github.com/user-attachments/assets/bd0feb08-55d2-4ec9-823d-8a4bf65d061c)

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] [Meet tenets criteria](https://docs.powertools.aws.dev/lambda/python/#tenets)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented
* [x] PR title follows [conventional commit semantics](https://github.com/aws-powertools/powertools-lambda-python/blob/develop/.github/semantic.yml)

<details>
<summary>Is this a breaking change?</summary>

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
