### PR TITLE
chore(ci): remove daily changelog rebuild schedule

### DIFF
--- a/.github/workflows/build_changelog.yml
+++ b/.github/workflows/build_changelog.yml
@@ -9,16 +9,10 @@ name: Build changelog
 
 # USAGE
 #
-# Always triggered on PR merge or manually from GitHub UI if we must.
+# Triggered manually from GitHub UI when needed (e.g., before a release).
 
 on:
   workflow_dispatch:
-#  push:
-#    branches:
-#      - develop
-  schedule:
-    # Note: run daily at 10am UTC time until upstream git-chlog uses stable sorting
-    - cron: "0 10 * * *"
 
 permissions:
   contents: read


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
**Issue number:** closes #7880

## Summary

Remove daily scheduled changelog rebuild to reduce noise. The changelog will now only be updated manually when needed (e.g., before releases).

### Changes

> Please provide a summary of what's being changed

### User experience

> Please share what the user experience looks like before and after this change

<!-------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/aws-powertools/powertools-lambda-python/blob/main/CONTRIBUTING.md#sending-a-pull-request
- Check that there isn't already a PR that addresses the same issue. If you find a duplicate, please leave a comment under the existing PR so we can discuss how to move forward
- Check that the change meets the project's tenets https://docs.powertools.aws.dev/lambda/python/latest/#tenets
- Add a PR title that follows the conventional commit semantics - https://github.com/aws-powertools/powertools-lambda-python/blob/develop/.github/semantic.yml
- If relevant, add tests that prove that the change is effective and works
------->

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
