### PR TITLE
docs(api): migrating the event handler utility to mkdocstrings

### DIFF
--- a/aws_lambda_powertools/event_handler/api_gateway.py
+++ b/aws_lambda_powertools/event_handler/api_gateway.py
@@ -313,10 +313,10 @@ class Route:
         middlewares: list[Callable[..., Response]] | None = None,
     ):
         """
+        Internally used Route Configuration
 
         Parameters
         ----------
-
         method: str
             The HTTP method, example "GET"
         path: str
@@ -908,6 +908,8 @@ class ResponseBuilder(Generic[ResponseEventT]):
 
 
 class BaseRouter(ABC):
+    """Base class for Routing"""
+
     current_event: BaseProxyEvent
     lambda_context: LambdaContext
     context: dict
@@ -1459,7 +1461,7 @@ def _registered_api_adapter(app: ApiGatewayResolver, next_middleware: Callable[.
 
 
 class ApiGatewayResolver(BaseRouter):
-    """API Gateway and ALB proxy resolver
+    """API Gateway, VPC Laticce, Bedrock and ALB proxy resolver
 
     Examples
     --------
@@ -2570,6 +2572,8 @@ class Router(BaseRouter):
 
 
 class APIGatewayRestResolver(ApiGatewayResolver):
+    """Amazon API Gateway REST and HTTP API v1 payload resolver"""
+
     current_event: APIGatewayProxyEvent
 
     def __init__(
@@ -2650,6 +2654,8 @@ class APIGatewayRestResolver(ApiGatewayResolver):
 
 
 class APIGatewayHttpResolver(ApiGatewayResolver):
+    """Amazon API Gateway HTTP API v2 payload resolver"""
+
     current_event: APIGatewayProxyEventV2
 
     def __init__(
@@ -2685,6 +2691,8 @@ class APIGatewayHttpResolver(ApiGatewayResolver):
 
 
 class ALBResolver(ApiGatewayResolver):
+    """Amazon Application Load Balancer (ALB) resolver"""
+
     current_event: ALBEvent
 
     def __init__(

--- a/aws_lambda_powertools/event_handler/middlewares/base.py
+++ b/aws_lambda_powertools/event_handler/middlewares/base.py
@@ -26,7 +26,7 @@ class BaseMiddlewareHandler(Generic[EventHandlerInstance], ABC):
     This is the middleware handler function where middleware logic is implemented.
     The next middleware handler is represented by `next_middleware`, returning a Response object.
 
-    Examples
+    Example
     --------
 
     **Correlation ID Middleware**

--- a/aws_lambda_powertools/event_handler/middlewares/openapi_validation.py
+++ b/aws_lambda_powertools/event_handler/middlewares/openapi_validation.py
@@ -37,7 +37,7 @@ class OpenAPIValidationMiddleware(BaseMiddlewareHandler):
     Lambda handler. It also validates the response against the OpenAPI schema defined by the Lambda handler. It
     should not be used directly, but rather through the `enable_validation` parameter of the `ApiGatewayResolver`.
 
-    Examples
+    Example
     --------
 
     ```python

--- a/aws_lambda_powertools/event_handler/middlewares/schema_validation.py
+++ b/aws_lambda_powertools/event_handler/middlewares/schema_validation.py
@@ -18,7 +18,7 @@ logger = logging.getLogger(__name__)
 class SchemaValidationMiddleware(BaseMiddlewareHandler):
     """Middleware to validate API request and response against JSON Schema using the [Validation utility](https://docs.powertools.aws.dev/lambda/python/latest/utilities/validation/).
 
-    Examples
+    Example
     --------
     **Validating incoming event**
 

--- a/aws_lambda_powertools/event_handler/openapi/params.py
+++ b/aws_lambda_powertools/event_handler/openapi/params.py
@@ -879,8 +879,6 @@ def get_flat_dependant(
     ----------
     dependant: Dependant
         The dependant model to flatten
-    skip_repeats: bool
-        If True, child Dependents already visited will be skipped to avoid duplicates
     visited: list[CacheKey], optional
         Keeps track of visited Dependents to avoid infinite recursion. Defaults to empty list.
 
@@ -932,8 +930,9 @@ def analyze_param(
     ModelField | None
         The type annotation and the Pydantic field representing the parameter
     """
-    field_info, type_annotation = \
-        get_field_info_and_type_annotation(annotation, value, is_path_param, is_response_param)
+    field_info, type_annotation = get_field_info_and_type_annotation(
+        annotation, value, is_path_param, is_response_param,
+    )
 
     # If the value is a FieldInfo, we use it as the FieldInfo for the parameter
     if isinstance(value, FieldInfo):
@@ -964,7 +963,7 @@ def analyze_param(
 
 
 def get_field_info_and_type_annotation(
-    annotation, value, is_path_param: bool, is_response_param: bool
+    annotation, value, is_path_param: bool, is_response_param: bool,
 ) -> tuple[FieldInfo | None, Any]:
     """
     Get the FieldInfo and type annotation from an annotation and value.

--- a/aws_lambda_powertools/event_handler/openapi/swagger_ui/html.py
+++ b/aws_lambda_powertools/event_handler/openapi/swagger_ui/html.py
@@ -22,7 +22,7 @@ def generate_swagger_html(
     spec: str
         The OpenAPI spec
     swagger_js: str
-       Swagger UI JavaScript source code or URL
+        Swagger UI JavaScript source code or URL
     swagger_css: str
         Swagger UI CSS source code or URL
     swagger_base_url: str

--- a/aws_lambda_powertools/logging/exceptions.py
+++ b/aws_lambda_powertools/logging/exceptions.py
@@ -2,4 +2,5 @@ class InvalidLoggerSamplingRateError(Exception):
     """
     Logger configured with Invalid Sampling value
     """
+
     pass

--- a/aws_lambda_powertools/logging/logger.py
+++ b/aws_lambda_powertools/logging/logger.py
@@ -3,6 +3,7 @@ Logger utility
 !!! abstract "Usage Documentation"
     [`Logger`](../../core/logger.md)
 """
+
 from __future__ import annotations
 
 import functools

--- a/aws_lambda_powertools/metrics/provider/datadog/datadog.py
+++ b/aws_lambda_powertools/metrics/provider/datadog/datadog.py
@@ -87,10 +87,6 @@ class DatadogProvider(BaseProvider):
             Timestamp in int for the metrics, default = time.time()
         tags: list[str]
             In format like ["tag:value", "tag2:value2"]
-        args: Any
-            extra args will be dropped for compatibility
-        kwargs: Any
-            extra kwargs will be converted into tags, e.g., add_metrics(sales=sam) -> tags=['sales:sam']
 
         Examples
         --------

--- a/aws_lambda_powertools/tracing/base.py
+++ b/aws_lambda_powertools/tracing/base.py
@@ -3,6 +3,7 @@ Tracing utility
 !!! abstract "Usage Documentation"
     [`Tracer`](../../core/tracer.md)
 """
+
 from __future__ import annotations
 
 import abc

--- a/docs/api_doc/event_handler/api_gateway.md
+++ b/docs/api_doc/event_handler/api_gateway.md
@@ -1,0 +1,2 @@
+<!-- markdownlint-disable MD043 MD041 -->
+::: aws_lambda_powertools.event_handler.api_gateway

--- a/docs/api_doc/event_handler/appsync.md
+++ b/docs/api_doc/event_handler/appsync.md
@@ -1,0 +1,2 @@
+<!-- markdownlint-disable MD043 MD041 -->
+::: aws_lambda_powertools.event_handler.appsync

--- a/docs/api_doc/event_handler/middleware.md
+++ b/docs/api_doc/event_handler/middleware.md
@@ -1,0 +1,2 @@
+<!-- markdownlint-disable MD043 MD041 -->
+::: aws_lambda_powertools.event_handler.middlewares

--- a/docs/api_doc/event_handler/openapi.md
+++ b/docs/api_doc/event_handler/openapi.md
@@ -1,0 +1,2 @@
+<!-- markdownlint-disable MD043 MD041 -->
+::: aws_lambda_powertools.event_handler.openapi

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -72,6 +72,11 @@ nav:
           - Base: api_doc/data_masking/base.md
           - Exception: api_doc/data_masking/exceptions.md
           - Provider: api_doc/data_masking/provider.md
+      - Event Handler:
+          - AppSync: api_doc/event_handler/appsync.md
+          - Middleware: api_doc/event_handler/middleware.md
+          - OpenAPI: api_doc/event_handler/openapi.md
+          - REST: api_doc/event_handler/api_gateway.md
       - Feature Flags:
           - AppConfig: api_doc/feature_flags/appconfig.md
           - Base: api_doc/feature_flags/base.md


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
**Issue number:** #5995 

## Summary

### Changes

Update event handler utility comments and docstrings to add support for mkdocstrings.

### User experience

![image](https://github.com/user-attachments/assets/6c0a3628-adbf-4025-9b22-c5396d0fd2cd)

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] [Meet tenets criteria](https://docs.powertools.aws.dev/lambda/python/#tenets)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented
* [x] PR title follows [conventional commit semantics](https://github.com/aws-powertools/powertools-lambda-python/blob/develop/.github/semantic.yml)

<details>
<summary>Is this a breaking change?</summary>

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
