### PR TITLE
docs(logger): fix typo in sampling examples

### DIFF
--- a/examples/logger/src/sampling_debug_logs_with_decorator.py
+++ b/examples/logger/src/sampling_debug_logs_with_decorator.py
@@ -2,7 +2,7 @@ from aws_lambda_powertools import Logger
 from aws_lambda_powertools.utilities.typing import LambdaContext
 
 # Sample 10% of debug logs e.g. 0.1
-logger = Logger(service="payment", sample_rate=0.1)
+logger = Logger(service="payment", sampling_rate=0.1)
 
 
 @logger.inject_lambda_context

--- a/examples/logger/src/sampling_debug_logs_with_standalone_function.py
+++ b/examples/logger/src/sampling_debug_logs_with_standalone_function.py
@@ -2,7 +2,7 @@ from aws_lambda_powertools import Logger
 from aws_lambda_powertools.utilities.typing import LambdaContext
 
 # Sample 10% of debug logs e.g. 0.1
-logger = Logger(service="payment", sample_rate=0.1)
+logger = Logger(service="payment", sampling_rate=0.1)
 
 
 def lambda_handler(event: dict, context: LambdaContext):


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
**Issue number:** #7131 
Closes #7131

## Summary
Fixed the sampling example code present in the documentation regarding sampling.

### Changes

Changed sample_rate to sampling_rate on line 5 in both sampling_debug_logs_with_standalone_function.py and sampling_debug_logs_with_decorator.py.

### User experience

User's now have access to accurate example code in the sampling section of the documentation.

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] [Meet tenets criteria](https://docs.powertools.aws.dev/lambda/python/#tenets)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented
* [x] PR title follows [conventional commit semantics](https://github.com/aws-powertools/powertools-lambda-python/blob/develop/.github/semantic.yml)

<details>
<summary>Is this a breaking change? No</summary>

**RFC issue number**:

Checklist:

* [x] Migration process documented
* [x] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
