### PR TITLE
docs: fix SSM recursive parameter highlighting

### DIFF
--- a/docs/utilities/parameters.md
+++ b/docs/utilities/parameters.md
@@ -243,7 +243,7 @@ For greater flexibility such as configuring the underlying SDK client used by bu
     ```
 
 === "builtin_provider_ssm_recursive_parameter.py"
-    ```python hl_lines="6 19-25"
+    ```python hl_lines="6 26 32"
     --8<-- "examples/parameters/src/builtin_provider_ssm_recursive_parameter.py"
     ```
 


### PR DESCRIPTION
## Summary

This PR fixes incorrect syntax highlighting in the Parameters utility documentation for SSM Provider recursive parameters, addressing issue #7281.

## Changes Made

• Fixed highlighting to focus on Powertools-specific code instead of boto3 setup
• Changed `hl_lines="6 19-25"` to `hl_lines="6 26 32"` in SSM recursive parameter example

## Before

```python hl_lines="6 19-25"
# Highlighted boto3 session setup (lines 19-25) - not relevant for learning Powertools
```

## After

```python hl_lines="6 26 32"  
# Highlights actual Powertools usage:
# Line 6: Powertools import
# Line 26: SSMProvider creation  
# Line 32: get_multiple() method call
```

## Why This Matters

The current highlighting teaches users about AWS SDK setup, but developers come to learn about Powertools. The fix focuses attention on the actual Powertools-specific code that matters for learning the utility.

Issue number: closes #7281

--------

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
