### PR TITLE
feat(bedrock): add `openapi_extensions` in BedrockAgentResolver

### DIFF
--- a/aws_lambda_powertools/event_handler/bedrock_agent.py
+++ b/aws_lambda_powertools/event_handler/bedrock_agent.py
@@ -197,7 +197,6 @@ class BedrockAgentResolver(ApiGatewayResolver):
         custom_response_validation_http_code: int | HTTPStatus | None = None,
         middlewares: list[Callable[..., Any]] | None = None,
     ):
-        openapi_extensions = None
         security = None
 
         return super().put(
@@ -239,7 +238,6 @@ class BedrockAgentResolver(ApiGatewayResolver):
         custom_response_validation_http_code: int | HTTPStatus | None = None,
         middlewares: list[Callable] | None = None,
     ):
-        openapi_extensions = None
         security = None
 
         return super().patch(
@@ -281,7 +279,6 @@ class BedrockAgentResolver(ApiGatewayResolver):
         custom_response_validation_http_code: int | HTTPStatus | None = None,
         middlewares: list[Callable[..., Any]] | None = None,
     ):
-        openapi_extensions = None
         security = None
 
         return super().delete(
@@ -368,8 +365,6 @@ class BedrockAgentResolver(ApiGatewayResolver):
             The OpenAPI schema as a JSON serializable dict.
         """
         from aws_lambda_powertools.event_handler.openapi.compat import model_json
-
-        openapi_extensions = None
 
         schema = super().get_openapi_schema(
             title=title,

--- a/aws_lambda_powertools/event_handler/bedrock_agent.py
+++ b/aws_lambda_powertools/event_handler/bedrock_agent.py
@@ -110,11 +110,11 @@ class BedrockAgentResolver(ApiGatewayResolver):
         tags: list[str] | None = None,
         operation_id: str | None = None,
         include_in_schema: bool = True,
+        openapi_extensions: dict[str, Any] | None = None,
         deprecated: bool = False,
         custom_response_validation_http_code: int | HTTPStatus | None = None,
         middlewares: list[Callable[..., Any]] | None = None,
     ) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
-        openapi_extensions = None
         security = None
 
         return super().get(
@@ -151,11 +151,11 @@ class BedrockAgentResolver(ApiGatewayResolver):
         tags: list[str] | None = None,
         operation_id: str | None = None,
         include_in_schema: bool = True,
+        openapi_extensions: dict[str, Any] | None = None,
         deprecated: bool = False,
         custom_response_validation_http_code: int | HTTPStatus | None = None,
         middlewares: list[Callable[..., Any]] | None = None,
     ):
-        openapi_extensions = None
         security = None
 
         return super().post(
@@ -192,6 +192,7 @@ class BedrockAgentResolver(ApiGatewayResolver):
         tags: list[str] | None = None,
         operation_id: str | None = None,
         include_in_schema: bool = True,
+        openapi_extensions: dict[str, Any] | None = None,
         deprecated: bool = False,
         custom_response_validation_http_code: int | HTTPStatus | None = None,
         middlewares: list[Callable[..., Any]] | None = None,
@@ -233,6 +234,7 @@ class BedrockAgentResolver(ApiGatewayResolver):
         tags: list[str] | None = None,
         operation_id: str | None = None,
         include_in_schema: bool = True,
+        openapi_extensions: dict[str, Any] | None = None,
         deprecated: bool = False,
         custom_response_validation_http_code: int | HTTPStatus | None = None,
         middlewares: list[Callable] | None = None,
@@ -274,6 +276,7 @@ class BedrockAgentResolver(ApiGatewayResolver):
         tags: list[str] | None = None,
         operation_id: str | None = None,
         include_in_schema: bool = True,
+        openapi_extensions: dict[str, Any] | None = None,
         deprecated: bool = False,
         custom_response_validation_http_code: int | HTTPStatus | None = None,
         middlewares: list[Callable[..., Any]] | None = None,
@@ -325,6 +328,7 @@ class BedrockAgentResolver(ApiGatewayResolver):
         license_info: License | None = None,
         security_schemes: dict[str, SecurityScheme] | None = None,
         security: list[dict[str, list[str]]] | None = None,
+        openapi_extensions: dict[str, Any] | None = None,
     ) -> str:
         """
         Returns the OpenAPI schema as a JSON serializable dict.

--- a/docs/core/event_handler/bedrock_agents.md
+++ b/docs/core/event_handler/bedrock_agents.md
@@ -313,6 +313,16 @@ To implement these customizations, include extra parameters when defining your r
 --8<-- "examples/event_handler_bedrock_agents/src/customizing_bedrock_api_operations.py"
 ```
 
+#### Enabling user confirmation
+
+You can enable user confirmation with Bedrock Agents to have your application ask for explicit user approval before invoking an action.
+
+```python hl_lines="14" title="enabling_user_confirmation.py" title="Enabling user confirmation"
+--8<-- "examples/event_handler_bedrock_agents/src/enabling_user_confirmation.py"
+```
+
+1. Add an openapi extension
+
 ## Testing your code
 
 Test your routes by passing an [Agent for Amazon Bedrock proxy event](https://docs.aws.amazon.com/bedrock/latest/userguide/agents-lambda.html#agents-lambda-input) request:

--- a/examples/event_handler_bedrock_agents/src/enabling_user_confirmation.py
+++ b/examples/event_handler_bedrock_agents/src/enabling_user_confirmation.py
@@ -1,0 +1,26 @@
+from time import time
+
+from aws_lambda_powertools import Logger
+from aws_lambda_powertools.event_handler import BedrockAgentResolver
+from aws_lambda_powertools.utilities.typing import LambdaContext
+
+logger = Logger()
+app = BedrockAgentResolver()
+
+
+@app.get(
+    "/current_time",
+    description="Gets the current time in seconds",
+    openapi_extensions={"x-requireConfirmation": "ENABLED"},  # (1)!
+)
+def current_time() -> int:
+    return int(time())
+
+
+@logger.inject_lambda_context
+def lambda_handler(event: dict, context: LambdaContext):
+    return app.resolve(event, context)
+
+
+if __name__ == "__main__":
+    print(app.get_openapi_json_schema())

--- a/tests/functional/event_handler/_pydantic/test_bedrock_agent.py
+++ b/tests/functional/event_handler/_pydantic/test_bedrock_agent.py
@@ -200,3 +200,21 @@ def test_openapi_schema_for_pydanticv2(openapi30_schema):
     # THEN the schema must be a valid 3.0.3 version
     assert openapi30_schema(schema)
     assert schema.get("openapi") == "3.0.3"
+
+
+def test_bedrock_resolver_with_openapi_extensions():
+    # GIVEN BedrockAgentResolver is initialized with enable_validation=True
+    app = BedrockAgentResolver(enable_validation=True)
+
+    # WHEN we have a simple handler with openapi extension
+    @app.get("/", description="Testing", openapi_extensions={"x-requireConfirmation": "ENABLED"})
+    def handler() -> Optional[Dict]:
+        pass
+
+    # WHEN we get the schema
+    schema = app.get_openapi_schema()
+
+    schema = json.loads(app.get_openapi_json_schema())
+
+    # THEN the OpenAPI schema must contain the "x-requireConfirmation" extension at the operation level
+    assert schema["paths"]["/"]["get"]["x-requireConfirmation"] == "ENABLED"

--- a/tests/functional/event_handler/_pydantic/test_bedrock_agent.py
+++ b/tests/functional/event_handler/_pydantic/test_bedrock_agent.py
@@ -212,8 +212,6 @@ def test_bedrock_resolver_with_openapi_extensions():
         pass
 
     # WHEN we get the schema
-    schema = app.get_openapi_schema()
-
     schema = json.loads(app.get_openapi_json_schema())
 
     # THEN the OpenAPI schema must contain the "x-requireConfirmation" extension at the operation level


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
**Issue number:** #6500 

## Summary
The BedrockAgentResolver class currently doesn't expose the `openapi_extensions` parameter in its route decorators, which is necessary for enabling Bedrock Agent user confirmations. To enable user confirmations in Bedrock Agents, we need to set `"x-requireConfirmation":"ENABLED"` in the API schema file. 

### Changes:
- Added `openapi_extensions` parameter to route decorators in BedrockAgentResolver
- Ensured parameter is properly passed to parent class implementation
- Added documentation
- Added a test case demonstrating usage with Bedrock Agent user confirmations

### User experience

```python
@app.get("/confirm-action", openapi_extensions={"x-requireConfirmation": "ENABLED"})
def confirm_action():
    return {"message": "Action confirmed"}
```

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] [Meet tenets criteria](https://docs.powertools.aws.dev/lambda/python/#tenets)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented
* [x] PR title follows [conventional commit semantics](https://github.com/aws-powertools/powertools-lambda-python/blob/develop/.github/semantic.yml)

<details>
<summary>Is this a breaking change?</summary>

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
