### PR TITLE
feat(logger,metrics): add DurableContext support for decorators

### DIFF
--- a/aws_lambda_powertools/logging/lambda_context.py
+++ b/aws_lambda_powertools/logging/lambda_context.py
@@ -1,4 +1,9 @@
-from typing import Any
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from aws_lambda_powertools.utilities.typing import LambdaContext
 
 
 class LambdaContextModel:
@@ -34,25 +39,47 @@ class LambdaContextModel:
         self.function_request_id = function_request_id
 
 
+def _unwrap_durable_context(context: Any) -> LambdaContext:
+    """Unwrap Lambda Context from DurableContext if applicable.
+
+    Parameters
+    ----------
+    context : object
+        Lambda context object or DurableContext
+
+    Returns
+    -------
+    LambdaContext
+        The unwrapped Lambda context
+    """
+    # Check if this is a DurableContext by duck typing
+    if hasattr(context, "lambda_context") and hasattr(context, "state"):
+        return context.lambda_context
+
+    return context
+
+
 def build_lambda_context_model(context: Any) -> LambdaContextModel:
     """Captures Lambda function runtime info to be used across all log statements
 
     Parameters
     ----------
     context : object
-        Lambda context object
+        Lambda context object or DurableContext
 
     Returns
     -------
     LambdaContextModel
         Lambda context only with select fields
     """
+    # Unwrap DurableContext if applicable
+    lambda_context = _unwrap_durable_context(context)
 
     context = {
-        "function_name": context.function_name,
-        "function_memory_size": context.memory_limit_in_mb,
-        "function_arn": context.invoked_function_arn,
-        "function_request_id": context.aws_request_id,
+        "function_name": lambda_context.function_name,
+        "function_memory_size": lambda_context.memory_limit_in_mb,
+        "function_arn": lambda_context.invoked_function_arn,
+        "function_request_id": lambda_context.aws_request_id,
     }
 
     return LambdaContextModel(**context)

--- a/aws_lambda_powertools/logging/logger.py
+++ b/aws_lambda_powertools/logging/logger.py
@@ -473,6 +473,11 @@ class Logger:
         POWERTOOLS_LOGGER_LOG_EVENT : str
             instruct logger to log Lambda Event (e.g. `"true", "True", "TRUE"`)
 
+        Notes
+        -----
+        Supports both standard Lambda Context and DurableContext from AWS Durable Execution SDK.
+        When DurableContext is passed, it automatically unwraps the underlying Lambda Context.
+
         Example
         -------
         **Captures Lambda contextual runtime info (e.g memory, arn, req_id)**

--- a/aws_lambda_powertools/metrics/provider/base.py
+++ b/aws_lambda_powertools/metrics/provider/base.py
@@ -14,6 +14,26 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
+def _unwrap_durable_context(context: Any) -> LambdaContext:
+    """Unwrap Lambda Context from DurableContext if applicable.
+
+    Parameters
+    ----------
+    context : object
+        Lambda context object or DurableContext
+
+    Returns
+    -------
+    LambdaContext
+        The unwrapped Lambda context
+    """
+    # Check if this is a DurableContext by duck typing
+    if hasattr(context, "lambda_context") and hasattr(context, "state"):
+        return context.lambda_context
+
+    return context
+
+
 class BaseProvider(ABC):
     """
     Interface to create a metrics provider.
@@ -177,6 +197,11 @@ class BaseProvider(ABC):
         default_dimensions: dict[str, str], optional
             metric dimensions as key=value that will always be present
 
+        Notes
+        -----
+        Supports both standard Lambda Context and DurableContext from AWS Durable Execution SDK.
+        When DurableContext is passed, it automatically unwraps the underlying Lambda Context.
+
         Raises
         ------
         e
@@ -221,13 +246,15 @@ class BaseProvider(ABC):
         Parameters
         ----------
         context : Any
-            Lambda context
+            Lambda context or DurableContext
         """
         if not cold_start.is_cold_start:
             return
 
         logger.debug("Adding cold start metric and function_name dimension")
