### PR TITLE
chore(ci): stop publishing to gh-pages branch

### DIFF
--- a/.github/workflows/reusable_publish_docs.yml
+++ b/.github/workflows/reusable_publish_docs.yml
@@ -53,8 +53,9 @@ jobs:
         with:
           python-version: "3.12"
           cache: "poetry"
-      - name: Install dependencies
-        run: make dev
+      - name: Install doc generation dependencies
+        run: |
+          pip install --require-hashes -r docs/requirements.txt
       - name: Git client setup
         run: |
           git config --global user.name Docs deploy


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
**Issue number:** https://github.com/aws-powertools/powertools-lambda-python/issues/6898

## Summary

### Changes

We need to stop publishing to the gh-pages branch. This branch is no longer being used for our documentation or site hosting purposes.


### User experience

> Please share what the user experience looks like before and after this change

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] [Meet tenets criteria](https://docs.powertools.aws.dev/lambda/python/#tenets)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented
* [x] PR title follows [conventional commit semantics](https://github.com/aws-powertools/powertools-lambda-python/blob/develop/.github/semantic.yml)

<details>
<summary>Is this a breaking change?</summary>

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
