### PR TITLE
refactor(parser): Improve Transfer Family models with examples and descriptions

### DIFF
--- a/aws_lambda_powertools/utilities/parser/models/transfer_family.py
+++ b/aws_lambda_powertools/utilities/parser/models/transfer_family.py
@@ -12,7 +12,7 @@ class TransferFamilyAuthorizer(BaseModel):
     password: Optional[str] = Field(
         default=None,
         description="The password for authentication.",
-        examples=["mysecretpassword", "Password1234", "secure-pass", None],
+        examples=["<password>", "<user-password>", None],
     )
     protocol: Literal["SFTP", "FTP", "FTPS"] = Field(
         description="The protocol used for the connection.",

--- a/aws_lambda_powertools/utilities/parser/models/transfer_family.py
+++ b/aws_lambda_powertools/utilities/parser/models/transfer_family.py
@@ -5,8 +5,28 @@ from pydantic.networks import IPvAnyAddress
 
 
 class TransferFamilyAuthorizer(BaseModel):
-    username: str
-    password: Optional[str] = None
-    protocol: Literal["SFTP", "FTP", "FTPS"]
-    server_id: str = Field(..., alias="serverId")
-    source_ip: IPvAnyAddress = Field(..., alias="sourceIp")
+    username: str = Field(
+        description="The username of the user attempting to authenticate.",
+        examples=["bobusa", "john.doe", "sftp-user-123", "data-transfer-user"],
+    )
+    password: Optional[str] = Field(
+        default=None,
+        description="The password for authentication.",
+        examples=["mysecretpassword", "Password1234", "secure-pass", None],
+    )
+    protocol: Literal["SFTP", "FTP", "FTPS"] = Field(
+        description="The protocol used for the connection.",
+        examples=["SFTP", "FTPS", "FTP"],
+    )
+    server_id: str = Field(
+        ...,
+        alias="serverId",
+        description="The server ID of the Transfer Family server.",
+        examples=["s-abcd123456", "s-1234567890abcdef0", "s-example123"],
+    )
+    source_ip: IPvAnyAddress = Field(
+        ...,
+        alias="sourceIp",
+        description="The IP address of the client connecting to the Transfer Family server.",
+        examples=["192.168.0.100", "10.0.0.50", "127.0.0.1", "203.0.113.12"],
+    )

--- a/aws_lambda_powertools/utilities/parser/models/transfer_family.py
+++ b/aws_lambda_powertools/utilities/parser/models/transfer_family.py
@@ -28,5 +28,4 @@ class TransferFamilyAuthorizer(BaseModel):
         ...,
         alias="sourceIp",
         description="The IP address of the client connecting to the Transfer Family server.",
-        examples=["192.168.0.100", "10.0.0.50", "127.0.0.1", "203.0.113.12"],
     )


### PR DESCRIPTION
**Issue number:** #7119

## Summary

Enhances the Transfer Family parser models with field descriptions and examples using Pydantic's Field() functionality. This improvement provides better documentation and metadata for Transfer Family event parsing, following the pattern established in PR #7100.

### Changes

- Added Field() descriptions and examples to the Transfer Family parser model:
  - `TransferFamilyAuthorizer` - Lambda authorizer event model with comprehensive field documentation

- All field descriptions are based on official AWS Transfer Family Lambda authorizer documentation
- Examples sourced from actual test events (transferFamilyAuthorizer.json) and AWS documentation
- Maintains 100% backward compatibility - no breaking changes to type annotations or validation logic
- Preserves existing field aliases (serverId, sourceIp) and IPvAnyAddress type validation

### User experience

Customers will be able to see examples and descriptions when using Transfer Family parser models, providing:
- Rich IntelliSense with field descriptions and realistic examples
- Self-documenting code without needing external AWS documentation  
- Professional API documentation via .model_json_schema()
- Faster development with immediate reference for acceptable values
- Clear understanding of Transfer Family Lambda authorizer event structure

## Checklist

- [x] Meet tenets criteria
- [x] I have performed a self-review of this change
- [x] Changes have been tested (all existing tests pass)
- [x] Changes are documented (via Field descriptions)
- [x] PR title follows conventional commit semantics

**Is this a breaking change?** No

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.

Closes #7119