### PR TITLE
refactor(batch): improve type annotation for event parameter

### DIFF
--- a/aws_lambda_powertools/utilities/batch/decorators.py
+++ b/aws_lambda_powertools/utilities/batch/decorators.py
@@ -158,7 +158,7 @@ def batch_processor(
 
 
 def process_partial_response(
-    event: dict,
+    event: dict[str, Any],
     record_handler: Callable,
     processor: BasePartialBatchProcessor,
     context: LambdaContext | None = None,
@@ -227,7 +227,7 @@ def process_partial_response(
 
 
 def async_process_partial_response(
-    event: dict,
+    event: dict[str, Any],
     record_handler: Callable,
     processor: AsyncBatchProcessor,
     context: LambdaContext | None = None,


### PR DESCRIPTION
**Issue number:** closes #7923  

## Summary

### Changes

Changed the `event` parameter type annotation from `dict` to `dict[str, Any]` in both `process_partial_response` and `async_process_partial_response` functions in `aws_lambda_powertools/utilities/batch/decorators.py`.

### User experience

**Before:** When using strict type checkers like `pyright`, users would see type errors:
```
error: Type of "process_partial_response" is partially unknown
  Type of "process_partial_response" is "(event: dict[Unknown, Unknown], ...)" (reportUnknownVariableType)
```

**After:** Type checkers correctly infer `event: dict[str, Any]`, eliminating the type error and providing better IDE support and type safety.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
