### PR TITLE
fix(event_source): fix HomeDirectoryDetails type in TransferFamilyAuthorizerResponse method

### DIFF
--- a/aws_lambda_powertools/utilities/data_classes/transfer_family_event.py
+++ b/aws_lambda_powertools/utilities/data_classes/transfer_family_event.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 from typing import Any, Literal
 
 from aws_lambda_powertools.utilities.data_classes.common import (
@@ -44,7 +45,7 @@ class TransferFamilyAuthorizerResponse:
         role_arn: str,
         policy: str | None = None,
         home_directory: str | None = None,
-        home_directory_details: dict | None = None,
+        home_directory_details: list[dict] | None = None,
         home_directory_type: Literal["LOGICAL", "PATH"] = "PATH",
         user_gid: int | None = None,
         user_uid: int | None = None,
@@ -62,7 +63,7 @@ class TransferFamilyAuthorizerResponse:
             if not home_directory_details:
                 raise ValueError("home_directory_details must be set when home_directory_type is LOGICAL")
 
-            response["HomeDirectoryDetails"] = [home_directory_details]
+            response["HomeDirectoryDetails"] = json.dumps(home_directory_details)
 
         else:
             raise ValueError(f"Invalid home_directory_type: {home_directory_type}")
@@ -88,7 +89,7 @@ class TransferFamilyAuthorizerResponse:
         user_uid: int,
         policy: str | None = None,
         home_directory: str | None = None,
-        home_directory_details: dict | None = None,
+        home_directory_details: list[dict] | None = None,
         home_directory_type: Literal["LOGICAL", "PATH"] = "PATH",
         public_keys: str | None = None,
     ) -> dict[str, Any]:
@@ -143,7 +144,7 @@ class TransferFamilyAuthorizerResponse:
         role_arn: str,
         policy: str | None = None,
         home_directory: str | None = None,
-        home_directory_details: dict | None = None,
+        home_directory_details: list[dict] | None = None,
         home_directory_type: Literal["LOGICAL", "PATH"] = "PATH",
         public_keys: str | None = None,
     ) -> dict[str, Any]:

--- a/tests/unit/data_classes/required_dependencies/test_transfer_family_event.py
+++ b/tests/unit/data_classes/required_dependencies/test_transfer_family_event.py
@@ -28,7 +28,7 @@ def test_build_authentication_response_s3(home_directory_type):
     policy = '{"Version": "2012-10-17", "Statement": [{"Effect": "Allow", "Action": "s3:*", "Resource": "*"}]}'
     home_directory = "/bucket/user" if home_directory_type == "PATH" else None
     home_directory_details = (
-        {"Entry": "/", "Target": "/bucket/${transfer:UserName}"} if home_directory_type == "LOGICAL" else None
+        [{"Entry": "/", "Target": "/bucket/${transfer:UserName}"}] if home_directory_type == "LOGICAL" else None
     )
     public_keys = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC0g+Z"
 
@@ -52,7 +52,7 @@ def test_build_authentication_response_s3(home_directory_type):
         assert response.get("HomeDirectory") == home_directory
         assert "HomeDirectoryDetails" not in response
     else:
-        assert response.get("HomeDirectoryDetails") == [home_directory_details]
+        assert response.get("HomeDirectoryDetails") == '[{"Entry": "/", "Target": "/bucket/${transfer:UserName}"}]'
         assert "HomeDirectory" not in response
 
 
@@ -65,7 +65,7 @@ def test_build_authentication_response_efs(home_directory_type):
     role_arn = "arn:aws:iam::123456789012:role/S3Access"
     home_directory = "/bucket/user" if home_directory_type == "PATH" else None
     home_directory_details = (
-        {"Entry": "/", "Target": "/bucket/${transfer:UserName}"} if home_directory_type == "LOGICAL" else None
+        [{"Entry": "/", "Target": "/bucket/${transfer:UserName}"}] if home_directory_type == "LOGICAL" else None
     )
 
     # WHEN building an authentication response for EFS with different home directory types
@@ -86,7 +86,7 @@ def test_build_authentication_response_efs(home_directory_type):
         assert response.get("HomeDirectory") == home_directory
         assert "HomeDirectoryDetails" not in response
     else:
-        assert response.get("HomeDirectoryDetails") == [home_directory_details]
+        assert response.get("HomeDirectoryDetails") == '[{"Entry": "/", "Target": "/bucket/${transfer:UserName}"}]'
         assert "HomeDirectory" not in response
 
 
@@ -97,7 +97,7 @@ def test_build_authentication_missing_home_directory():
 
     # WHEN home_directory_details is empty and type is LOGICAL
     role_arn = "arn:aws:iam::123456789012:role/S3Access"
-    home_directory_details = {}
+    home_directory_details = []
     home_directory_type = "LOGICAL"
 
     # THEN must raise an exception


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
**Issue number:** #6396

## Summary

### Changes

This PR resolve an issue with the return type of the parameter HomeDirectoryDetails from the _build_authentication_response() method in TransferFamilyAuthorizerResponse.

- HomeDirectoryDetails can be a list of mapping.
- HomeDirectoryDetails need to be return as a string representation to the AWS Transfer Server.

### User experience

Before this PR, the AWS Transfer Server return an error : "Unable to parse Json", when HomeDirectoryDetails was set.

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [ ] [Meet tenets criteria](https://docs.powertools.aws.dev/lambda/python/#tenets)
* [X] I have performed a self-review of this change
* [X] Changes have been tested
* [ ] Changes are documented
* [X] PR title follows [conventional commit semantics](https://github.com/aws-powertools/powertools-lambda-python/blob/develop/.github/semantic.yml)

<details>
<summary>Is this a breaking change?</summary>

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
