### PR TITLE
docs(openapi): Update docstring's openapi default version to match current default version

### DIFF
--- a/aws_lambda_powertools/event_handler/api_gateway.py
+++ b/aws_lambda_powertools/event_handler/api_gateway.py
@@ -1827,7 +1827,7 @@ class ApiGatewayResolver(BaseRouter):
             The title of the application.
         version: str
             The version of the OpenAPI document (which is distinct from the OpenAPI Specification version or the API
-        openapi_version: str, default = "3.0.0"
+        openapi_version: str, default = "3.1.0"
             The version of the OpenAPI Specification (which the document uses).
         summary: str, optional
             A short summary of what the application does.
@@ -2041,7 +2041,7 @@ class ApiGatewayResolver(BaseRouter):
             The title of the application.
         version: str
             The version of the OpenAPI document (which is distinct from the OpenAPI Specification version or the API
-        openapi_version: str, default = "3.0.0"
+        openapi_version: str, default = "3.1.0"
             The version of the OpenAPI Specification (which the document uses).
         summary: str, optional
             A short summary of what the application does.
@@ -2124,7 +2124,7 @@ class ApiGatewayResolver(BaseRouter):
             The title of the application.
         version: str
             The version of the OpenAPI document (which is distinct from the OpenAPI Specification version or the API
-        openapi_version: str, default = "3.0.0"
+        openapi_version: str, default = "3.1.0"
             The version of the OpenAPI Specification (which the document uses).
         summary: str, optional
             A short summary of what the application does.
@@ -2218,7 +2218,7 @@ class ApiGatewayResolver(BaseRouter):
             The title of the application.
         version: str
             The version of the OpenAPI document (which is distinct from the OpenAPI Specification version or the API
-        openapi_version: str, default = "3.0.0"
+        openapi_version: str, default = "3.1.0"
             The version of the OpenAPI Specification (which the document uses).
         summary: str, optional
             A short summary of what the application does.

--- a/aws_lambda_powertools/event_handler/openapi/config.py
+++ b/aws_lambda_powertools/event_handler/openapi/config.py
@@ -32,7 +32,7 @@ class OpenAPIConfig:
         The title of the application.
     version: str
         The version of the OpenAPI document (which is distinct from the OpenAPI Specification version or the API
-    openapi_version: str, default = "3.0.0"
+    openapi_version: str, default = "3.1.0"
         The version of the OpenAPI Specification (which the document uses).
     summary: str, optional
         A short summary of what the application does.


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
**Issue number:** closes #7668

## Summary
Updated openapi default version docstring to match current value of 3.1.0.

### Changes

> Please provide a summary of what's being changed
Changed docstrings of openapi-related functions and classes that had a wrong docstring default value for openapi version.

### User experience

> Please share what the user experience looks like before and after this change

<!-------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/aws-powertools/powertools-lambda-python/blob/main/CONTRIBUTING.md#sending-a-pull-request
- Check that there isn't already a PR that addresses the same issue. If you find a duplicate, please leave a comment under the existing PR so we can discuss how to move forward
- Check that the change meets the project's tenets https://docs.powertools.aws.dev/lambda/python/latest/#tenets
- Add a PR title that follows the conventional commit semantics - https://github.com/aws-powertools/powertools-lambda-python/blob/develop/.github/semantic.yml
- If relevant, add tests that prove that the change is effective and works
------->

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
