### PR TITLE
fix(event_handler): fix OpenAPI schema response for disabled validation

### DIFF
--- a/aws_lambda_powertools/event_handler/api_gateway.py
+++ b/aws_lambda_powertools/event_handler/api_gateway.py
@@ -546,20 +546,20 @@ class Route:
 
         return self._body_field
 
-    def _get_openapi_path(
+    def _get_openapi_path(  # noqa PLR0912
         self,
         *,
         dependant: Dependant,
         operation_ids: set[str],
         model_name_map: dict[TypeModelOrEnum, str],
         field_mapping: dict[tuple[ModelField, Literal["validation", "serialization"]], JsonSchemaValue],
+        enable_validation: bool = False,
     ) -> tuple[dict[str, Any], dict[str, Any]]:
         """
         Returns the OpenAPI path and definitions for the route.
         """
         from aws_lambda_powertools.event_handler.openapi.dependant import get_flat_params
 
-        path = {}
         definitions: dict[str, Any] = {}
 
         # Gather all the route parameters
@@ -598,13 +598,18 @@ class Route:
             if request_body_oai:
                 operation["requestBody"] = request_body_oai
 
-        # Validation failure response (422) will always be part of the schema
-        operation_responses: dict[int, OpenAPIResponse] = {
-            422: {
-                "description": "Validation Error",
-                "content": {_DEFAULT_CONTENT_TYPE: {"schema": {"$ref": f"{COMPONENT_REF_PREFIX}HTTPValidationError"}}},
-            },
-        }
+        operation_responses: dict[int, OpenAPIResponse] = {}
+
+        if enable_validation:
+            # Validation failure response (422) is added only if Enable Validation feature is true
+            operation_responses = {
+                422: {
+                    "description": "Validation Error",
+                    "content": {
+                        _DEFAULT_CONTENT_TYPE: {"schema": {"$ref": f"{COMPONENT_REF_PREFIX}HTTPValidationError"}},
+                    },
+                },
+            }
 
         # Add custom response validation response, if exists
         if self.custom_response_validation_http_code:
@@ -681,8 +686,7 @@ class Route:
             }
 
         operation["responses"] = operation_responses
-        path[self.method.lower()] = operation
-
+        path = {self.method.lower(): operation}
         # Add the validation error schema to the definitions, but only if it hasn't been added yet
         if "ValidationError" not in definitions:
             definitions.update(
@@ -1834,6 +1838,7 @@ class ApiGatewayResolver(BaseRouter):
                 operation_ids=operation_ids,
                 model_name_map=model_name_map,
                 field_mapping=field_mapping,
+                enable_validation=self._enable_validation,
             )
             if result:
                 path, path_definitions = self._add_resolver_response_validation_error_response_to_route(result)

--- a/tests/functional/event_handler/_pydantic/test_openapi_responses.py
+++ b/tests/functional/event_handler/_pydantic/test_openapi_responses.py
@@ -218,3 +218,22 @@ def test_openapi_route_and_resolver_with_custom_response_validation():
     assert 417 in responses_with_resolver_response_validation
     assert 418 not in responses_with_resolver_response_validation
     assert responses_with_resolver_response_validation[417].description == "Response Validation Error"
+
+
+def test_openapi_enable_validation_disabled():
+    # GIVEN An API Gateway resolver without validation
+    app = APIGatewayRestResolver()
+
+    @app.get("/")
+    def handler():
+        pass
+
+    # WHEN we retrieve the OpenAPI schema for the application
+    schema = app.get_openapi_schema()
+    responses = schema.paths["/"].get.responses
+
+    # THE the schema should include a 200 successful response
+    # but not a 422 validation error response since validation is disabled
+    assert 200 in responses.keys()
+    assert responses[200].description == "Successful Response"
+    assert 422 not in responses.keys()


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
**Issue number:** #6435 

## Summary

This PR fixes an issue where the OpenAPI schema incorrectly includes a 422 validation error response when validation is disabled. This ensures the API documentation accurately reflects the actual behavior of the application.

Additionally, I've ADDED `noqa ruff PLR0912` because this method is critical and requires more than 16 branches, which is something we configure to keep the maintenance well.

### Changes

- Updated the schema generation to conditionally include the 422 response only when validation is enabled
- Added a test case to verify this behavior

### User experience

> Please share what the user experience looks like before and after this change

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] [Meet tenets criteria](https://docs.powertools.aws.dev/lambda/python/#tenets)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented
* [x] PR title follows [conventional commit semantics](https://github.com/aws-powertools/powertools-lambda-python/blob/develop/.github/semantic.yml)

<details>
<summary>Is this a breaking change?</summary>

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
