### PR TITLE
docs(api): migrating the event source data classes utility to mkdocstrings

### DIFF
--- a/aws_lambda_powertools/utilities/data_classes/common.py
+++ b/aws_lambda_powertools/utilities/data_classes/common.py
@@ -1,3 +1,9 @@
+"""
+Base class for Event Source Data Classes
+!!! abstract "Usage Documentation"
+    [`Data classes`](../utilities/data_classes.md)
+"""
+
 from __future__ import annotations
 
 import base64

--- a/aws_lambda_powertools/utilities/feature_flags/appconfig.py
+++ b/aws_lambda_powertools/utilities/feature_flags/appconfig.py
@@ -2,6 +2,7 @@
 !!! abstract "Usage Documentation"
     [`Feature Flags`](../../utilities/feature_flags.md)
 """
+
 from __future__ import annotations
 
 import logging

--- a/aws_lambda_powertools/utilities/jmespath_utils/__init__.py
+++ b/aws_lambda_powertools/utilities/jmespath_utils/__init__.py
@@ -3,6 +3,7 @@ Built-in JMESPath Functions to easily deserialize common encoded JSON payloads i
 !!! abstract "Usage Documentation"
     [`JMESPath Functions`](../utilities/jmespath_functions.md)
 """
+
 from __future__ import annotations
 
 import base64

--- a/docs/api_doc/data_classes.md
+++ b/docs/api_doc/data_classes.md
@@ -1,0 +1,2 @@
+<!-- markdownlint-disable MD043 MD041 -->
+::: aws_lambda_powertools.utilities.data_classes.common

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -63,6 +63,7 @@ nav:
           #     - Casual to regular contributor: contributing/tracks/casual_regular_contributor.md
           #     - Customer to advocate: contributing/tracks/customer_advocate.md
   - API Documentation:
+      - Event Source Data Classes: api_doc/data_classes.md
       - Data Masking:
           - Base: api_doc/data_masking/base.md
           - Exception: api_doc/data_masking/exceptions.md


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
**Issue number:** #5989 

## Summary

### Changes

Update Event Source Data classes utility comments and docstrings to add support for mkdocstrings.

### User experience

![image](https://github.com/user-attachments/assets/7683c216-fd2b-4326-80e8-791ef8fe094c)

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] [Meet tenets criteria](https://docs.powertools.aws.dev/lambda/python/#tenets)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented
* [x] PR title follows [conventional commit semantics](https://github.com/aws-powertools/powertools-lambda-python/blob/develop/.github/semantic.yml)

<details>
<summary>Is this a breaking change?</summary>

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
