### PR TITLE
refactor(event-handler): remove kwargs from AppSync exception constructor

### DIFF
--- a/aws_lambda_powertools/event_handler/events_appsync/exceptions.py
+++ b/aws_lambda_powertools/event_handler/events_appsync/exceptions.py
@@ -12,14 +12,13 @@ class UnauthorizedException(Exception):
         message (str): The error message describing the unauthorized access.
     """
 
-    def __init__(self, message: str | None = None, *args, **kwargs):
+    def __init__(self, message: str | None = None, *args):
         """
         Initialize the UnauthorizedException.
 
         Args:
             message (str): A descriptive error message.
             *args: Variable positional arguments.
-            **kwargs: Variable keyword arguments.
         """
-        super().__init__(message, *args, **kwargs)
+        super().__init__(message, *args)
         self.name = "UnauthorizedException"


### PR DESCRIPTION
**Issue number:** closes #7693 

## Summary
Remove `**kwargs` from the signature to avoid confusing customers.

### Changes
Delete `**kwargs` from argument and doc.

### User experience

User will not be confused by the signatures.
<!-------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/aws-powertools/powertools-lambda-python/blob/main/CONTRIBUTING.md#sending-a-pull-request
- Check that there isn't already a PR that addresses the same issue. If you find a duplicate, please leave a comment under the existing PR so we can discuss how to move forward
- Check that the change meets the project's tenets https://docs.powertools.aws.dev/lambda/python/latest/#tenets
- Add a PR title that follows the conventional commit semantics - https://github.com/aws-powertools/powertools-lambda-python/blob/develop/.github/semantic.yml
- If relevant, add tests that prove that the change is effective and works
------->

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.

