### PR TITLE
docs(api): migrating the idempotency utility to mkdocstrings

### DIFF
--- a/aws_lambda_powertools/utilities/idempotency/base.py
+++ b/aws_lambda_powertools/utilities/idempotency/base.py
@@ -1,3 +1,9 @@
+"""
+Base for Idempotency utility
+!!! abstract "Usage Documentation"
+    [`Idempotency`](../../utilities/idempotency.md)
+"""
+
 from __future__ import annotations
 
 import datetime

--- a/aws_lambda_powertools/utilities/idempotency/idempotency.py
+++ b/aws_lambda_powertools/utilities/idempotency/idempotency.py
@@ -61,20 +61,20 @@ def idempotent(
     key_prefix: str | Optional
         Custom prefix for idempotency key: key_prefix#hash
 
-    Examples
+    Example
     --------
     **Processes Lambda's event in an idempotent manner**
 
-        >>> from aws_lambda_powertools.utilities.idempotency import (
-        >>>    idempotent, DynamoDBPersistenceLayer, IdempotencyConfig
-        >>> )
-        >>>
-        >>> idem_config=IdempotencyConfig(event_key_jmespath="body")
-        >>> persistence_layer = DynamoDBPersistenceLayer(table_name="idempotency_store")
-        >>>
-        >>> @idempotent(config=idem_config, persistence_store=persistence_layer)
-        >>> def handler(event, context):
-        >>>     return {"StatusCode": 200}
+        from aws_lambda_powertools.utilities.idempotency import (
+           idempotent, DynamoDBPersistenceLayer, IdempotencyConfig
+        )
+
+        idem_config=IdempotencyConfig(event_key_jmespath="body")
+        persistence_layer = DynamoDBPersistenceLayer(table_name="idempotency_store")
+
+        @idempotent(config=idem_config, persistence_store=persistence_layer)
+        def handler(event, context):
+            return {"StatusCode": 200}
     """
 
     # Skip idempotency controls when POWERTOOLS_IDEMPOTENCY_DISABLED has a truthy value
@@ -136,7 +136,7 @@ def idempotent_function(
     key_prefix: str | Optional
         Custom prefix for idempotency key: key_prefix#hash
 
-    Examples
+    Example
     --------
     **Processes an order in an idempotent manner**
 

--- a/aws_lambda_powertools/utilities/idempotency/persistence/dynamodb.py
+++ b/aws_lambda_powertools/utilities/idempotency/persistence/dynamodb.py
@@ -76,7 +76,7 @@ class DynamoDBPersistenceLayer(BasePersistenceLayer):
         boto3_client : DynamoDBClient, optional
             Boto3 DynamoDB Client to use, boto3_session and boto_config will be ignored if both are provided
 
-        Examples
+        Example
         --------
         **Create a DynamoDB persistence layer with custom settings**
 

--- a/aws_lambda_powertools/utilities/idempotency/persistence/redis.py
+++ b/aws_lambda_powertools/utilities/idempotency/persistence/redis.py
@@ -112,7 +112,7 @@ class RedisConnection:
         ssl: bool, optional: default True
             set whether to use ssl for Redis connection
 
-        Examples
+        Example
         --------
 
         ```python

--- a/aws_lambda_powertools/utilities/parameters/base.py
+++ b/aws_lambda_powertools/utilities/parameters/base.py
@@ -1,7 +1,7 @@
 """
 Base for Parameter providers
 !!! abstract "Usage Documentation"
-    [`Parameters`](../utilities/parameters.md)
+    [`Parameters`](../../utilities/parameters.md)
 """
 
 from __future__ import annotations

--- a/docs/api_doc/idempotency/base.md
+++ b/docs/api_doc/idempotency/base.md
@@ -1,0 +1,2 @@
+<!-- markdownlint-disable MD043 MD041 -->
+::: aws_lambda_powertools.utilities.idempotency.base

--- a/docs/api_doc/idempotency/config.md
+++ b/docs/api_doc/idempotency/config.md
@@ -1,0 +1,2 @@
+<!-- markdownlint-disable MD043 MD041 -->
+::: aws_lambda_powertools.utilities.idempotency.config

--- a/docs/api_doc/idempotency/exceptions.md
+++ b/docs/api_doc/idempotency/exceptions.md
@@ -1,0 +1,2 @@
+<!-- markdownlint-disable MD043 MD041 -->
+::: aws_lambda_powertools.utilities.idempotency.exceptions

--- a/docs/api_doc/idempotency/persistence.md
+++ b/docs/api_doc/idempotency/persistence.md
@@ -1,0 +1,2 @@
+<!-- markdownlint-disable MD043 MD041 -->
+::: aws_lambda_powertools.utilities.idempotency.persistence

--- a/docs/api_doc/idempotency/serialization.md
+++ b/docs/api_doc/idempotency/serialization.md
@@ -1,0 +1,2 @@
+<!-- markdownlint-disable MD043 MD041 -->
+::: aws_lambda_powertools.utilities.idempotency.serialization

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -63,6 +63,12 @@ nav:
           #     - Casual to regular contributor: contributing/tracks/casual_regular_contributor.md
           #     - Customer to advocate: contributing/tracks/customer_advocate.md
   - API Documentation:
+      - Idempotency: 
+          - Base: api_doc/idempotency/base.md
+          - Config: api_doc/idempotency/config.md
+          - Exceptions: api_doc/idempotency/exceptions.md
+          - Persistence: api_doc/idempotency/persistence.md
+          - Serialization: api_doc/idempotency/serialization.md
       - JMESPath Functions: api_doc/jmespath_functions.md
       - Parameters:
           - Base: api_doc/parameters/base.md


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
**Issue number:** #5986 

## Summary

### Changes

Update Idempotency utility comments and docstrings to add support for mkdocstrings.

### User experience

![image](https://github.com/user-attachments/assets/e5d0f940-03b5-48a8-940c-29d6c8ec2657)

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] [Meet tenets criteria](https://docs.powertools.aws.dev/lambda/python/#tenets)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented
* [x] PR title follows [conventional commit semantics](https://github.com/aws-powertools/powertools-lambda-python/blob/develop/.github/semantic.yml)

<details>
<summary>Is this a breaking change?</summary>

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
