### PR TITLE
docs(api): migrating the parameters utility to mkdocstrings

### DIFF
--- a/docs/api_doc/parameters/appconfig.md
+++ b/docs/api_doc/parameters/appconfig.md
@@ -1,0 +1,2 @@
+<!-- markdownlint-disable MD043 MD041 -->
+::: aws_lambda_powertools.utilities.parameters.appconfig

--- a/docs/api_doc/parameters/base.md
+++ b/docs/api_doc/parameters/base.md
@@ -1,0 +1,2 @@
+<!-- markdownlint-disable MD043 MD041 -->
+::: aws_lambda_powertools.utilities.parameters.base

--- a/docs/api_doc/parameters/dynamodb.md
+++ b/docs/api_doc/parameters/dynamodb.md
@@ -1,0 +1,2 @@
+<!-- markdownlint-disable MD043 MD041 -->
+::: aws_lambda_powertools.utilities.parameters.dynamodb

--- a/docs/api_doc/parameters/secrets.md
+++ b/docs/api_doc/parameters/secrets.md
@@ -1,0 +1,2 @@
+<!-- markdownlint-disable MD043 MD041 -->
+::: aws_lambda_powertools.utilities.parameters.secrets

--- a/docs/api_doc/parameters/ssm.md
+++ b/docs/api_doc/parameters/ssm.md
@@ -1,0 +1,2 @@
+<!-- markdownlint-disable MD043 MD041 -->
+::: aws_lambda_powertools.utilities.parameters.ssm

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -63,6 +63,12 @@ nav:
           #     - Casual to regular contributor: contributing/tracks/casual_regular_contributor.md
           #     - Customer to advocate: contributing/tracks/customer_advocate.md
   - API Documentation:
+      - Parameters:
+          - Base: api_doc/parameters/base.md
+          - AppConfig: api_doc/parameters/appconfig.md
+          - DynamoDB: api_doc/parameters/dynamodb.md
+          - SSM: api_doc/parameters/ssm.md
+          - Secrets: api_doc/parameters/secrets.md
       - Parser: api_doc/parser.md
       - Streaming: api_doc/streaming.md
       - Typing: api_doc/typing.md


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
**Issue number:** #5984 

## Summary

### Changes

Update parameters utility comments and docstrings to add support for mkdocstrings.

### User experience

![image](https://github.com/user-attachments/assets/18c2b7ff-ba66-429c-8e71-176a6831ab29)

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] [Meet tenets criteria](https://docs.powertools.aws.dev/lambda/python/#tenets)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented
* [x] PR title follows [conventional commit semantics](https://github.com/aws-powertools/powertools-lambda-python/blob/develop/.github/semantic.yml)

<details>
<summary>Is this a breaking change?</summary>

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
