### PR TITLE
docs(api): migrating the parser utility to mkdocstrings

### DIFF
--- a/aws_lambda_powertools/utilities/parser/parser.py
+++ b/aws_lambda_powertools/utilities/parser/parser.py
@@ -1,3 +1,10 @@
+"""
+The Parser utility simplifies data parsing and validation using Pydantic. It allows you to define data models
+in pure Python classes, parse and validate incoming events, and extract only the data you need.
+!!! abstract "Usage Documentation"
+    [`Parser`](../utilities/parser.md)
+"""
+
 from __future__ import annotations
 
 import logging

--- a/docs/api_doc/parser.md
+++ b/docs/api_doc/parser.md
@@ -1,0 +1,2 @@
+<!-- markdownlint-disable MD043 MD041 -->
+::: aws_lambda_powertools.utilities.parser.parser

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -63,6 +63,7 @@ nav:
           #     - Casual to regular contributor: contributing/tracks/casual_regular_contributor.md
           #     - Customer to advocate: contributing/tracks/customer_advocate.md
   - API Documentation:
+      - Parser: api_doc/parser.md
       - Streaming: api_doc/streaming.md
       - Typing: api_doc/typing.md
       - Validation: api_doc/validation.md


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
**Issue number:** #5983 

## Summary

### Changes

Update parser utility comments and docstrings to add support for mkdocstrings.

### User experience

![image](https://github.com/user-attachments/assets/8a183081-34a9-4302-90c1-62d4c6b445ab)

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] [Meet tenets criteria](https://docs.powertools.aws.dev/lambda/python/#tenets)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented
* [x] PR title follows [conventional commit semantics](https://github.com/aws-powertools/powertools-lambda-python/blob/develop/.github/semantic.yml)

<details>
<summary>Is this a breaking change?</summary>

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
