### PR TITLE
docs(event_handler): add section about Pydantic serialization

### DIFF
--- a/docs/core/event_handler/api_gateway.md
+++ b/docs/core/event_handler/api_gateway.md
@@ -559,8 +559,6 @@ With data validation enabled, we natively support serializing the following data
 !!! warning "Important: Pydantic models are serialized using aliases by default"
     When `enable_validation=True` is set, **all Pydantic models in responses are automatically serialized using `by_alias=True`**. This differs from Pydantic's default behavior (`by_alias=False`).
 
-    This design choice ensures compatibility with HTTP standards where field names may contain characters like hyphens (`-`) that are not valid Python identifiers.
-
 When you return Pydantic models from your handlers, Event Handler will serialize them using field aliases defined in your model configuration:
 
 === "pydantic_alias_serialization.py"

--- a/docs/core/event_handler/api_gateway.md
+++ b/docs/core/event_handler/api_gateway.md
@@ -554,6 +554,40 @@ With data validation enabled, we natively support serializing the following data
 ???+ info "See [custom serializer section](#custom-serializer) for bringing your own."
     Otherwise, we will raise `SerializationError` for any unsupported types _e.g., SQLAlchemy models_.
 
+#### Pydantic serialization behavior
+
+!!! warning "Important: Pydantic models are serialized using aliases by default"
+    When `enable_validation=True` is set, **all Pydantic models in responses are automatically serialized using `by_alias=True`**. This differs from Pydantic's default behavior (`by_alias=False`).
+
+    This design choice ensures compatibility with HTTP standards where field names may contain characters like hyphens (`-`) that are not valid Python identifiers.
+
+When you return Pydantic models from your handlers, Event Handler will serialize them using field aliases defined in your model configuration:
+
+=== "pydantic_alias_serialization.py"
+
+    ```python hl_lines="1 2 11 20"
+    --8<-- "examples/event_handler_rest/src/pydantic_alias_serialization.py"
+    ```
+
+    1. The `alias_generator=to_snake` converts camelCase field names to snake_case aliases
+    2. `firstName` becomes `first_name` and lastName` becomes `last_name` in the JSON response
+
+=== "pydantic_alias_serialization_output.json"
+
+    ```json hl_lines="3"
+    --8<-- "examples/event_handler_rest/src/pydantic_alias_serialization_output.json"
+    ```
+
+##### Serializing using field name
+
+If you need to serialize using field names instead of aliases, you can dump the model:
+
+=== "pydantic_field_name_serialization.py"
+
+    ```python hl_lines="11 19 20"
+    --8<-- "examples/event_handler_rest/src/pydantic_field_name_serialization.py"
+    ```
+
 ### Accessing request details
 
 Event Handler integrates with [Event Source Data Classes utilities](../../utilities/data_classes.md){target="_blank"}, and it exposes their respective resolver request details and convenient methods under `app.current_event`.

--- a/examples/event_handler_rest/src/pydantic_alias_serialization.py
+++ b/examples/event_handler_rest/src/pydantic_alias_serialization.py
@@ -1,0 +1,24 @@
+from pydantic import BaseModel, ConfigDict
+from pydantic.alias_generators import to_snake
+
+from aws_lambda_powertools.event_handler import APIGatewayRestResolver
+from aws_lambda_powertools.utilities.typing import LambdaContext
+
+app = APIGatewayRestResolver(enable_validation=True)
+
+
+class UserResponse(BaseModel):
+    model_config = ConfigDict(alias_generator=to_snake, populate_by_name=True)  # (1)!
+
+    firstName: str  # Will be serialized as "first_name"
+    lastName: str  # Will be serialized as "last_name"
+
+
+@app.get("/user")
+def get_user() -> UserResponse:
+    return UserResponse(firstName="John", lastName="Doe")  # (2)!
+    # Response will be: {"first_name": "John", "last_name": "Doe"}
+
+
+def lambda_handler(event: dict, context: LambdaContext) -> dict:
+    return app.resolve(event, context)

--- a/examples/event_handler_rest/src/pydantic_alias_serialization_output.json
+++ b/examples/event_handler_rest/src/pydantic_alias_serialization_output.json
@@ -1,0 +1,9 @@
+{
+    "statusCode": 200,
+    "body": "{\"first_name\":\"John\",\"last_name\":\"Doe\"}",
+    "headers": {
+        "Content-Type": "application/json"
+    },
+    "multiValueHeaders": {},
+    "isBase64Encoded": false
+}

--- a/examples/event_handler_rest/src/pydantic_field_name_serialization.py
+++ b/examples/event_handler_rest/src/pydantic_field_name_serialization.py
@@ -1,0 +1,24 @@
+from pydantic import BaseModel, ConfigDict
+from pydantic.alias_generators import to_snake
+
+from aws_lambda_powertools.event_handler import APIGatewayRestResolver
+from aws_lambda_powertools.utilities.typing import LambdaContext
+
+app = APIGatewayRestResolver(enable_validation=True)
+
+
+class UserResponse(BaseModel):
+    model_config = ConfigDict(alias_generator=to_snake, populate_by_name=True)
+
+    firstName: str
+    lastName: str
+
+
+@app.get("/user")
+def get_user_manual() -> dict:
+    user = UserResponse(firstName="John", lastName="Doe")
+    return user.model_dump(by_alias=False)  # Returns dict, not UserResponse
+
+
+def lambda_handler(event: dict, context: LambdaContext) -> dict:
+    return app.resolve(event, context)


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
**Issue number:** #6728 

## Summary

This PR addresses issue #6728 by adding comprehensive documentation about Pydantic serialization behavior when using Event Handler with validation enabled.

## Changes

### Documentation Updates
- Added new section **"Pydantic serialization behavior"** in the Event Handler documentation
- Explains that Pydantic models are serialized using `by_alias=True` by default when `enable_validation=True`
- Clarifies the difference from Pydantic's default behavior (`by_alias=False`)

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [X] [Meet tenets criteria](https://docs.powertools.aws.dev/lambda/python/#tenets)
* [X] I have performed a self-review of this change
* [X] Changes have been tested
* [X] Changes are documented
* [X] PR title follows [conventional commit semantics](https://github.com/aws-powertools/powertools-lambda-python/blob/develop/.github/semantic.yml)

<details>
<summary>Is this a breaking change?</summary>

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.