### PR TITLE
docs(api): migrating the data masking utility to mkdocstrings

### DIFF
--- a/aws_lambda_powertools/utilities/data_masking/base.py
+++ b/aws_lambda_powertools/utilities/data_masking/base.py
@@ -1,3 +1,9 @@
+"""
+Base class for Data Masking
+!!! abstract "Usage Documentation"
+    [`Data masking`](../../utilities/data_masking.md)
+"""
+
 from __future__ import annotations
 
 import functools
@@ -24,8 +30,9 @@ class DataMasking:
     The DataMasking class orchestrates erasing, encrypting, and decrypting
     for the base provider.
 
-    Example:
-    ```
+    Example
+    -------
+    ```python
     from aws_lambda_powertools.utilities.data_masking.base import DataMasking
 
     def lambda_handler(event, context):

--- a/aws_lambda_powertools/utilities/data_masking/provider/base.py
+++ b/aws_lambda_powertools/utilities/data_masking/provider/base.py
@@ -11,9 +11,9 @@ class BaseProvider:
     """
     The BaseProvider class serves as an abstract base class for data masking providers.
 
-    Examples
+    Example
     --------
-    ```
+    ```python
     from aws_lambda_powertools.utilities._data_masking.provider import BaseProvider
     from aws_lambda_powertools.utilities.data_masking import DataMasking
 

--- a/aws_lambda_powertools/utilities/data_masking/provider/kms/aws_encryption_sdk.py
+++ b/aws_lambda_powertools/utilities/data_masking/provider/kms/aws_encryption_sdk.py
@@ -48,9 +48,9 @@ class AWSEncryptionSDKProvider(BaseProvider):
     """
     The AWSEncryptionSDKProvider is used as a provider for the DataMasking class.
 
-    Usage
+    Example
     -------
-    ```
+    ```python
     from aws_lambda_powertools.utilities.data_masking import DataMasking
     from aws_lambda_powertools.utilities.data_masking.providers.kms.aws_encryption_sdk import (
         AWSEncryptionSDKProvider,

--- a/docs/api_doc/data_masking/base.md
+++ b/docs/api_doc/data_masking/base.md
@@ -1,0 +1,2 @@
+<!-- markdownlint-disable MD043 MD041 -->
+::: aws_lambda_powertools.utilities.data_masking.base

--- a/docs/api_doc/data_masking/exceptions.md
+++ b/docs/api_doc/data_masking/exceptions.md
@@ -1,0 +1,2 @@
+<!-- markdownlint-disable MD043 MD041 -->
+::: aws_lambda_powertools.utilities.data_masking.exceptions

--- a/docs/api_doc/data_masking/provider.md
+++ b/docs/api_doc/data_masking/provider.md
@@ -1,0 +1,2 @@
+<!-- markdownlint-disable MD043 MD041 -->
+::: aws_lambda_powertools.utilities.data_masking.provider

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -63,14 +63,18 @@ nav:
           #     - Casual to regular contributor: contributing/tracks/casual_regular_contributor.md
           #     - Customer to advocate: contributing/tracks/customer_advocate.md
   - API Documentation:
-      - Feature Flags: 
+      - Data Masking:
+          - Base: api_doc/data_masking/base.md
+          - Exception: api_doc/data_masking/exceptions.md
+          - Provider: api_doc/data_masking/provider.md
+      - Feature Flags:
           - AppConfig: api_doc/feature_flags/appconfig.md
           - Base: api_doc/feature_flags/base.md
           - Comparators: api_doc/feature_flags/comparators.md
           - Exceptions: api_doc/feature_flags/exceptions.md
           - Feature flags: api_doc/feature_flags/feature_flags.md
           - Schema: api_doc/feature_flags/schema.md
-      - Idempotency: 
+      - Idempotency:
           - Base: api_doc/idempotency/base.md
           - Config: api_doc/idempotency/config.md
           - Exceptions: api_doc/idempotency/exceptions.md


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
**Issue number:** #5988 

## Summary

### Changes

Update Data Masking utility comments and docstrings to add support for mkdocstrings.

### User experience

![image](https://github.com/user-attachments/assets/a07e3dc9-c580-4fe9-b6d2-6f9b0096c516)

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] [Meet tenets criteria](https://docs.powertools.aws.dev/lambda/python/#tenets)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented
* [x] PR title follows [conventional commit semantics](https://github.com/aws-powertools/powertools-lambda-python/blob/develop/.github/semantic.yml)

<details>
<summary>Is this a breaking change?</summary>

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
