### PR TITLE
refactor(metrics): use standard collections for types

### DIFF
--- a/aws_lambda_powertools/metrics/base.py
+++ b/aws_lambda_powertools/metrics/base.py
@@ -15,7 +15,7 @@ import os
 import warnings
 from collections import defaultdict
 from contextlib import contextmanager
-from typing import TYPE_CHECKING, Any, Callable, Generator
+from typing import TYPE_CHECKING, Any
 
 from aws_lambda_powertools.metrics.exceptions import (
     MetricResolutionError,
@@ -34,6 +34,8 @@ from aws_lambda_powertools.shared import constants
 from aws_lambda_powertools.shared.functions import resolve_env_var_choice
 
 if TYPE_CHECKING:
+    from collections.abc import Callable, Generator
+
     from aws_lambda_powertools.metrics.types import MetricNameUnitResolution
 
 logger = logging.getLogger(__name__)

--- a/aws_lambda_powertools/metrics/metrics.py
+++ b/aws_lambda_powertools/metrics/metrics.py
@@ -1,11 +1,13 @@
 # NOTE: keeps for compatibility
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Callable
+from typing import TYPE_CHECKING, Any
 
 from aws_lambda_powertools.metrics.provider.cloudwatch_emf.cloudwatch import AmazonCloudWatchEMFProvider
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
+
     from aws_lambda_powertools.metrics.base import MetricResolution, MetricUnit
     from aws_lambda_powertools.metrics.provider.cloudwatch_emf.types import CloudWatchEMFOutput
     from aws_lambda_powertools.shared.types import AnyCallableT

--- a/tests/functional/metrics/conftest.py
+++ b/tests/functional/metrics/conftest.py
@@ -1,4 +1,6 @@
-from typing import Any, Dict, List, Union
+from __future__ import annotations
+
+from typing import Any
 
 import pytest
 
@@ -20,22 +22,22 @@ def reset_metric_set():
 
 
 @pytest.fixture
-def metric_with_resolution() -> Dict[str, Union[str, int]]:
+def metric_with_resolution() -> dict[str, str | int]:
     return {"name": "single_metric", "unit": MetricUnit.Count, "value": 1, "resolution": MetricResolution.High}
 
 
 @pytest.fixture
-def metric() -> Dict[str, str]:
+def metric() -> dict[str, str]:
     return {"name": "single_metric", "unit": MetricUnit.Count, "value": 1}
 
 
 @pytest.fixture
-def metric_datadog() -> Dict[str, str]:
+def metric_datadog() -> dict[str, str]:
     return {"name": "single_metric", "value": 1, "timestamp": 1691678198, "powertools": "datadog"}
 
 
 @pytest.fixture
-def metrics() -> List[Dict[str, str]]:
+def metrics() -> list[dict[str, str]]:
     return [
         {"name": "metric_one", "unit": MetricUnit.Count, "value": 1},
         {"name": "metric_two", "unit": MetricUnit.Count, "value": 1},
@@ -43,7 +45,7 @@ def metrics() -> List[Dict[str, str]]:
 
 
 @pytest.fixture
-def metrics_same_name() -> List[Dict[str, str]]:
+def metrics_same_name() -> list[dict[str, str]]:
     return [
         {"name": "metric_one", "unit": MetricUnit.Count, "value": 1},
         {"name": "metric_one", "unit": MetricUnit.Count, "value": 5},
@@ -51,12 +53,12 @@ def metrics_same_name() -> List[Dict[str, str]]:
 
 
 @pytest.fixture
-def dimension() -> Dict[str, str]:
+def dimension() -> dict[str, str]:
     return {"name": "test_dimension", "value": "test"}
 
 
 @pytest.fixture
-def dimensions() -> List[Dict[str, str]]:
+def dimensions() -> list[dict[str, str]]:
     return [
         {"name": "test_dimension", "value": "test"},
         {"name": "test_dimension_2", "value": "test"},
@@ -64,7 +66,7 @@ def dimensions() -> List[Dict[str, str]]:
 
 
 @pytest.fixture
-def non_str_dimensions() -> List[Dict[str, Any]]:
+def non_str_dimensions() -> list[dict[str, Any]]:
     return [
         {"name": "test_dimension", "value": True},
         {"name": "test_dimension_2", "value": 3},
@@ -82,15 +84,15 @@ def service() -> str:
 
 
 @pytest.fixture
-def metadata() -> Dict[str, str]:
+def metadata() -> dict[str, str]:
     return {"key": "username", "value": "test"}
 
 
 @pytest.fixture
-def a_hundred_metrics() -> List[Dict[str, str]]:
+def a_hundred_metrics() -> list[dict[str, str]]:
     return [{"name": f"metric_{i}", "unit": "Count", "value": 1} for i in range(100)]
 
 
 @pytest.fixture
-def a_hundred_metric_values() -> List[Dict[str, str]]:
+def a_hundred_metric_values() -> list[dict[str, str]]:
     return [{"name": "metric", "unit": "Count", "value": i} for i in range(100)]

--- a/tests/functional/metrics/datadog/test_metrics_datadog.py
+++ b/tests/functional/metrics/datadog/test_metrics_datadog.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import json
 import warnings
 from collections import namedtuple

--- a/tests/functional/metrics/required_dependencies/test_metrics_cloudwatch_emf.py
+++ b/tests/functional/metrics/required_dependencies/test_metrics_cloudwatch_emf.py
@@ -1,8 +1,10 @@
+from __future__ import annotations
+
 import datetime
 import json
 import warnings
 from collections import namedtuple
-from typing import Dict, List, Optional, Union
+from typing import Any
 
 import pytest
 
@@ -29,10 +31,10 @@ from aws_lambda_powertools.metrics.provider.cloudwatch_emf.types import (
 
 
 def serialize_metrics(
-    metrics: List[Dict],
-    dimensions: List[Dict],
+    metrics: list[dict[str, Any]],
+    dimensions: list[dict[str, Any]],
     namespace: str,
-    metadatas: Optional[List[Dict]] = None,
+    metadatas: list[dict] | None = None,
 ) -> CloudWatchEMFOutput:
     """Helper function to build EMF object from a list of metrics, dimensions"""
     my_metrics = AmazonCloudWatchEMFProvider(namespace=namespace)
@@ -51,11 +53,11 @@ def serialize_metrics(
 
 
 def serialize_single_metric(
-    metric: Dict,
-    dimension: Dict,
+    metric: dict[str, Any],
+    dimension: dict[str, Any],
     namespace: str,
-    metadata: Optional[Dict] = None,
-    timestamp: Union[int, datetime.datetime, None] = None,
+    metadata: dict[str, Any] | None = None,
+    timestamp: int | datetime.datetime | None = None,
 ) -> CloudWatchEMFOutput:
     """Helper function to build EMF object from a given metric, dimension and namespace"""
     my_metrics = AmazonCloudWatchEMFProvider(namespace=namespace)
@@ -71,7 +73,7 @@ def serialize_single_metric(
     return my_metrics.serialize_metric_set()
 
 
-def remove_timestamp(metrics: List):
+def remove_timestamp(metrics: list):
     """Helper function to remove Timestamp key from EMF objects as they're built at serialization"""
     for metric in metrics:
         del metric["_aws"]["Timestamp"]
@@ -81,7 +83,7 @@ def capture_metrics_output(capsys):
     return json.loads(capsys.readouterr().out.strip())
 
 
-def capture_metrics_output_multiple_emf_objects(capsys) -> List[CloudWatchEMFOutput]:
+def capture_metrics_output_multiple_emf_objects(capsys) -> list[CloudWatchEMFOutput]:
     return [json.loads(line.strip()) for line in capsys.readouterr().out.split("\n") if line]
 
 

--- a/tests/functional/metrics/required_dependencies/test_metrics_provider.py
+++ b/tests/functional/metrics/required_dependencies/test_metrics_provider.py
@@ -1,5 +1,7 @@
+from __future__ import annotations
+
 import json
-from typing import Any, List
+from typing import Any
 
 from aws_lambda_powertools.metrics import (
     SchemaValidationError,
@@ -15,9 +17,9 @@ def capture_metrics_output(capsys):
 
 class FakeMetricsProvider(BaseProvider):
     def __init__(self):
-        self.metric_store: List = []
+        self.metric_store: list = []
 
-    def add_metric(self, name: str, value: float, tag: List = None, *args, **kwargs):
+    def add_metric(self, name: str, value: float, tag: list = None, *args, **kwargs):
         self.metric_store.append({"name": name, "value": value})
 
     def serialize_metric_set(self, raise_on_empty_metrics: bool = False, *args, **kwargs):

--- a/tests/unit/metrics/conftest.py
+++ b/tests/unit/metrics/conftest.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pytest
 
 

--- a/tests/unit/metrics/test_functions.py
+++ b/tests/unit/metrics/test_functions.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import warnings
 
 import pytest

--- a/tests/unit/metrics/test_unit_datadog.py
+++ b/tests/unit/metrics/test_unit_datadog.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pytest
 
 from aws_lambda_powertools.metrics.exceptions import SchemaValidationError


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
**Issue number:** #6469 

## Summary

### Changes

PEP 585 recommends using collections for type hints instead of their typing counterparts.

### User experience

no changes

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] [Meet tenets criteria](https://docs.powertools.aws.dev/lambda/python/#tenets)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [ ] Changes are documented
* [x] PR title follows [conventional commit semantics](https://github.com/aws-powertools/powertools-lambda-python/blob/develop/.github/semantic.yml)

<details>
<summary>Is this a breaking change?</summary>

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
