### PR TITLE
chore(ci): improve feature flags UA

### DIFF
--- a/aws_lambda_powertools/utilities/feature_flags/appconfig.py
+++ b/aws_lambda_powertools/utilities/feature_flags/appconfig.py
@@ -87,6 +87,17 @@ class AppConfigStore(StoreProvider):
             boto3_session=boto3_session,
         )
 
+        # Override the user agent to use "feature_flags" instead of "parameters"
+        self._register_feature_flags_user_agent()
+
+    def _register_feature_flags_user_agent(self):
+        """Register feature_flags user agent to the AppConfig client"""
+        from aws_lambda_powertools.shared import user_agent
+
+        # Register feature_flags to the client used by the AppConfigProvider
+        if hasattr(self._conf_store, "client") and self._conf_store.client is not None:
+            user_agent.register_feature_to_client(client=self._conf_store.client, feature="feature_flags")
+
     @property
     def get_raw_configuration(self) -> dict[str, Any]:
         """Fetch feature schema configuration from AWS AppConfig"""


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
**Issue number:** #6334 

## Summary

### Changes

Fixes the user agent header for feature flags to use `feature_flags` instead of the generic `parameters` label when creating boto3 clients.

### User experience

> Please share what the user experience looks like before and after this change

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] [Meet tenets criteria](https://docs.powertools.aws.dev/lambda/python/#tenets)
* [x] I have performed a self-review of this change
* [ ] Changes have been tested
* [ ] Changes are documented
* [x] PR title follows [conventional commit semantics](https://github.com/aws-powertools/powertools-lambda-python/blob/develop/.github/semantic.yml)

<details>
<summary>Is this a breaking change?</summary>

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
