### PR TITLE
docs(api): migrating the jmespath utility to mkdocstrings

### DIFF
--- a/aws_lambda_powertools/utilities/jmespath_utils/__init__.py
+++ b/aws_lambda_powertools/utilities/jmespath_utils/__init__.py
@@ -1,3 +1,8 @@
+"""
+Built-in JMESPath Functions to easily deserialize common encoded JSON payloads in Lambda functions.
+!!! abstract "Usage Documentation"
+    [`JMESPath Functions`](../utilities/jmespath_functions.md)
+"""
 from __future__ import annotations
 
 import base64
@@ -42,7 +47,7 @@ def query(data: dict | str, envelope: str, jmespath_options: dict | None = None)
 
     Built-in JMESPath functions include: powertools_json, powertools_base64, powertools_base64_gzip
 
-    Examples
+    Example
     --------
 
     **Deserialize JSON string and extracts data from body key**

--- a/aws_lambda_powertools/utilities/parameters/base.py
+++ b/aws_lambda_powertools/utilities/parameters/base.py
@@ -1,5 +1,7 @@
 """
 Base for Parameter providers
+!!! abstract "Usage Documentation"
+    [`Parameters`](../utilities/parameters.md)
 """
 
 from __future__ import annotations

--- a/docs/api_doc/jmespath_functions.md
+++ b/docs/api_doc/jmespath_functions.md
@@ -1,0 +1,2 @@
+<!-- markdownlint-disable MD043 MD041 -->
+::: aws_lambda_powertools.utilities.jmespath_utils

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -63,6 +63,7 @@ nav:
           #     - Casual to regular contributor: contributing/tracks/casual_regular_contributor.md
           #     - Customer to advocate: contributing/tracks/customer_advocate.md
   - API Documentation:
+      - JMESPath Functions: api_doc/jmespath_functions.md
       - Parameters:
           - Base: api_doc/parameters/base.md
           - AppConfig: api_doc/parameters/appconfig.md


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
**Issue number:** #5985 

## Summary

### Changes

Update JMESPath Functions utility comments and docstrings to add support for mkdocstrings.

### User experience

![image](https://github.com/user-attachments/assets/43e598ca-a0ee-4beb-bfef-9ec183a35b8d)

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] [Meet tenets criteria](https://docs.powertools.aws.dev/lambda/python/#tenets)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented
* [x] PR title follows [conventional commit semantics](https://github.com/aws-powertools/powertools-lambda-python/blob/develop/.github/semantic.yml)

<details>
<summary>Is this a breaking change?</summary>

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
