### PR TITLE
fix(parser): fix EventBridgeModel when working with scheduled events

### DIFF
--- a/tests/events/eventBridgeSchedulerEvent.json
+++ b/tests/events/eventBridgeSchedulerEvent.json
@@ -3,7 +3,7 @@
   "id":"d167b752-343a-4b28-afd6-d4de056319e8",
   "detail-type":"Scheduled Event",
   "source":"aws.scheduler",
-  "account":"533568316194",
+  "account":"123456789012",
   "time":"2025-02-20T16:03:00Z",
   "region":"us-east-1",
   "resources":[

--- a/tests/events/eventBridgeSchedulerEvent.json
+++ b/tests/events/eventBridgeSchedulerEvent.json
@@ -1,0 +1,13 @@
+{
+  "version":"0",
+  "id":"d167b752-343a-4b28-afd6-d4de056319e8",
+  "detail-type":"Scheduled Event",
+  "source":"aws.scheduler",
+  "account":"533568316194",
+  "time":"2025-02-20T16:03:00Z",
+  "region":"us-east-1",
+  "resources":[
+     "arn:aws:scheduler:us-east-1:123456789012:schedule/default/aaaaa"
+  ],
+  "detail":"{}"
+}

--- a/tests/unit/parser/_pydantic/test_eventbridge.py
+++ b/tests/unit/parser/_pydantic/test_eventbridge.py
@@ -1,6 +1,7 @@
 import pytest
 
 from aws_lambda_powertools.utilities.parser import ValidationError, envelopes, parse
+from aws_lambda_powertools.utilities.parser.models import EventBridgeModel
 from tests.functional.utils import load_event
 from tests.unit.parser._pydantic.schemas import (
     MyAdvancedEventbridgeBusiness,
@@ -51,3 +52,10 @@ def test_handle_invalid_event_with_eventbridge_envelope():
     empty_event = {}
     with pytest.raises(ValidationError):
         parse(event=empty_event, model=MyEventbridgeBusiness, envelope=envelopes.EventBridgeEnvelope)
+
+
+def test_handle_eventbridge_scheduler():
+    raw_event = load_event("eventBridgeSchedulerEvent.json")
+    parsed_event: EventBridgeModel = EventBridgeModel(**raw_event)
+
+    assert parsed_event.detail == {}


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
**Issue number:** #6112 

## Summary

### Changes

This PR improves EventBridge Scheduler payload validation. It converts "{}" strings to empty dictionaries for AWS Scheduler events. This change prevents parsing errors and enhances event processing reliability, especially for events with empty payloads.

### User experience

> Please share what the user experience looks like before and after this change

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] [Meet tenets criteria](https://docs.powertools.aws.dev/lambda/python/#tenets)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented
* [x] PR title follows [conventional commit semantics](https://github.com/aws-powertools/powertools-lambda-python/blob/develop/.github/semantic.yml)

<details>
<summary>Is this a breaking change?</summary>

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
