### PR TITLE
chore(docs): enable privacy plugin in docs

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -189,6 +189,7 @@ markdown_extensions:
 copyright: Copyright &copy; 2023 Amazon Web Services
 
 plugins:
+  - privacy
   - git-revision-date
   - search
   - mkdocstrings:


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
**Issue number:** fixes #6035 

## Summary

### Changes

> Please provide a summary of what's being changed

This PR enables the [MKDocs Material `privacy` plugin](https://squidfunk.github.io/mkdocs-material/plugins/privacy/) in our documentation so that all assets are cached in our CDN for better security and performance.

### User experience

> Please share what the user experience looks like before and after this change

N/A

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] [Meet tenets criteria](https://docs.powertools.aws.dev/lambda/python/#tenets)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [ ] Changes are documented
* [x] PR title follows [conventional commit semantics](https://github.com/aws-powertools/powertools-lambda-python/blob/develop/.github/semantic.yml)

<details>
<summary>Is this a breaking change?</summary>

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
