### PR TITLE
fix(logger): improve behavior with `exc_info=True` to prevent errors

### DIFF
--- a/aws_lambda_powertools/logging/formatter.py
+++ b/aws_lambda_powertools/logging/formatter.py
@@ -357,18 +357,24 @@ class LambdaPowertoolsFormatter(BasePowertoolsFormatter):
         return message
 
     def _serialize_stacktrace(self, log_record: logging.LogRecord) -> LogStackTrace | None:
-        if log_record.exc_info:
+        # Check if the first element of exc_info has the __name__ attribute,
+        # which indicates it is likely an exception class or object.
+        # See: https://github.com/aws-powertools/powertools-lambda-python/issues/6358
+        if isinstance(log_record.exc_info, tuple) and hasattr(log_record.exc_info[0], "__name__"):
             exception_info: LogStackTrace = {
                 "type": log_record.exc_info[0].__name__,  # type: ignore
                 "value": log_record.exc_info[1],  # type: ignore
                 "module": log_record.exc_info[1].__class__.__module__,
-                "frames": [],
+                "frames": [
+                    {
+                        "file": fs.filename,
+                        "line": fs.lineno,
+                        "function": fs.name,
+                        "statement": fs.line,
+                    }
+                    for fs in traceback.extract_tb(log_record.exc_info[2])
+                ],
             }
-
-            exception_info["frames"] = [
-                {"file": fs.filename, "line": fs.lineno, "function": fs.name, "statement": fs.line}
-                for fs in traceback.extract_tb(log_record.exc_info[2])
-            ]
 
             return exception_info
 
@@ -387,7 +393,7 @@ class LambdaPowertoolsFormatter(BasePowertoolsFormatter):
         log_record: tuple[str, str] | tuple[None, None]
             Log record with constant traceback info and exception name
         """
-        if log_record.exc_info:
+        if isinstance(log_record.exc_info, tuple) and hasattr(log_record.exc_info[0], "__name__"):
             return self.formatException(log_record.exc_info), log_record.exc_info[0].__name__  # type: ignore
 
         return None, None

--- a/aws_lambda_powertools/utilities/parser/models/appsync.py
+++ b/aws_lambda_powertools/utilities/parser/models/appsync.py
@@ -1,5 +1,7 @@
-from typing import Optional, List, Dict, Union, Any
+from typing import Any, Dict, List, Optional, Union
+
 from pydantic import BaseModel
+
 
 class AppSyncIamIdentity(BaseModel):
     accountId: str

--- a/tests/functional/logger/required_dependencies/test_logger.py
+++ b/tests/functional/logger/required_dependencies/test_logger.py
@@ -638,6 +638,19 @@ def test_logger_exception_extract_exception_name(stdout, service_name):
     assert "ValueError" == log["exception_name"]
 
 
+def test_logger_exception_should_not_fail_with_exception_block(stdout, service_name):
+    # GIVEN Logger is initialized
+    logger = Logger(service=service_name, stream=stdout)
+
+    # WHEN calling a logger.exception with a ValueError and outside of a try/except block
+    logger.exception("Received an exception")
+
+    # THEN the log output should not contain "exception_name" or "exception" and not fail
+    log = capture_logging_output(stdout)
+    assert "exception_name" not in log
+    assert "exception" not in log
+
+
 def test_logger_set_correlation_id(lambda_context, stdout, service_name):
     # GIVEN
     logger = Logger(service=service_name, stream=stdout)

--- a/tests/unit/parser/_pydantic/test_appsync.py
+++ b/tests/unit/parser/_pydantic/test_appsync.py
@@ -1,8 +1,9 @@
 import pytest
 
-from aws_lambda_powertools.utilities.parser import parse, ValidationError
+from aws_lambda_powertools.utilities.parser import ValidationError, parse
 from aws_lambda_powertools.utilities.parser.models import AppSyncResolverEventModel
 from tests.functional.utils import load_event
+
 
 def test_appsync_event_model_parses_successfully():
     """


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
**Issue number:** #6358 

### Summary

This pull request addresses an issue raised by @flatherskevin to improve the developer experience when logging with `exc_info=True`. Currently, Powertools automatically adds exception details to the logging message when `exc_info` is set, even if no actual exception is present. This behavior can lead to unexpected results in certain scenarios.

### Changes

- Updated the logging logic to check if an actual exception exists before adding exception-related keys (`exception_name`, `exception`, etc.) to the log.
- Added tests to ensure that logs with `exc_info=True` but no real exception do not include unnecessary exception-related information.

### User experience

```python
from aws_lambda_powertools import Logger

logger = Logger()

logger.exception("my exception")
```

`{"level":"ERROR","location":"<module>:5","message":"my exception","timestamp":"2025-04-07 13:08:24,241+0100","service":"service_undefined"}`

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] [Meet tenets criteria](https://docs.powertools.aws.dev/lambda/python/#tenets)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [ ] Changes are documented
* [x] PR title follows [conventional commit semantics](https://github.com/aws-powertools/powertools-lambda-python/blob/develop/.github/semantic.yml)

<details>
<summary>Is this a breaking change?</summary>

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
