### PR TITLE
fix(docs): correct build optimization script and docs

### DIFF
--- a/docs/build_recipes/performance-optimization.md
+++ b/docs/build_recipes/performance-optimization.md
@@ -7,6 +7,8 @@ description: Optimize Lambda functions for better performance and reduced costs
 
 Optimize your Lambda functions for better performance, reduced cold start times, and lower costs. These techniques help minimize package size, improve startup speed, and reduce memory usage.
 
+Always validate your function's behavior after applying optimizations to ensure an optimization hasn't introduced any issues with your packages. For example, removal of directories that appear to be unnecessary, such as `docs`, can break some libraries. 
+
 ## Reduce cold start times
 
 1. **Minimize package size** by excluding unnecessary files

--- a/examples/build_recipes/build_optimization/optimize-advanced.sh
+++ b/examples/build_recipes/build_optimization/optimize-advanced.sh
@@ -15,7 +15,6 @@ find build/ -name "*.so.*" -exec strip --strip-debug {} \; 2>/dev/null || true
 rm -rf build/*/site-packages/*/tests/
 rm -rf build/*/site-packages/*/test/
 rm -rf build/*/site-packages/*/.git/
-rm -rf build/*/site-packages/*/docs/
 rm -rf build/*/site-packages/*/examples/
 rm -rf build/*/site-packages/*/*.md
 rm -rf build/*/site-packages/*/*.rst

--- a/examples/build_recipes/build_optimization/optimize-package.sh
+++ b/examples/build_recipes/build_optimization/optimize-package.sh
@@ -7,8 +7,7 @@ find build/ -name "*.dist-info" -type d -exec rm -rf {} +
 find build/ -name "tests" -type d -exec rm -rf {} +
 find build/ -name "test_*" -delete
 
-# Remove documentation and examples
-find build/ -name "docs" -type d -exec rm -rf {} +
+# Remove examples
 find build/ -name "examples" -type d -exec rm -rf {} +
 
 echo "✅ Package optimized"


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
**Issue number:** closes #7361

## Summary
The build optimization script was removing the docs directory, which is a dependency of boto3. 

### Changes
This change removes the line that removes the docs directory and adds a warning to the documentation to test the build after optimization.

### User experience

A copy and paste of the example will no longer break a vendored version of boto3. The prompt that removing directories may have side effects may direct some to perform a test when they may otherwise not, avoiding issues .

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
