### PR TITLE
docs: Add installation snippet for uv package manager

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -47,6 +47,7 @@ You can install Powertools for AWS Lambda (Python) using your favorite dependenc
     * **pip**: **`pip install "aws-lambda-powertools"`**{: .copyMe}
     * **poetry**: **`poetry add "aws-lambda-powertools"`**{: .copyMe}
     * **pdm**: **`pdm add "aws-lambda-powertools"`**{: .copyMe}
+    * **uv**: **`uv add "aws-lambda-powertools"`**{: .copyMe}
 
     ### Extra dependencies
 
@@ -299,6 +300,7 @@ You can install Powertools for AWS Lambda (Python) using your favorite dependenc
     - __Pip__: [**`pip install --pre "aws-lambda-powertools"`**](#){: .copyMe}
     - __Poetry__: [**`poetry add --allow-prereleases "aws-lambda-powertools" --group dev`**](#){: .copyMe}
     - __Pdm__: [**`pdm add -dG --prerelease "aws-lambda-powertools"`**](#){: .copyMe}
+    - __uv__: [**`uv add --prerelease allow "aws-lambda-powertools"`**](#){: .copyMe}
 
 ### Local development
 
@@ -309,6 +311,7 @@ Powertools for AWS Lambda (Python) relies on the [AWS SDK bundled in the Lambda 
 - __Pip__: [**`pip install "aws-lambda-powertools[aws-sdk]"`**](#){: .copyMe}
 - __Poetry__: [**`poetry add "aws-lambda-powertools[aws-sdk]" --group dev`**](#){: .copyMe}
 - __Pdm__: [**`pdm add -dG "aws-lambda-powertools[aws-sdk]"`**](#){: .copyMe}
+- __uv__: [**`uv add "aws-lambda-powertools[aws-sdk]"`**](#){: .copyMe}
 
 __A word about dependency resolution__
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
**Issue number:** closes #7262 

## Summary

Add snippets for installing powertools with the uv package manager

### Changes

Update the docs index page to include snippets for uv alongside the existing package management snippets.

I tested the commands locally

<!-------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/aws-powertools/powertools-lambda-python/blob/main/CONTRIBUTING.md#sending-a-pull-request
- Check that there isn't already a PR that addresses the same issue. If you find a duplicate, please leave a comment under the existing PR so we can discuss how to move forward
- Check that the change meets the project's tenets https://docs.powertools.aws.dev/lambda/python/latest/#tenets
- Add a PR title that follows the conventional commit semantics - https://github.com/aws-powertools/powertools-lambda-python/blob/develop/.github/semantic.yml
- If relevant, add tests that prove that the change is effective and works
------->

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
