### PR TITLE
docs(api): migrating the AppConfig utility to mkdocstrings

### DIFF
--- a/aws_lambda_powertools/utilities/feature_flags/appconfig.py
+++ b/aws_lambda_powertools/utilities/feature_flags/appconfig.py
@@ -1,3 +1,7 @@
+"""Advanced feature flags utility
+!!! abstract "Usage Documentation"
+    [`Feature Flags`](../../utilities/feature_flags.md)
+"""
 from __future__ import annotations
 
 import logging

--- a/aws_lambda_powertools/utilities/feature_flags/base.py
+++ b/aws_lambda_powertools/utilities/feature_flags/base.py
@@ -28,7 +28,8 @@ class StoreProvider(ABC):
         dict[str, Any]
             parsed JSON dictionary
 
-            **Example**
+        Example
+        -------
 
         ```python
         {

--- a/aws_lambda_powertools/utilities/feature_flags/comparators.py
+++ b/aws_lambda_powertools/utilities/feature_flags/comparators.py
@@ -56,6 +56,8 @@ def compare_time_range(context_value: Any, condition_value: dict) -> bool:
     end_time = current_time.replace(hour=int(end_hour), minute=int(end_min))
 
     if int(end_hour) < int(start_hour):
+        # In normal circumstances, we need to assert **both** conditions
+        """
         # When the end hour is smaller than start hour, it means we are crossing a day's boundary.
         # In this case we need to assert that current_time is **either** on one side or the other side of the boundary
         #
@@ -69,10 +71,9 @@ def compare_time_range(context_value: Any, condition_value: dict) -> bool:
         #                                             │ │                                        │
         #    └ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─  │ └ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─
         #                                               │
-
+        """
         return (start_time <= current_time) or (current_time <= end_time)
     else:
-        # In normal circumstances, we need to assert **both** conditions
         return start_time <= current_time <= end_time
 
 

--- a/aws_lambda_powertools/utilities/feature_flags/feature_flags.py
+++ b/aws_lambda_powertools/utilities/feature_flags/feature_flags.py
@@ -179,7 +179,8 @@ class FeatureFlags:
         dict[str, dict]
             parsed JSON dictionary
 
-            **Example**
+        Example
+        -------
 
         ```python
         {
@@ -251,7 +252,7 @@ class FeatureFlags:
             Can be boolean or any JSON values for non-boolean features.
 
 
-        Examples
+        Example
         --------
 
         ```python
@@ -343,7 +344,8 @@ class FeatureFlags:
         list[str]
             list of all feature names that either matches context or have True as default
 
-            **Example**
+        Example
+        -------
 
         ```python
         ["premium_features", "my_feature_two", "always_true_feature"]
@@ -400,8 +402,8 @@ class FeatureFlags:
         exc_class : Exception | list[Exception]
             One or more exceptions to catch
 
-        Examples
-        --------
+        Example
+        -------
 
         ```python
         feature_flags = FeatureFlags(store=app_config)

--- a/docs/api_doc/feature_flags/appconfig.md
+++ b/docs/api_doc/feature_flags/appconfig.md
@@ -1,0 +1,2 @@
+<!-- markdownlint-disable MD043 MD041 -->
+::: aws_lambda_powertools.utilities.feature_flags.appconfig

--- a/docs/api_doc/feature_flags/base.md
+++ b/docs/api_doc/feature_flags/base.md
@@ -1,0 +1,2 @@
+<!-- markdownlint-disable MD043 MD041 -->
+::: aws_lambda_powertools.utilities.feature_flags.base

--- a/docs/api_doc/feature_flags/comparators.md
+++ b/docs/api_doc/feature_flags/comparators.md
@@ -1,0 +1,2 @@
+<!-- markdownlint-disable MD043 MD041 -->
+::: aws_lambda_powertools.utilities.feature_flags.comparators

--- a/docs/api_doc/feature_flags/exceptions.md
+++ b/docs/api_doc/feature_flags/exceptions.md
@@ -1,0 +1,2 @@
+<!-- markdownlint-disable MD043 MD041 -->
+::: aws_lambda_powertools.utilities.feature_flags.exceptions

--- a/docs/api_doc/feature_flags/feature_flags.md
+++ b/docs/api_doc/feature_flags/feature_flags.md
@@ -1,0 +1,2 @@
+<!-- markdownlint-disable MD043 MD041 -->
+::: aws_lambda_powertools.utilities.feature_flags.feature_flags

--- a/docs/api_doc/feature_flags/schema.md
+++ b/docs/api_doc/feature_flags/schema.md
@@ -1,0 +1,2 @@
+<!-- markdownlint-disable MD043 MD041 -->
+::: aws_lambda_powertools.utilities.feature_flags.schema

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -63,6 +63,13 @@ nav:
           #     - Casual to regular contributor: contributing/tracks/casual_regular_contributor.md
           #     - Customer to advocate: contributing/tracks/customer_advocate.md
   - API Documentation:
+      - Feature Flags: 
+          - AppConfig: api_doc/feature_flags/appconfig.md
+          - Base: api_doc/feature_flags/base.md
+          - Comparators: api_doc/feature_flags/comparators.md
+          - Exceptions: api_doc/feature_flags/exceptions.md
+          - Feature flags: api_doc/feature_flags/feature_flags.md
+          - Schema: api_doc/feature_flags/schema.md
       - Idempotency: 
           - Base: api_doc/idempotency/base.md
           - Config: api_doc/idempotency/config.md


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
**Issue number:** #5987 

## Summary

### Changes

Update AppConfig utility comments and docstrings to add support for mkdocstrings.

### User experience

![image](https://github.com/user-attachments/assets/dba829cb-c1e4-4687-b759-6f730b851b89)

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] [Meet tenets criteria](https://docs.powertools.aws.dev/lambda/python/#tenets)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented
* [x] PR title follows [conventional commit semantics](https://github.com/aws-powertools/powertools-lambda-python/blob/develop/.github/semantic.yml)

<details>
<summary>Is this a breaking change?</summary>

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
