### PR TITLE
fix(parser): fix data types for `sourceIPAddress` and `sequencer` fields in S3RecordModel Model

### DIFF
--- a/aws_lambda_powertools/utilities/parser/models/s3.py
+++ b/aws_lambda_powertools/utilities/parser/models/s3.py
@@ -1,5 +1,5 @@
 from datetime import datetime
-from typing import List, Literal, Optional
+from typing import List, Literal, Optional, Union
 
 from pydantic import BaseModel, model_validator
 from pydantic.fields import Field
@@ -23,7 +23,7 @@ class S3Identity(BaseModel):
 
 
 class S3RequestParameters(BaseModel):
-    sourceIPAddress: IPvAnyNetwork
+    sourceIPAddress: Union[IPvAnyNetwork, Literal["s3.amazonaws.com"]]
 
 
 class S3ResponseElements(BaseModel):
@@ -45,7 +45,7 @@ class S3Object(BaseModel):
     key: str
     size: Optional[NonNegativeFloat] = None
     eTag: Optional[str] = None
-    sequencer: str
+    sequencer: Optional[str] = None
     versionId: Optional[str] = None
 
 

--- a/tests/events/s3EventLifecycleTransition.json
+++ b/tests/events/s3EventLifecycleTransition.json
@@ -1,0 +1,43 @@
+{
+  "Records": [
+    {
+      "eventVersion": "2.3",
+      "eventSource": "aws:s3",
+      "awsRegion": "us-east-1",
+      "eventTime": "2019-09-03T19:37:27.192Z",
+      "eventName": "LifecycleTransition",
+      "userIdentity": {
+        "principalId": "s3.amazonaws.com"
+      },
+      "requestParameters": {
+        "sourceIPAddress": "s3.amazonaws.com"
+      },
+      "responseElements": {
+        "x-amz-request-id": "D82B88E5F771F645",
+        "x-amz-id-2": "vlR7PnpV2Ce81l0PRw6jlUpck7Jo5ZsQjryTjKlc5aLWGVHPZLj5NeC6qMa0emYBDXOo6QBU0Wo="
+      },
+      "s3": {
+        "s3SchemaVersion": "1.0",
+        "configurationId": "828aa6fc-f7b5-4305-8584-487c791949c1",
+        "bucket": {
+          "name": "lambda-artifacts-deafc19498e3f2df",
+          "ownerIdentity": {
+            "principalId": "A3I5XTEXAMAI3E"
+          },
+          "arn": "arn:aws:s3:::lambda-artifacts-deafc19498e3f2df"
+        },
+        "object": {
+          "key": "/path/to/file.parquet",
+          "size": 12345,
+          "eTag": "abcdef1232423423",
+          "versionId": "SomeThingThere"
+        }
+      },
+      "lifecycleEventData": {
+        "transitionEventData": {
+          "destinationStorageClass": "INTELLIGENT_TIERING"
+        }
+      }
+    }
+  ]
+}


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
**Issue number:** #6150 

## Summary
make it possible for S3 object to have s3.amazonaws.com in sourceIPAddress and not to have sequencer

### Changes

sourceIPAddress can be IP address or s3.amazonaws.com
sequencer is optional

### User experience

Library failed during S3 LifecycleTransition parsin
Now it works.

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] [Meet tenets criteria](https://docs.powertools.aws.dev/lambda/python/#tenets)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [ ] Changes are documented
* [x] PR title follows [conventional commit semantics](https://github.com/aws-powertools/powertools-lambda-python/blob/develop/.github/semantic.yml)

<details>
<summary>Is this a breaking change?</summary>

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
