### PR TITLE
fix(event_handler): fix bug regression in Annotated field

### DIFF
--- a/aws_lambda_powertools/event_handler/openapi/params.py
+++ b/aws_lambda_powertools/event_handler/openapi/params.py
@@ -1112,11 +1112,23 @@ def get_field_info_annotated_type(annotation, value, is_path_param: bool) -> tup
     """
     annotated_args = get_args(annotation)
     type_annotation = annotated_args[0]
-    powertools_annotations = [arg for arg in annotated_args[1:] if isinstance(arg, FieldInfo)]
+
+    # Handle both FieldInfo instances and FieldInfo subclasses (e.g., Body vs Body())
+    powertools_annotations: list[FieldInfo] = []
+    for arg in annotated_args[1:]:
+        if isinstance(arg, FieldInfo):
+            powertools_annotations.append(arg)
+        elif isinstance(arg, type) and issubclass(arg, FieldInfo):
+            # If it's a class (e.g., Body instead of Body()), instantiate it
+            powertools_annotations.append(arg())
 
     # Preserve non-FieldInfo metadata (like annotated_types constraints)
     # This is important for constraints like Interval, Gt, Lt, etc.
-    other_metadata = [arg for arg in annotated_args[1:] if not isinstance(arg, FieldInfo)]
+    other_metadata = [
+        arg
+        for arg in annotated_args[1:]
+        if not isinstance(arg, FieldInfo) and not (isinstance(arg, type) and issubclass(arg, FieldInfo))
+    ]
 
     # Determine which annotation to use
     powertools_annotation: FieldInfo | None = None

--- a/tests/functional/event_handler/_pydantic/test_openapi_params.py
+++ b/tests/functional/event_handler/_pydantic/test_openapi_params.py
@@ -1267,3 +1267,123 @@ def test_annotated_types_interval_in_openapi_schema():
     assert limit_param.schema_.type == "integer"
     assert limit_param.schema_.default == 10
     assert limit_param.required is False
+
+
+def test_body_class_annotation_without_parentheses():
+    """
+    GIVEN an endpoint using Body class (not instance) in Annotated
+    WHEN sending a valid request body
+    THEN the request should be validated correctly
+    """
+    app = APIGatewayRestResolver(enable_validation=True)
+
+    class MyRequest(BaseModel):
+        foo: str
+        bar: str = "default_bar"
+
+    class MyResponse(BaseModel):
+        concatenated: str
+
+    # Using Body (class) instead of Body() (instance)
+    @app.patch("/test")
+    def handler(body: Annotated[MyRequest, Body]) -> MyResponse:
+        return MyResponse(concatenated=body.foo + body.bar)
+
+    event = {
+        "resource": "/test",
+        "path": "/test",
+        "httpMethod": "PATCH",
+        "body": '{"foo": "hello"}',
+        "isBase64Encoded": False,
+    }
+
+    result = app(event, {})
+    assert result["statusCode"] == 200
+    response_body = json.loads(result["body"])
+    assert response_body["concatenated"] == "hellodefault_bar"
+
+
+def test_body_instance_annotation_with_parentheses():
+    """
+    GIVEN an endpoint using Body() instance in Annotated
+    WHEN sending a valid request body
+    THEN the request should be validated correctly
+    """
+    app = APIGatewayRestResolver(enable_validation=True)
+
+    class MyRequest(BaseModel):
+        foo: str
+        bar: str = "default_bar"
+
+    class MyResponse(BaseModel):
+        concatenated: str
+
+    # Using Body() (instance)
+    @app.patch("/test")
+    def handler(body: Annotated[MyRequest, Body()]) -> MyResponse:
+        return MyResponse(concatenated=body.foo + body.bar)
+
+    event = {
+        "resource": "/test",
+        "path": "/test",
+        "httpMethod": "PATCH",
+        "body": '{"foo": "hello"}',
+        "isBase64Encoded": False,
+    }
+
+    result = app(event, {})
+    assert result["statusCode"] == 200
+    response_body = json.loads(result["body"])
+    assert response_body["concatenated"] == "hellodefault_bar"
+
+
+def test_query_class_annotation_without_parentheses():
+    """
+    GIVEN an endpoint using Query class (not instance) in Annotated
+    WHEN sending a valid query parameter
+    THEN the request should be validated correctly
+    """
+    app = APIGatewayRestResolver(enable_validation=True)
+
+    @app.get("/test")
+    def handler(name: Annotated[str, Query]) -> dict:
+        return {"name": name}
+
+    event = {
+        "resource": "/test",
+        "path": "/test",
+        "httpMethod": "GET",
+        "queryStringParameters": {"name": "hello"},
+        "isBase64Encoded": False,
+    }
+
+    result = app(event, {})
+    assert result["statusCode"] == 200
+    response_body = json.loads(result["body"])
+    assert response_body["name"] == "hello"
+
+
+def test_header_class_annotation_without_parentheses():
+    """
+    GIVEN an endpoint using Header class (not instance) in Annotated
+    WHEN sending a valid header
+    THEN the request should be validated correctly
+    """
+    app = APIGatewayRestResolver(enable_validation=True)
+
+    @app.get("/test")
+    def handler(x_custom: Annotated[str, Header]) -> dict:
+        return {"header": x_custom}
+
+    event = {
+        "resource": "/test",
+        "path": "/test",
+        "httpMethod": "GET",
+        "headers": {"x-custom": "my-value"},
+        "isBase64Encoded": False,
+    }
+
+    result = app(event, {})
+    assert result["statusCode"] == 200
+    response_body = json.loads(result["body"])
+    assert response_body["header"] == "my-value"


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
**Issue number:** closes #7673 

## Summary

This PR fixes a regression introduced in 3.22.1 where using `Annotated[..., Body] `(class) instead of `Annotated[..., Body()] `(instance) would fail validation with a 422 error.

### Changes

> Please provide a summary of what's being changed

### User experience

> Please share what the user experience looks like before and after this change

<!-------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/aws-powertools/powertools-lambda-python/blob/main/CONTRIBUTING.md#sending-a-pull-request
- Check that there isn't already a PR that addresses the same issue. If you find a duplicate, please leave a comment under the existing PR so we can discuss how to move forward
- Check that the change meets the project's tenets https://docs.powertools.aws.dev/lambda/python/latest/#tenets
- Add a PR title that follows the conventional commit semantics - https://github.com/aws-powertools/powertools-lambda-python/blob/develop/.github/semantic.yml
- If relevant, add tests that prove that the change is effective and works
------->

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
