### PR TITLE
docs(batch): fix error handling code highlight line number

### DIFF
--- a/docs/utilities/batch.md
+++ b/docs/utilities/batch.md
@@ -243,7 +243,7 @@ By default, we catch any exception raised by your record handler function. This 
 
 === "Sample error handling with custom exception"
 
-    ```python title="" hl_lines="24"
+    ```python title="" hl_lines="23"
     --8<-- "examples/batch_processing/src/getting_started_error_handling.py"
     ```
 


### PR DESCRIPTION
**Issue number:** closes #7637

## Summary

### Changes

Fixed incorrect line highlighting in the batch processing error handling documentation. Changed `hl_lines="24"` to `hl_lines="23"` in docs/utilities/batch.md to correctly highlight the line where the `raise InvalidPayload` exception is raised instead of highlighting an empty line.

### User experience

**Before:** Documentation highlighted line 24, which is an empty line, making it unclear which code demonstrates the error handling behavior.

**After:** Documentation now correctly highlights line 23, where the `raise InvalidPayload("Payload does not contain minimum information to be processed.")` statement occurs, clearly showing the error handling example.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.