### PR TITLE
docs(i-made-this): adding Michael's MCP server

### DIFF
--- a/docs/we_made_this.md
+++ b/docs/we_made_this.md
@@ -15,6 +15,18 @@ This space is dedicated to highlight our awesome community content featuring Pow
 
 Join us on [Discord](https://discord.gg/B8zZKbbyET){target="_blank" rel="nofollow"} to connect with the Powertools for AWS Lambda (Python) community 👋. Ask questions, learn from each other, contribute, hang out with key contributors, and more!
 
+## Unofficial MCP Server
+
+**Author: [Michael Walmsley](https://twitter.com/walmsles){target="_blank" rel="nofollow"}** :material-twitter:
+
+A Model Context Protocol (MCP) server that provides search functionality for Powertools for AWS Lambda documentation across all the runtimes.
+
+See this video where Michael demonstrates how to use the Powertools MCP server with [Amazon Q](https://aws.amazon.com/q/?nc1=h_ls), query cross-runtime documentation, and writes a serverless application with embedded Powertools best practices.
+
+<iframe width="560" height="315" src="https://www.youtube.com/embed/5qz8ysWT4eM?si=Sx-K4v4W6RQKWYb6" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+
+GitHub: [https://github.com/serverless-dna/powertools-mcp](https://github.com/serverless-dna/powertools-mcp)
+
 ## Blog posts
 
 ### AWS Lambda Cookbook — Following best practices with Powertools for AWS Lambda


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
**Issue number:** #6532 

## Summary

Adds the Michael's Model Context Protocol (MCP) server implementation that provides cross-runtime search functionality for Powertools for AWS Lambda documentation. 

### Changes

> Please provide a summary of what's being changed

### User experience

> Please share what the user experience looks like before and after this change

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] [Meet tenets criteria](https://docs.powertools.aws.dev/lambda/python/#tenets)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented
* [x] PR title follows [conventional commit semantics](https://github.com/aws-powertools/powertools-lambda-python/blob/develop/.github/semantic.yml)

<details>
<summary>Is this a breaking change?</summary>

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
