### PR TITLE
docs(parser): fix a a typo in SqsEnvelope

### DIFF
--- a/aws_lambda_powertools/utilities/parser/envelopes/sqs.py
+++ b/aws_lambda_powertools/utilities/parser/envelopes/sqs.py
@@ -19,7 +19,7 @@ class SqsEnvelope(BaseEnvelope):
     Regardless of its type it'll be parsed into a BaseModel object.
 
     Note: Records will be parsed the same way so if model is str,
-    all items in the list will be parsed as str and npt as JSON (and vice versa)
+    all items in the list will be parsed as str and not as JSON (and vice versa)
     """
 
     def parse(self, data: dict[str, Any] | Any | None, model: type[Model]) -> list[Model | None]:


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
**Issue number:** #7053 

## Summary

There is a small spelling mistake in the docstring for SqsEnvelope.

### Changes

npt -> not in a comment

### User experience

<img width="1086" height="306" alt="image" src="https://github.com/user-attachments/assets/5e39cdcc-7432-4943-ac59-7f7be3c0a100" />

<img width="1091" height="282" alt="image" src="https://github.com/user-attachments/assets/9e511f48-bfbf-4347-8090-fe24816a9a81" />


## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] [Meet tenets criteria](https://docs.powertools.aws.dev/lambda/python/#tenets)
* [ ] I have performed a self-review of this change
* [ ] Changes have been tested
* [x] Changes are documented
* [x] PR title follows [conventional commit semantics](https://github.com/aws-powertools/powertools-lambda-python/blob/develop/.github/semantic.yml)

<details>
<summary>Is this a breaking change?</summary>

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
