### PR TITLE
docs(api): migrating the Middleware Factory utility to mkdocstrings

### DIFF
--- a/aws_lambda_powertools/middleware_factory/__init__.py
+++ b/aws_lambda_powertools/middleware_factory/__init__.py
@@ -1,4 +1,4 @@
-"""Utilities to enhance middlewares
+"""Utilities to enhance middleware
 !!! abstract "Usage Documentation"
     [`Middleware Factory`](../utilities/middleware_factory.md)
 """

--- a/aws_lambda_powertools/middleware_factory/__init__.py
+++ b/aws_lambda_powertools/middleware_factory/__init__.py
@@ -1,4 +1,7 @@
-"""Utilities to enhance middlewares"""
+"""Utilities to enhance middlewares
+!!! abstract "Usage Documentation"
+    [`Middleware Factory`](../utilities/middleware_factory.md)
+"""
 
 from .factory import lambda_handler_decorator
 

--- a/docs/api_doc/middleware_factory.md
+++ b/docs/api_doc/middleware_factory.md
@@ -1,0 +1,2 @@
+<!-- markdownlint-disable MD043 MD041 -->
+::: aws_lambda_powertools.middleware_factory

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -86,6 +86,7 @@ nav:
           - Persistence: api_doc/idempotency/persistence.md
           - Serialization: api_doc/idempotency/serialization.md
       - JMESPath Functions: api_doc/jmespath_functions.md
+      - Middleware Factory: api_doc/middleware_factory.md
       - Parameters:
           - Base: api_doc/parameters/base.md
           - AppConfig: api_doc/parameters/appconfig.md


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
**Issue number:** #5992 

## Summary

### Changes

Update middleware factory utility comments and docstrings to add support for mkdocstrings.

### User experience

![image](https://github.com/user-attachments/assets/9113e43a-05ae-4042-b052-5f25da203eb1)

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] [Meet tenets criteria](https://docs.powertools.aws.dev/lambda/python/#tenets)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented
* [x] PR title follows [conventional commit semantics](https://github.com/aws-powertools/powertools-lambda-python/blob/develop/.github/semantic.yml)

<details>
<summary>Is this a breaking change?</summary>

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
