### PR TITLE
docs(layer): Fix SSM parameter name for looking up layer ARN

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -88,7 +88,7 @@ You can install Powertools for AWS Lambda (Python) using your favorite dependenc
         Sample Placeholders:
 
         - `{arch}` is either `arm64` (Graviton based functions) or `x86_64`
-        - `{python_version}` is the Python version without the period (.), e.g., `python313` for `Python 3.13`.
+        - `{python_version}` is the Python runtime version, e.g., `python3.13` for `Python 3.13`.
         - `{version}` is the semantic version number (e,g. 3.1.0) for a release or `latest`
 
         ```yaml


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
**Issue number:** #6213 

### Changes

Corrects details about the python version string used in SSM parameters.

### User experience

Users no longer need to dig through changelog to find correct SSM parameter name patttern.

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] [Meet tenets criteria](https://docs.powertools.aws.dev/lambda/python/#tenets)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented
* [x] PR title follows [conventional commit semantics](https://github.com/aws-powertools/powertools-lambda-python/blob/develop/.github/semantic.yml)

<details>
<summary>Is this a breaking change?</summary>

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
