### PR TITLE
docs(event_handler): remove the wrong CORS warning

### DIFF
--- a/docs/core/event_handler/api_gateway.md
+++ b/docs/core/event_handler/api_gateway.md
@@ -1144,7 +1144,7 @@ You can enable debug mode via `debug` param, or via `POWERTOOLS_DEV` [environmen
 This will enable full tracebacks errors in the response, print request and responses, and set CORS in development mode.
 
 ???+ danger
-    This might reveal sensitive information in your logs and relax CORS restrictions, use it sparingly.
+    This might reveal sensitive information in your logs, use it sparingly.
 
     It's best to use for local development only!
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
**Issue number:** closes #7379 

## Summary

### Changes

Remove the wrong warning about relaxing CORS.

### User experience

> Please share what the user experience looks like before and after this change

<!-------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/aws-powertools/powertools-lambda-python/blob/main/CONTRIBUTING.md#sending-a-pull-request
- Check that there isn't already a PR that addresses the same issue. If you find a duplicate, please leave a comment under the existing PR so we can discuss how to move forward
- Check that the change meets the project's tenets https://docs.powertools.aws.dev/lambda/python/latest/#tenets
- Add a PR title that follows the conventional commit semantics - https://github.com/aws-powertools/powertools-lambda-python/blob/develop/.github/semantic.yml
- If relevant, add tests that prove that the change is effective and works
------->

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
