### PR TITLE
chore(git): add LLM tools to .gitignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -318,3 +318,8 @@ cdk.context.json
 
 # vim
 *.swp
+
+# LLMs
+.claude
+.amazonq
+.kiro

--- a/.gitignore
+++ b/.gitignore
@@ -323,3 +323,4 @@ cdk.context.json
 .claude
 .amazonq
 .kiro
+.github/instructions


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
**Issue number:** #7136 

## Summary

### Changes

Adding commonly used LLM tools to the `.gitignore` file to prevent their configuration folders from being removed when developers run `git clean`

### User experience

> Please share what the user experience looks like before and after this change

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] [Meet tenets criteria](https://docs.powertools.aws.dev/lambda/python/#tenets)
* [ ] I have performed a self-review of this change
* [ ] Changes have been tested
* [ ] Changes are documented
* [ ] PR title follows [conventional commit semantics](https://github.com/aws-powertools/powertools-lambda-python/blob/develop/.github/semantic.yml)

<details>
<summary>Is this a breaking change?</summary>

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