-        self.add_cold_start_metric(context=context)
+        # Unwrap DurableContext if applicable before passing to add_cold_start_metric
+        lambda_context = _unwrap_durable_context(context)
+        self.add_cold_start_metric(context=lambda_context)
 
         cold_start.is_cold_start = False
 

--- a/tests/functional/logger/required_dependencies/test_logger_durable_context.py
+++ b/tests/functional/logger/required_dependencies/test_logger_durable_context.py
@@ -66,7 +66,7 @@ def test_inject_lambda_context_with_durable_context(durable_context, stdout, ser
 
     # THEN lambda contextual info from the unwrapped context should be in the logs
     log = capture_logging_output(stdout)
-    
+
     expected_logger_context_keys = (
         "function_name",
         "function_memory_size",
@@ -75,7 +75,7 @@ def test_inject_lambda_context_with_durable_context(durable_context, stdout, ser
     )
     for key in expected_logger_context_keys:
         assert key in log
-    
+
     # Verify the actual values match the embedded lambda_context
     assert log["function_name"] == durable_context.lambda_context.function_name
     assert log["function_memory_size"] == durable_context.lambda_context.memory_limit_in_mb
@@ -88,7 +88,7 @@ def test_inject_lambda_context_with_durable_context_log_event(durable_context, s
     """Test that inject_lambda_context with log_event=True works with DurableContext."""
     # GIVEN Logger is initialized
     logger = Logger(service=service_name, stream=stdout)
-    
+
     test_event = {"test_key": "test_value"}
 
     # WHEN a lambda function is decorated with log_event=True and receives DurableContext
@@ -101,7 +101,7 @@ def test_inject_lambda_context_with_durable_context_log_event(durable_context, s
     # THEN both the event and lambda contextual info should be logged
     logs = capture_multiple_logging_statements_output(stdout)
     assert len(logs) >= 2  # At least event log and info log
-    
+
     # First log should be the event
     assert logs[0]["message"] == test_event
 
@@ -121,11 +121,11 @@ def test_inject_lambda_context_with_durable_context_clear_state(durable_context,
 
     # THEN the custom key should be cleared and lambda context should be present
     log = capture_logging_output(stdout)
-    
+
     # Lambda context fields should be present
     assert "function_name" in log
     assert log["function_name"] == durable_context.lambda_context.function_name
-    
+
     # Custom key should not be present (cleared)
     assert "custom_key" not in log or log.get("custom_key") != "initial_value"
 
@@ -144,7 +144,7 @@ def test_inject_lambda_context_standard_context_still_works(lambda_context, stdo
 
     # THEN lambda contextual info should be in the logs
     log = capture_logging_output(stdout)
-    
+
     expected_logger_context_keys = (
         "function_name",
         "function_memory_size",
@@ -153,6 +153,6 @@ def test_inject_lambda_context_standard_context_still_works(lambda_context, stdo
     )
     for key in expected_logger_context_keys:
         assert key in log
-    
+
     assert log["function_name"] == lambda_context.function_name
     assert log["message"] == "Hello from standard lambda"

--- a/tests/functional/logger/required_dependencies/test_logger_durable_context.py
+++ b/tests/functional/logger/required_dependencies/test_logger_durable_context.py
@@ -1,0 +1,158 @@
+"""Tests for Logger with DurableContext support."""
+
+import io
+import json
+import random
+import string
+from collections import namedtuple
+from unittest.mock import Mock
+
+import pytest
+
+from aws_lambda_powertools import Logger
+from aws_lambda_powertools.utilities.typing import DurableContextProtocol
+
+
+@pytest.fixture
+def stdout():
+    return io.StringIO()
+
+
+@pytest.fixture
+def lambda_context():
+    lambda_context = {
+        "function_name": "test",
+        "memory_limit_in_mb": 128,
+        "invoked_function_arn": "arn:aws:lambda:eu-west-1:809313241:function:test",
+        "aws_request_id": "52fdfc07-2182-154f-163f-5f0f9a621d72",
+    }
+    return namedtuple("LambdaContext", lambda_context.keys())(*lambda_context.values())
+
+
+@pytest.fixture
+def service_name():
+    chars = string.ascii_letters + string.digits
+    return "".join(random.SystemRandom().choice(chars) for _ in range(15))
+
+
+def capture_logging_output(stdout):
+    return json.loads(stdout.getvalue().strip())
+
+
+def capture_multiple_logging_statements_output(stdout):
+    return [json.loads(line.strip()) for line in stdout.getvalue().split("\n") if line]
+
+
+@pytest.fixture
+def durable_context(lambda_context):
+    """Create a mock DurableContext with embedded Lambda context."""
+    durable_ctx = Mock(spec=DurableContextProtocol)
+    durable_ctx.lambda_context = lambda_context
+    durable_ctx.state = Mock(operations=[{"id": "op1"}])
+    return durable_ctx
+
+
+def test_inject_lambda_context_with_durable_context(durable_context, stdout, service_name):
+    """Test that inject_lambda_context works with DurableContext."""
+    # GIVEN Logger is initialized
+    logger = Logger(service=service_name, stream=stdout)
+
+    # WHEN a lambda function is decorated with logger and receives DurableContext
+    @logger.inject_lambda_context
+    def handler(event, context):
+        logger.info("Hello from durable function")
+
+    handler({}, durable_context)
+
+    # THEN lambda contextual info from the unwrapped context should be in the logs
+    log = capture_logging_output(stdout)
+    
+    expected_logger_context_keys = (
+        "function_name",
+        "function_memory_size",
+        "function_arn",
+        "function_request_id",
+    )
+    for key in expected_logger_context_keys:
+        assert key in log
+    
+    # Verify the actual values match the embedded lambda_context
+    assert log["function_name"] == durable_context.lambda_context.function_name
+    assert log["function_memory_size"] == durable_context.lambda_context.memory_limit_in_mb
+    assert log["function_arn"] == durable_context.lambda_context.invoked_function_arn
+    assert log["function_request_id"] == durable_context.lambda_context.aws_request_id
+    assert log["message"] == "Hello from durable function"
+
+
+def test_inject_lambda_context_with_durable_context_log_event(durable_context, stdout, service_name):
+    """Test that inject_lambda_context with log_event=True works with DurableContext."""
+    # GIVEN Logger is initialized
+    logger = Logger(service=service_name, stream=stdout)
+    
+    test_event = {"test_key": "test_value"}
+
+    # WHEN a lambda function is decorated with log_event=True and receives DurableContext
+    @logger.inject_lambda_context(log_event=True)
+    def handler(event, context):
+        logger.info("Processing event")
+
+    handler(test_event, durable_context)
+
+    # THEN both the event and lambda contextual info should be logged
+    logs = capture_multiple_logging_statements_output(stdout)
+    assert len(logs) >= 2  # At least event log and info log
+    
+    # First log should be the event
+    assert logs[0]["message"] == test_event
+
+
+def test_inject_lambda_context_with_durable_context_clear_state(durable_context, stdout, service_name):
+    """Test that inject_lambda_context with clear_state works with DurableContext."""
+    # GIVEN Logger is initialized with custom keys
+    logger = Logger(service=service_name, stream=stdout)
+    logger.append_keys(custom_key="initial_value")
+
+    # WHEN a lambda function is decorated with clear_state=True and receives DurableContext
+    @logger.inject_lambda_context(clear_state=True)
+    def handler(event, context):
+        logger.info("After clear state")
+
+    handler({}, durable_context)
+
+    # THEN the custom key should be cleared and lambda context should be present
+    log = capture_logging_output(stdout)
+    
+    # Lambda context fields should be present
+    assert "function_name" in log
+    assert log["function_name"] == durable_context.lambda_context.function_name
+    
+    # Custom key should not be present (cleared)
+    assert "custom_key" not in log or log.get("custom_key") != "initial_value"
+
+
+def test_inject_lambda_context_standard_context_still_works(lambda_context, stdout, service_name):
+    """Test that standard Lambda context still works (regression test)."""
+    # GIVEN Logger is initialized
+    logger = Logger(service=service_name, stream=stdout)
+
+    # WHEN a lambda function is decorated with logger and receives standard LambdaContext
+    @logger.inject_lambda_context
+    def handler(event, context):
+        logger.info("Hello from standard lambda")
+
+    handler({}, lambda_context)
+
+    # THEN lambda contextual info should be in the logs
+    log = capture_logging_output(stdout)
+    
+    expected_logger_context_keys = (
+        "function_name",
+        "function_memory_size",
+        "function_arn",
+        "function_request_id",
+    )
+    for key in expected_logger_context_keys:
+        assert key in log
+    
+    assert log["function_name"] == lambda_context.function_name
+    assert log["message"] == "Hello from standard lambda"

--- a/tests/functional/metrics/required_dependencies/test_metrics_durable_context.py
+++ b/tests/functional/metrics/required_dependencies/test_metrics_durable_context.py
@@ -17,8 +17,23 @@ def capture_metrics_output(capsys):
     return json.loads(capsys.readouterr().out.strip())
 
 
+def capture_metrics_output_multiple_emf_objects(capsys):
+    return [json.loads(line.strip()) for line in capsys.readouterr().out.split("\n") if line]
+
+
 def reset_cold_start_flag():
     cold_start.is_cold_start = True
+
+
+@pytest.fixture
+def lambda_context():
+    lambda_context = {
+        "function_name": "test",
+        "memory_limit_in_mb": 128,
+        "invoked_function_arn": "arn:aws:lambda:eu-west-1:809313241:function:test",
+        "aws_request_id": "52fdfc07-2182-154f-163f-5f0f9a621d72",
+    }
+    return namedtuple("LambdaContext", lambda_context.keys())(*lambda_context.values())
 
 
 @pytest.fixture
@@ -79,12 +94,13 @@ def test_log_metrics_capture_cold_start_with_durable_context(capsys, namespace, 
     lambda_handler({}, durable_ctx)
 
     # THEN ColdStart metric should be captured with the function name from unwrapped context
-    output = capture_metrics_output(capsys)
+    outputs = capture_metrics_output_multiple_emf_objects(capsys)
     
-    assert "ColdStart" in output or output.get("ColdStart") == [1.0]
-    # The function_name should come from the unwrapped lambda_context
-    assert output.get("function_name") == "durable_test_function"
-    assert output["service"] == service
+    # Cold start is in a separate EMF blob
+    cold_start_output = outputs[0]
+    assert cold_start_output["ColdStart"] == [1.0]
+    assert cold_start_output["function_name"] == "durable_test_function"
+    assert cold_start_output["service"] == service
 
 
 def test_log_metrics_capture_cold_start_with_durable_context_explicit_function_name(

--- a/tests/functional/metrics/required_dependencies/test_metrics_durable_context.py
+++ b/tests/functional/metrics/required_dependencies/test_metrics_durable_context.py
@@ -7,10 +7,10 @@ from unittest.mock import Mock
 import pytest
 
 from aws_lambda_powertools import Metrics
-from aws_lambda_powertools.utilities.typing import DurableContextProtocol
 
 # Reset cold start flag before each test
 from aws_lambda_powertools.metrics.provider import cold_start
+from aws_lambda_powertools.utilities.typing import DurableContextProtocol
 
 
 def capture_metrics_output(capsys):
@@ -66,7 +66,7 @@ def test_log_metrics_with_durable_context_basic(capsys, namespace, service, dura
 
     # THEN metrics should be emitted successfully
     output = capture_metrics_output(capsys)
-    
+
     assert output["test_metric"] == [1.0]
     assert output["service"] == service
 
@@ -74,14 +74,14 @@ def test_log_metrics_with_durable_context_basic(capsys, namespace, service, dura
 def test_log_metrics_capture_cold_start_with_durable_context(capsys, namespace, service):
     """Test that capture_cold_start_metric works with DurableContext."""
     reset_cold_start_flag()
-    
+
     # GIVEN Metrics is initialized
     my_metrics = Metrics(service=service, namespace=namespace)
-    
+
     # Create a DurableContext with embedded Lambda context
     LambdaContext = namedtuple("LambdaContext", "function_name")
     lambda_ctx = LambdaContext("durable_test_function")
-    
+
     durable_ctx = Mock(spec=DurableContextProtocol)
     durable_ctx.lambda_context = lambda_ctx
     durable_ctx.state = Mock(operations=[{"id": "op1"}])
@@ -95,7 +95,7 @@ def test_log_metrics_capture_cold_start_with_durable_context(capsys, namespace, 
 
     # THEN ColdStart metric should be captured with the function name from unwrapped context
     outputs = capture_metrics_output_multiple_emf_objects(capsys)
-    
+
     # Cold start is in a separate EMF blob
     cold_start_output = outputs[0]
     assert cold_start_output["ColdStart"] == [1.0]
@@ -103,19 +103,17 @@ def test_log_metrics_capture_cold_start_with_durable_context(capsys, namespace, 
     assert cold_start_output["service"] == service
 
 
-def test_log_metrics_capture_cold_start_with_durable_context_explicit_function_name(
-    capsys, namespace, service
-):
+def test_log_metrics_capture_cold_start_with_durable_context_explicit_function_name(capsys, namespace, service):
     """Test capture_cold_start_metric with explicit function_name and DurableContext."""
     reset_cold_start_flag()
-    
+
     # GIVEN Metrics is initialized with explicit function_name
     my_metrics = Metrics(service=service, namespace=namespace, function_name="explicit_function")
-    
+
     # Create a DurableContext
     LambdaContext = namedtuple("LambdaContext", "function_name")
     lambda_ctx = LambdaContext("context_function")
-    
+
     durable_ctx = Mock(spec=DurableContextProtocol)
     durable_ctx.lambda_context = lambda_ctx
     durable_ctx.state = Mock(operations=[{"id": "op1"}])
@@ -129,7 +127,7 @@ def test_log_metrics_capture_cold_start_with_durable_context_explicit_function_n
 
     # THEN explicit function_name should take priority
     output = capture_metrics_output(capsys)
-    
+
     assert output.get("function_name") == "explicit_function"
 
 
@@ -147,7 +145,7 @@ def test_log_metrics_with_standard_context_still_works(capsys, namespace, servic
 
     # THEN metrics should be emitted successfully
     output = capture_metrics_output(capsys)
-    
+
     assert output["regression_test"] == [42.0]
     assert output["service"] == service
 
@@ -155,10 +153,10 @@ def test_log_metrics_with_standard_context_still_works(capsys, namespace, servic
 def test_log_metrics_capture_cold_start_standard_context_still_works(capsys, namespace, service):
     """Test that capture_cold_start_metric with standard context still works (regression test)."""
     reset_cold_start_flag()
-    
+
     # GIVEN Metrics is initialized
     my_metrics = Metrics(service=service, namespace=namespace)
-    
+
     LambdaContext = namedtuple("LambdaContext", "function_name")
     standard_context = LambdaContext("standard_function")
 
@@ -171,6 +169,6 @@ def test_log_metrics_capture_cold_start_standard_context_still_works(capsys, nam
 
     # THEN ColdStart metric should be captured
     output = capture_metrics_output(capsys)
-    
+
     assert "ColdStart" in output or output.get("ColdStart") == [1.0]
     assert output.get("function_name") == "standard_function"

--- a/tests/functional/metrics/required_dependencies/test_metrics_durable_context.py
+++ b/tests/functional/metrics/required_dependencies/test_metrics_durable_context.py
@@ -1,0 +1,160 @@
+"""Tests for Metrics with DurableContext support."""
+
+import json
+from collections import namedtuple
+from unittest.mock import Mock
+
+import pytest
+
+from aws_lambda_powertools import Metrics
+from aws_lambda_powertools.utilities.typing import DurableContextProtocol
+
+# Reset cold start flag before each test
+from aws_lambda_powertools.metrics.provider import cold_start
+
+
+def capture_metrics_output(capsys):
+    return json.loads(capsys.readouterr().out.strip())
+
+
+def reset_cold_start_flag():
+    cold_start.is_cold_start = True
+
+
+@pytest.fixture
+def durable_context(lambda_context):
+    """Create a mock DurableContext with embedded Lambda context."""
+    durable_ctx = Mock(spec=DurableContextProtocol)
+    durable_ctx.lambda_context = lambda_context
+    durable_ctx.state = Mock(operations=[{"id": "op1"}])
+    return durable_ctx
+
+
+@pytest.fixture
+def lambda_context_with_function_name():
+    """Create a simple lambda context with function_name."""
+    LambdaContext = namedtuple("LambdaContext", "function_name")
+    return LambdaContext("test_function")
+
+
+def test_log_metrics_with_durable_context_basic(capsys, namespace, service, durable_context):
+    """Test that log_metrics works with DurableContext."""
+    # GIVEN Metrics is initialized
+    my_metrics = Metrics(service=service, namespace=namespace)
+
+    # WHEN log_metrics decorator is used with a handler that receives DurableContext
+    @my_metrics.log_metrics
+    def lambda_handler(evt, context):
+        my_metrics.add_metric(name="test_metric", value=1.0, unit="Count")
+
+    lambda_handler({}, durable_context)
+
+    # THEN metrics should be emitted successfully
+    output = capture_metrics_output(capsys)
+    
+    assert output["test_metric"] == [1.0]
+    assert output["service"] == service
+
+
+def test_log_metrics_capture_cold_start_with_durable_context(capsys, namespace, service):
+    """Test that capture_cold_start_metric works with DurableContext."""
+    reset_cold_start_flag()
+    
+    # GIVEN Metrics is initialized
+    my_metrics = Metrics(service=service, namespace=namespace)
+    
+    # Create a DurableContext with embedded Lambda context
+    LambdaContext = namedtuple("LambdaContext", "function_name")
+    lambda_ctx = LambdaContext("durable_test_function")
+    
+    durable_ctx = Mock(spec=DurableContextProtocol)
+    durable_ctx.lambda_context = lambda_ctx
+    durable_ctx.state = Mock(operations=[{"id": "op1"}])
+
+    # WHEN log_metrics is used with capture_cold_start_metric and DurableContext
+    @my_metrics.log_metrics(capture_cold_start_metric=True)
+    def lambda_handler(evt, context):
+        my_metrics.add_metric(name="test_metric", value=1.0, unit="Count")
+
+    lambda_handler({}, durable_ctx)
+
+    # THEN ColdStart metric should be captured with the function name from unwrapped context
+    output = capture_metrics_output(capsys)
+    
+    assert "ColdStart" in output or output.get("ColdStart") == [1.0]
+    # The function_name should come from the unwrapped lambda_context
+    assert output.get("function_name") == "durable_test_function"
+    assert output["service"] == service
+
+
+def test_log_metrics_capture_cold_start_with_durable_context_explicit_function_name(
+    capsys, namespace, service
+):
+    """Test capture_cold_start_metric with explicit function_name and DurableContext."""
+    reset_cold_start_flag()
+    
+    # GIVEN Metrics is initialized with explicit function_name
+    my_metrics = Metrics(service=service, namespace=namespace, function_name="explicit_function")
+    
+    # Create a DurableContext
+    LambdaContext = namedtuple("LambdaContext", "function_name")
+    lambda_ctx = LambdaContext("context_function")
+    
+    durable_ctx = Mock(spec=DurableContextProtocol)
+    durable_ctx.lambda_context = lambda_ctx
+    durable_ctx.state = Mock(operations=[{"id": "op1"}])
+
+    # WHEN log_metrics is used with capture_cold_start_metric
+    @my_metrics.log_metrics(capture_cold_start_metric=True)
+    def lambda_handler(evt, context):
+        pass
+
+    lambda_handler({}, durable_ctx)
+
+    # THEN explicit function_name should take priority
+    output = capture_metrics_output(capsys)
+    
+    assert output.get("function_name") == "explicit_function"
+
+
+def test_log_metrics_with_standard_context_still_works(capsys, namespace, service, lambda_context):
+    """Test that standard Lambda context still works (regression test)."""
+    # GIVEN Metrics is initialized
+    my_metrics = Metrics(service=service, namespace=namespace)
+
+    # WHEN log_metrics decorator is used with standard LambdaContext
+    @my_metrics.log_metrics
+    def lambda_handler(evt, context):
+        my_metrics.add_metric(name="regression_test", value=42.0, unit="Count")
+
+    lambda_handler({}, lambda_context)
+
+    # THEN metrics should be emitted successfully
+    output = capture_metrics_output(capsys)
+    
+    assert output["regression_test"] == [42.0]
+    assert output["service"] == service
+
+
+def test_log_metrics_capture_cold_start_standard_context_still_works(capsys, namespace, service):
+    """Test that capture_cold_start_metric with standard context still works (regression test)."""
+    reset_cold_start_flag()
+    
+    # GIVEN Metrics is initialized
+    my_metrics = Metrics(service=service, namespace=namespace)
+    
+    LambdaContext = namedtuple("LambdaContext", "function_name")
+    standard_context = LambdaContext("standard_function")
+
+    # WHEN log_metrics is used with capture_cold_start_metric and standard context
+    @my_metrics.log_metrics(capture_cold_start_metric=True)
+    def lambda_handler(evt, context):
+        pass
+
+    lambda_handler({}, standard_context)
+
+    # THEN ColdStart metric should be captured
+    output = capture_metrics_output(capsys)
+    
+    assert "ColdStart" in output or output.get("ColdStart") == [1.0]
+    assert output.get("function_name") == "standard_function"


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
**Issue number:** closes #7763

## Summary

### Changes

This PR adds support for AWS Durable Execution SDK's `DurableContext` in Logger and Metrics decorators, addressing compatibility issues when using Powertools with durable Lambda functions.

**Core Implementation:**
- Added `_unwrap_durable_context()` helper function to detect and unwrap `DurableContext` via duck typing (checking for `lambda_context` and `state` attributes)
- Updated `build_lambda_context_model()` in logger to automatically unwrap `DurableContext` before accessing Lambda context properties
- Updated `_add_cold_start_metric()` in metrics base provider to unwrap `DurableContext` before passing to `add_cold_start_metric()`
- Enhanced docstrings for both `inject_lambda_context` and `log_metrics` decorators to document DurableContext support

**Testing:**
- Added 4 comprehensive tests for Logger's `inject_lambda_context` decorator with DurableContext
- Added 5 comprehensive tests for Metrics' `log_metrics` decorator with DurableContext
- All tests verify backward compatibility with standard `LambdaContext`
- Tests cover: basic functionality, `log_event=True`, `clear_state=True`, `capture_cold_start_metric=True`, and explicit function names

**Quality:**
- All existing tests pass (no regressions)
- Code formatting with ruff
- Linting with ruff check
- Type checking with mypy

### User experience

**Before:**
Users using AWS Durable Execution SDK would encounter errors when using Logger or Metrics decorators because the decorators expected a standard `LambdaContext` but received a `DurableContext` wrapper instead.

```python
from aws_durable_execution_sdk_python import DurableContext, durable_execution
from aws_lambda_powertools import Logger, Metrics

logger = Logger(service="durable")
metrics = Metrics(service="durable")

@durable_execution
@logger.inject_lambda_context(log_event=True)  # Raises AttributeError
@metrics.log_metrics(capture_cold_start_metric=True)  # Raises AttributeError
def lambda_handler(event: dict, context: DurableContext) -> str:
    logger.info("Processing")
    metrics.add_metric("ProcessedItems", 1, "Count")
    return "success"
```

After:
The decorators now seamlessly work with both standard LambdaContext and DurableContext. The unwrapping happens automatically and transparently to the user.

```python
from aws_durable_execution_sdk_python import DurableContext, durable_execution
from aws_lambda_powertools import Logger, Metrics

logger = Logger(service="durable")
metrics = Metrics(service="durable")

@durable_execution
@logger.inject_lambda_context(log_event=True)  # Works seamlessly
@metrics.log_metrics(capture_cold_start_metric=True)  # Works seamlessly
def lambda_handler(event: dict, context: DurableContext) -> str:
    logger.info("Processing")
    metrics.add_metric("ProcessedItems", 1, "Count")
    return "success"
```

The implementation uses duck typing to detect DurableContext checking for lambda_context and state, automatically extracts the underlying LambdaContextand processes it normally. 

This approach:
Requires no code changes from users
Maintains full backward compatibility
Follows the same pattern used in Idempotency utility
Is fully tested with both context types
 
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

Disclaimer: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.