### PR TITLE
fix(event_source): Added missing properties in APIGatewayWebSocketEvent class

### DIFF
--- a/aws_lambda_powertools/utilities/data_classes/api_gateway_websocket_event.py
+++ b/aws_lambda_powertools/utilities/data_classes/api_gateway_websocket_event.py
@@ -124,5 +124,13 @@ class APIGatewayWebSocketEvent(DictWrapper):
         return CaseInsensitiveDict(self.get("multiValueHeaders"))
 
     @property
+    def query_string_parameters(self) -> dict[str, str]:
+        return CaseInsensitiveDict(self.get("queryStringParameters"))
+
+    @property
+    def multi_value_query_string_parameters(self) -> dict[str, list[str]]:
+        return CaseInsensitiveDict(self.get("multiValueQueryStringParameters"))
+
+    @property
     def request_context(self) -> APIGatewayWebSocketEventRequestContext:
         return APIGatewayWebSocketEventRequestContext(self["requestContext"])

--- a/tests/events/apiGatewayWebSocketApiConnect.json
+++ b/tests/events/apiGatewayWebSocketApiConnect.json
@@ -19,6 +19,15 @@
       "X-Forwarded-Port": ["443"],
       "X-Forwarded-Proto": ["https"]
   },
+  "queryStringParameters": {
+    "userId": "user123",
+    "token": "abc.def.ghi"
+  },
+  "multiValueQueryStringParameters": {
+    "userId": ["123"],
+    "token": ["abc.def.ghi"],
+    "filter": ["new", "unread"]
+  },
   "requestContext": {
       "routeKey": "$connect",
       "eventType": "CONNECT",

--- a/tests/events/apiGatewayWebSocketApiDisconnect.json
+++ b/tests/events/apiGatewayWebSocketApiDisconnect.json
@@ -11,6 +11,15 @@
         "X-Forwarded-For": [""],
         "x-restapi": [""]
     },
+    "queryStringParameters": {
+        "userId": "user123",
+        "token": "abc.def.ghi"
+    },
+    "multiValueQueryStringParameters": {
+    "userId": ["123"],
+    "token": ["abc.def.ghi"],
+    "filter": ["new", "unread"]
+    },
     "requestContext": {
         "routeKey": "$disconnect",
         "disconnectStatusCode": 1005,

--- a/tests/unit/data_classes/required_dependencies/test_api_gateway_websocket_event.py
+++ b/tests/unit/data_classes/required_dependencies/test_api_gateway_websocket_event.py
@@ -14,6 +14,8 @@ def test_connect_api_gateway_websocket_event():
     assert parsed_event.json_body is None
     assert parsed_event.headers == raw_event["headers"]
     assert parsed_event.multi_value_headers == raw_event["multiValueHeaders"]
+    assert parsed_event.query_string_parameters == raw_event["queryStringParameters"]
+    assert parsed_event.multi_value_query_string_parameters == raw_event["multiValueQueryStringParameters"]
 
     request_context = parsed_event.request_context
     request_context_raw = raw_event["requestContext"]
@@ -84,6 +86,8 @@ def test_message_api_gateway_websocket_event():
     assert parsed_event.json_body == json.loads(raw_event["body"])
     assert parsed_event.headers == {}
     assert parsed_event.multi_value_headers == {}
+    assert parsed_event.query_string_parameters == {}
+    assert parsed_event.multi_value_query_string_parameters == {}
 
     request_context = parsed_event.request_context
     request_context_raw = raw_event["requestContext"]


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
**Issue number:** #6409 

## Summary
Added missing properties for querystring parameters.

### Changes

New properties added for `query_string_parameters` and `multi_value_query_string_parameters`.

### User experience

```python
def handler(event: APIGatewayWebSocketEvent):
    myParama = event.query_string_parameters["myParam"]
```

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [X] [Meet tenets criteria](https://docs.powertools.aws.dev/lambda/python/#tenets)
* [x] I have performed a self-review of this change
* [X] Changes have been tested
* [X] Changes are documented
* [X] PR title follows [conventional commit semantics](https://github.com/aws-powertools/powertools-lambda-python/blob/develop/.github/semantic.yml)

<details>
<summary>Is this a breaking change?</summary>

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
