### PR TITLE
fix: enable response compression when using multi-value headers

### DIFF
--- a/aws_lambda_powertools/event_handler/api_gateway.py
+++ b/aws_lambda_powertools/event_handler/api_gateway.py
@@ -916,8 +916,14 @@ class ResponseBuilder(Generic[ResponseEventT]):
         bool
             True if compression is enabled and the "gzip" encoding is accepted, False otherwise.
         """
-        encoding = event.headers.get("accept-encoding", "")
-        if "gzip" in encoding:
+        encoding = event.resolved_headers_field.get("accept-encoding", "")
+        gzip_accepted = False
+        if isinstance(encoding, str):
+            gzip_accepted = "gzip" in encoding
+        elif isinstance(encoding, list):
+            gzip_accepted = "gzip" in ",".join(encoding)
+
+        if gzip_accepted:
             if response_compression is not None:
                 return response_compression  # e.g., Response(compress=False/True))
             if route_compression:

--- a/tests/functional/event_handler/_pydantic/test_openapi_swagger.py
+++ b/tests/functional/event_handler/_pydantic/test_openapi_swagger.py
@@ -26,7 +26,7 @@ def test_openapi_swagger():
 def test_openapi_swagger_compressed():
     app = APIGatewayRestResolver(enable_validation=True)
     app.enable_swagger(compress=True)
-    LOAD_GW_EVENT["headers"] = {"Accept-Encoding": "gzip, deflate, br"}
+    LOAD_GW_EVENT["multiValueHeaders"] = {"Accept-Encoding": ["gzip, deflate, br"]}
     LOAD_GW_EVENT["path"] = "/swagger"
     result = app(LOAD_GW_EVENT, {})
     assert result["statusCode"] == 200

--- a/tests/functional/event_handler/required_dependencies/test_api_gateway.py
+++ b/tests/functional/event_handler/required_dependencies/test_api_gateway.py
@@ -464,12 +464,20 @@ def test_override_route_compress_parameter():
     assert result["multiValueHeaders"].get("Content-Encoding") is None
 
 
-def test_response_with_compress_enabled():
+@pytest.mark.parametrize(
+    "headers",
+    [
+        {"headers": {"Accept-Encoding": "deflate, gzip"}},
+        {"multiValueHeaders": {"Accept-Encoding": ["deflate, gzip"]}},
+        {"multiValueHeaders": {"Accept-Encoding": ["deflate", "gzip"]}},
+    ],
+)
+def test_response_with_compress_enabled(headers: dict):
     # GIVEN a function
     # AND an event with a "Accept-Encoding" that include gzip
     # AND the Response object with compress=True
     app = ApiGatewayResolver()
-    mock_event = {"path": "/my/request", "httpMethod": "GET", "headers": {"Accept-Encoding": "deflate, gzip"}}
+    mock_event = {"path": "/my/request", "httpMethod": "GET", **headers}
     expected_value = '{"test": "value"}'
 
     @app.get("/my/request")


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
**Issue number:** #6912

## Summary

### Changes

Enabled REST response compression to work when multi-value headers are enabled for REST resolvers. Previously only the Lambda invocation event's `"headers"` field was considered, now `"multiValueHeaders"` is used when present, relying on generic Powertools functionality (`event.resolved_headers_field`).

### User experience

Previously response compression would not work if the Lambda function integration had multi-value headers enabled. Now it does.

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] [Meet tenets criteria](https://docs.powertools.aws.dev/lambda/python/#tenets)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [ ] Changes are documented
* [x] PR title follows [conventional commit semantics](https://github.com/aws-powertools/powertools-lambda-python/blob/develop/.github/semantic.yml)

<details>
<summary>Is this a breaking change?</summary>

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
