### PR TITLE
docs(api): migrating the metrics utility to mkdocstrings

### DIFF
--- a/aws_lambda_powertools/metrics/base.py
+++ b/aws_lambda_powertools/metrics/base.py
@@ -1,3 +1,9 @@
+"""
+Metrics utility
+!!! abstract "Usage Documentation"
+    [`Metrics`](../../core/metrics.md)
+"""
+
 from __future__ import annotations
 
 import datetime

--- a/aws_lambda_powertools/metrics/provider/cloudwatch_emf/cloudwatch.py
+++ b/aws_lambda_powertools/metrics/provider/cloudwatch_emf/cloudwatch.py
@@ -330,7 +330,7 @@ class AmazonCloudWatchEMFProvider(BaseProvider):
         """
         Set the timestamp for the metric.
 
-        Parameters:
+        Parameters
         -----------
         timestamp: int | datetime.datetime
             The timestamp to create the metric.

--- a/docs/api_doc/metrics/base.md
+++ b/docs/api_doc/metrics/base.md
@@ -1,0 +1,2 @@
+<!-- markdownlint-disable MD043 MD041 -->
+::: aws_lambda_powertools.metrics.base

--- a/docs/api_doc/metrics/exceptions.md
+++ b/docs/api_doc/metrics/exceptions.md
@@ -1,0 +1,2 @@
+<!-- markdownlint-disable MD043 MD041 -->
+::: aws_lambda_powertools.metrics.exceptions

--- a/docs/api_doc/metrics/metrics.md
+++ b/docs/api_doc/metrics/metrics.md
@@ -1,0 +1,2 @@
+<!-- markdownlint-disable MD043 MD041 -->
+::: aws_lambda_powertools.metrics.metrics

--- a/docs/api_doc/metrics/provider_datadog.md
+++ b/docs/api_doc/metrics/provider_datadog.md
@@ -1,0 +1,2 @@
+<!-- markdownlint-disable MD043 MD041 -->
+::: aws_lambda_powertools.metrics.provider.datadog.datadog

--- a/docs/api_doc/metrics/provider_emf.md
+++ b/docs/api_doc/metrics/provider_emf.md
@@ -1,0 +1,2 @@
+<!-- markdownlint-disable MD043 MD041 -->
+::: aws_lambda_powertools.metrics.provider.cloudwatch_emf.cloudwatch

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -92,6 +92,12 @@ nav:
           - Formatter: api_doc/logger/formatter.md
           - Lambda Context: api_doc/logger/lambda_context.md
           - Logger: api_doc/logger/logger.md
+      - Metrics:
+          - Base: api_doc/metrics/base.md
+          - Exceptions: api_doc/metrics/exceptions.md
+          - Providers:
+            - EMF: api_doc/metrics/provider_emf.md
+            - DataDog: api_doc/metrics/provider_datadog.md
       - Middleware Factory: api_doc/middleware_factory.md
       - Parameters:
           - Base: api_doc/parameters/base.md


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
**Issue number:** #5993 

## Summary

### Changes

Update metrics utility comments and docstrings to add support for mkdocstrings.

### User experience

![image](https://github.com/user-attachments/assets/e78c870e-0572-40e0-b950-a30154990205)

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] [Meet tenets criteria](https://docs.powertools.aws.dev/lambda/python/#tenets)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented
* [x] PR title follows [conventional commit semantics](https://github.com/aws-powertools/powertools-lambda-python/blob/develop/.github/semantic.yml)

<details>
<summary>Is this a breaking change?</summary>

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
