### PR TITLE
refactor(tracer): use standard collections for types

### DIFF
--- a/aws_lambda_powertools/tracing/base.py
+++ b/aws_lambda_powertools/tracing/base.py
@@ -8,11 +8,12 @@ from __future__ import annotations
 
 import abc
 from contextlib import contextmanager
-from typing import TYPE_CHECKING, Any, Generator, Sequence
+from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
     import numbers
     import traceback
+    from collections.abc import Generator, Sequence
 
 
 class BaseSegment(abc.ABC):

--- a/aws_lambda_powertools/tracing/tracer.py
+++ b/aws_lambda_powertools/tracing/tracer.py
@@ -6,7 +6,7 @@ import functools
 import inspect
 import logging
 import os
-from typing import TYPE_CHECKING, Any, Callable, Sequence, TypeVar, cast, overload
+from typing import TYPE_CHECKING, Any, TypeVar, cast, overload
 
 from aws_lambda_powertools.shared import constants
 from aws_lambda_powertools.shared.functions import (
@@ -19,6 +19,7 @@ from aws_lambda_powertools.shared.types import AnyCallableT
 
 if TYPE_CHECKING:
     import numbers
+    from collections.abc import Callable, Sequence
 
     from aws_lambda_powertools.tracing.base import BaseProvider, BaseSegment
 

--- a/tests/functional/tracer/_aws_xray_sdk/test_tracing.py
+++ b/tests/functional/tracer/_aws_xray_sdk/test_tracing.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import contextlib
 
 import pytest

--- a/tests/unit/test_tracing.py
+++ b/tests/unit/test_tracing.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import contextlib
 from typing import NamedTuple
 from unittest import mock


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
**Issue number:** #6470 

## Summary

### Changes

PEP 585 recommends using collections for type hints instead of their typing counterparts.

### User experience

no changes

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] [Meet tenets criteria](https://docs.powertools.aws.dev/lambda/python/#tenets)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [ ] Changes are documented
* [x] PR title follows [conventional commit semantics](https://github.com/aws-powertools/powertools-lambda-python/blob/develop/.github/semantic.yml)

<details>
<summary>Is this a breaking change?</summary>

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
