### PR TITLE
chore(typing): add ty type checker to CI with baseline exclusions 

### DIFF
--- a/.github/workflows/quality_check.yml
+++ b/.github/workflows/quality_check.yml
@@ -14,7 +14,6 @@ name: Quality check - check code
 #
 # Always triggered on new PRs, PR changes and PR merge.
 
-
 on:
   pull_request:
     paths:
@@ -46,13 +45,13 @@ jobs:
     strategy:
       max-parallel: 5
       matrix:
-        python-version: ["3.10","3.11","3.12","3.13","3.14"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
     env:
       PYTHON: "${{ matrix.python-version }}"
     permissions:
-      contents: read  # checkout code only
+      contents: read # checkout code only
     steps:
-      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6.0.1
+      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
       - name: Install poetry
         run: pipx install poetry
       - name: Set up Python ${{ matrix.python-version }}
@@ -65,8 +64,10 @@ jobs:
         run: make format-check
       - name: Formatting and Linting
         run: make lint
-      - name: Static type checking
+      - name: Static type checking (mypy)
         run: make mypy
+      - name: Static type checking (ty)
+        run: make ty
       - name: Test with pytest
         run: make test
       - name: Test dependencies with Nox

--- a/Makefile
+++ b/Makefile
@@ -100,6 +100,8 @@ changelog:
 mypy:
 	poetry run mypy --pretty aws_lambda_powertools examples
 
+ty:
+	poetry run ty check .
 
 dev-version-plugin:
 	poetry self add git+https://github.com/monim67/poetry-bumpversion@348de6f247222e2953d649932426e63492e0a6bf

--- a/poetry.lock
+++ b/poetry.lock
@@ -11,7 +11,7 @@ files = [
     {file = "annotated_types-0.7.0-py3-none-any.whl", hash = "sha256:1f02e8b43a8fbbc3f3e0d4f0f4bfc8131bcb4eebe8849b8e5c773f3a1c582a53"},
     {file = "annotated_types-0.7.0.tar.gz", hash = "sha256:aff07c09a53a08bc8cfccb9c85b05f1aa9a2a6f23728d790723543408344ce89"},
 ]
-markers = {main = "extra == \"all\" or extra == \"parser\""}
+markers = {main = "extra == \"parser\" or extra == \"all\""}
 
 [[package]]
 name = "anyio"
@@ -325,7 +325,7 @@ description = "The AWS X-Ray SDK for Python (the SDK) enables Python developers 
 optional = true
 python-versions = ">=3.7"
 groups = ["main"]
-markers = "extra == \"all\" or extra == \"tracer\""
+markers = "extra == \"tracer\" or extra == \"all\""
 files = [
     {file = "aws_xray_sdk-2.15.0-py2.py3-none-any.whl", hash = "sha256:422d62ad7d52e373eebb90b642eb1bb24657afe03b22a8df4a8b2e5108e278a3"},
     {file = "aws_xray_sdk-2.15.0.tar.gz", hash = "sha256:794381b96e835314345068ae1dd3b9120bd8b4e21295066c37e8814dbb341365"},
@@ -1821,7 +1821,7 @@ description = "Fastest Python implementation of JSON schema"
 optional = true
 python-versions = "*"
 groups = ["main"]
-markers = "extra == \"all\" or extra == \"validation\""
+markers = "extra == \"validation\" or extra == \"all\""
 files = [
     {file = "fastjsonschema-2.21.2-py3-none-any.whl", hash = "sha256:1c797122d0a86c5cace2e54bf4e819c36223b552017172f32c5c024a6b77e463"},
     {file = "fastjsonschema-2.21.2.tar.gz", hash = "sha256:b1eb43748041c880796cd077f1a07c3d94e93ae84bba5ed36800a33554ae05de"},
@@ -3381,7 +3381,7 @@ files = [
     {file = "pydantic-2.12.5-py3-none-any.whl", hash = "sha256:e561593fccf61e8a20fc46dfc2dfe075b8be7d0188df33f221ad1f0139180f9d"},
     {file = "pydantic-2.12.5.tar.gz", hash = "sha256:4d351024c75c0f085a9febbb665ce8c0c6ec5d30e903bdb6394b7ede26aebb49"},
 ]
-markers = {main = "extra == \"all\" or extra == \"parser\""}
+markers = {main = "extra == \"parser\" or extra == \"all\""}
 
 [package.dependencies]
 annotated-types = ">=0.6.0"
@@ -3523,7 +3523,7 @@ files = [
     {file = "pydantic_core-2.41.5-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:56121965f7a4dc965bff783d70b907ddf3d57f6eba29b6d2e5dabfaf07799c51"},
     {file = "pydantic_core-2.41.5.tar.gz", hash = "sha256:08daa51ea16ad373ffd5e7606252cc32f07bc72b28284b6bc9c6df804816476e"},
 ]
-markers = {main = "extra == \"all\" or extra == \"parser\""}
+markers = {main = "extra == \"parser\" or extra == \"all\""}
 
 [package.dependencies]
 typing-extensions = ">=4.14.1"
@@ -4564,6 +4564,33 @@ files = [
 ]
 
 [[package]]
+name = "ty"
+version = "0.0.10"
+description = "An extremely fast Python type checker, written in Rust."
+optional = false
+python-versions = ">=3.8"
+groups = ["dev"]
+files = [
+    {file = "ty-0.0.10-py3-none-linux_armv6l.whl", hash = "sha256:406a8ea4e648551f885629b75dc3f070427de6ed099af45e52051d4c68224829"},
+    {file = "ty-0.0.10-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:d6e0a733e3d6d3bce56d6766bc61923e8b130241088dc2c05e3c549487190096"},
+    {file = "ty-0.0.10-py3-none-macosx_11_0_arm64.whl", hash = "sha256:e4832f8879cb95fc725f7e7fcab4f22be0cf2550f3a50641d5f4409ee04176d4"},
+    {file = "ty-0.0.10-py3-none-manylinux_2_24_aarch64.whl", hash = "sha256:6b58cc78e5865bc908f053559a80bb77cab0dc168aaad2e88f2b47955694b138"},
+    {file = "ty-0.0.10-py3-none-manylinux_2_24_armv7l.whl", hash = "sha256:83c6a514bb86f05005fa93e3b173ae3fde94d291d994bed6fe1f1d2e5c7331cf"},
+    {file = "ty-0.0.10-py3-none-manylinux_2_24_i686.whl", hash = "sha256:2e43f71e357f8a4f7fc75e4753b37beb2d0f297498055b1673a9306aa3e21897"},
+    {file = "ty-0.0.10-py3-none-manylinux_2_24_ppc64le.whl", hash = "sha256:18be3c679965c23944c8e574be0635504398c64c55f3f0c46259464e10c0a1c7"},
+    {file = "ty-0.0.10-py3-none-manylinux_2_24_s390x.whl", hash = "sha256:5477981681440a35acdf9b95c3097410c547abaa32b893f61553dbc3b0096fff"},
+    {file = "ty-0.0.10-py3-none-manylinux_2_24_x86_64.whl", hash = "sha256:e206a23bd887574302138b33383ae1edfcc39d33a06a12a5a00803b3f0287a45"},
+    {file = "ty-0.0.10-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:4e09ddb0d3396bd59f645b85eab20f9a72989aa8b736b34338dcb5ffecfe77b6"},
+    {file = "ty-0.0.10-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:139d2a741579ad86a044233b5d7e189bb81f427eebce3464202f49c3ec0eba3b"},
+    {file = "ty-0.0.10-py3-none-musllinux_1_2_i686.whl", hash = "sha256:6bae10420c0abfe4601fbbc6ce637b67d0b87a44fa520283131a26da98f2e74c"},
+    {file = "ty-0.0.10-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:7358bbc5d037b9c59c3a48895206058bcd583985316c4125a74dd87fd1767adb"},
+    {file = "ty-0.0.10-py3-none-win32.whl", hash = "sha256:f51b6fd485bc695d0fdf555e69e6a87d1c50f14daef6cb980c9c941e12d6bcba"},
+    {file = "ty-0.0.10-py3-none-win_amd64.whl", hash = "sha256:16deb77a72cf93b89b4d29577829613eda535fbe030513dfd9fba70fe38bc9f5"},
+    {file = "ty-0.0.10-py3-none-win_arm64.whl", hash = "sha256:7495288bca7afba9a4488c9906466d648ffd3ccb6902bc3578a6dbd91a8f05f0"},
+    {file = "ty-0.0.10.tar.gz", hash = "sha256:0a1f9f7577e56cd508a8f93d0be2a502fdf33de6a7d65a328a4c80b784f4ac5f"},
+]
+
+[[package]]
 name = "typeguard"
 version = "2.13.3"
 description = "Run-time type checker for Python"
@@ -4724,7 +4751,7 @@ files = [
     {file = "typing_inspection-0.4.2-py3-none-any.whl", hash = "sha256:4ed1cacbdc298c220f1bd249ed5287caa16f34d44ef4e9c3d0cbad5b521545e7"},
     {file = "typing_inspection-0.4.2.tar.gz", hash = "sha256:ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464"},
 ]
-markers = {main = "extra == \"all\" or extra == \"parser\""}
+markers = {main = "extra == \"parser\" or extra == \"all\""}
 
 [package.dependencies]
 typing-extensions = ">=4.12.0"
@@ -5051,7 +5078,7 @@ files = [
     {file = "wrapt-1.17.3-py3-none-any.whl", hash = "sha256:7171ae35d2c33d326ac19dd8facb1e82e5fd04ef8c6c0e394d7af55a55051c22"},
     {file = "wrapt-1.17.3.tar.gz", hash = "sha256:f66eb08feaa410fe4eebd17f2a2c8e2e46d3476e9f8c783daa8e09e0faa666d0"},
 ]
-markers = {main = "extra == \"all\" or extra == \"datamasking\" or extra == \"tracer\" or extra == \"datadog\""}
+markers = {main = "extra == \"tracer\" or extra == \"all\" or extra == \"datamasking\" or extra == \"datadog\""}
 
 [[package]]
 name = "xenon"
@@ -5107,4 +5134,4 @@ valkey = ["valkey-glide"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10,<4.0.0"
-content-hash = "45ff4588e3d2263d77c85badb0f92ec2541dc48c83a1395fe8ff9dd55dabb7d5"
+content-hash = "61483c266c6e190e9510206da33198dc68b34b3e0659505faa702404202f86f1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -129,6 +129,7 @@ mkdocs-llmstxt = ">=0.2,<0.5"
 avro = "^1.12.0"
 protobuf = "^6.30.2"
 types-protobuf = "^6.30.2.20250516"
+ty = "^0.0.10"
 
 [tool.coverage.run]
 source = ["aws_lambda_powertools"]
@@ -215,3 +216,30 @@ generate-setup-file = true
 [tool.poetry_bumpversion.file."aws_lambda_powertools/shared/version.py"]
 search = 'VERSION = "{current_version}"'
 replace = 'VERSION = "{new_version}"'
+
+[tool.ty]
+# ty type checker configuration
+
+[tool.ty.src]
+include = ["aws_lambda_powertools/**"]
+exclude = [
+    "tests/**",
+    "examples/**",
+    "docs/**",
+    # Baseline exclusions - modules with existing diagnostics (issue #7927)
+    # These will be addressed incrementally in follow-up PRs
+    "aws_lambda_powertools/logging/**",
+    "aws_lambda_powertools/utilities/validation/**",
+    "aws_lambda_powertools/shared/**",
+    "aws_lambda_powertools/metrics/**",
+    "aws_lambda_powertools/middleware_factory/**",
+    "aws_lambda_powertools/utilities/streaming/**",
+    "aws_lambda_powertools/utilities/parameters/**",
+    "aws_lambda_powertools/utilities/parser/**",
+    "aws_lambda_powertools/utilities/data_masking/**",
+    "aws_lambda_powertools/tracing/**",
+    "aws_lambda_powertools/utilities/data_classes/**",
+    "aws_lambda_powertools/utilities/batch/**",
+    "aws_lambda_powertools/utilities/idempotency/**",
+    "aws_lambda_powertools/event_handler/**",
+]


### PR DESCRIPTION




<!-- markdownlint-disable MD041 MD043 -->
**Issue number:** closes #7927 

## Summary

Add ty type checker integration with baseline exclusions for incremental adoption:
### Changes

- Add ty check step to quality_check workflow (runs on all Python versions like mypy)
- Configure ty exclusions for 14 modules with existing diagnostics
- Add `ty` command to makefile


<!-------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/aws-powertools/powertools-lambda-python/blob/main/CONTRIBUTING.md#sending-a-pull-request
- Check that there isn't already a PR that addresses the same issue. If you find a duplicate, please leave a comment under the existing PR so we can discuss how to move forward
- Check that the change meets the project's tenets https://docs.powertools.aws.dev/lambda/python/latest/#tenets
- Add a PR title that follows the conventional commit semantics - https://github.com/aws-powertools/powertools-lambda-python/blob/develop/.github/semantic.yml
- If relevant, add tests that prove that the change is effective and works
------->

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
