### PR TITLE
chore(automation): update PR template to include closes command

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,5 +1,5 @@
 <!-- markdownlint-disable MD041 MD043 -->
-**Issue number:**
+**Issue number:** closes #<replace with issue number>
 
 ## Summary
 
@@ -11,29 +11,17 @@
 
 > Please share what the user experience looks like before and after this change
 
-## Checklist
+<!-------
+Before creating the pull request, please make sure you do the following:
 
-If your change doesn't seem to apply, please leave them unchecked.
+- Read the Contributing Guidelines at https://github.com/aws-powertools/powertools-lambda-python/blob/main/CONTRIBUTING.md#sending-a-pull-request
+- Check that there isn't already a PR that addresses the same issue. If you find a duplicate, please leave a comment under the existing PR so we can discuss how to move forward
+- Check that the change meets the project's tenets https://docs.powertools.aws.dev/lambda/python/latest/#tenets
+- Add a PR title that follows the conventional commit semantics - https://github.com/aws-powertools/powertools-lambda-python/blob/develop/.github/semantic.yml
+- If relevant, add tests that prove that the change is effective and works
+------->
 
-* [ ] [Meet tenets criteria](https://docs.powertools.aws.dev/lambda/python/#tenets)
-* [ ] I have performed a self-review of this change
-* [ ] Changes have been tested
-* [ ] Changes are documented
-* [ ] PR title follows [conventional commit semantics](https://github.com/aws-powertools/powertools-lambda-python/blob/develop/.github/semantic.yml)
-
-<details>
-<summary>Is this a breaking change?</summary>
-
-**RFC issue number**:
-
-Checklist:
-
-* [ ] Migration process documented
-* [ ] Implement warnings (if it can live side by side)
-
-</details>
-
-## Acknowledgment
+---
 
 By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
**Issue number:** closes #7171

## Summary

### Changes

> Please provide a summary of what's being changed


This PR updates the PR template to include the keyword `closes #` in the issue template, which should nudge contributors towards writing the issue in the correct format.

The PR also proposes light updates to the overall template to remove checkboxes in favor of the same items - but included as comments - and removes the breaking change/RFC section since it's never used.

The aim was to remove overhead, but if you don't like the proposal or prefer to take more time to think about it, I'm more than ok reverting the changes beyond the issue number one described above.

### User experience

> Please share what the user experience looks like before and after this change

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [ ] [Meet tenets criteria](https://docs.powertools.aws.dev/lambda/python/#tenets)
* [ ] I have performed a self-review of this change
* [ ] Changes have been tested
* [ ] Changes are documented
* [ ] PR title follows [conventional commit semantics](https://github.com/aws-powertools/powertools-lambda-python/blob/develop/.github/semantic.yml)

<details>
<summary>Is this a breaking change?</summary>

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
