### PR TITLE
fix(data_classes): support path parameters in APIGatewayAuthorizerResponse

### DIFF
--- a/aws_lambda_powertools/utilities/data_classes/api_gateway_authorizer_event.py
+++ b/aws_lambda_powertools/utilities/data_classes/api_gateway_authorizer_event.py
@@ -437,8 +437,15 @@ class APIGatewayAuthorizerResponse:
     - https://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-lambda-authorizer-output.html
     """
 
-    path_regex = r"^[/.a-zA-Z0-9-_\*]+$"
-    """The regular expression used to validate resource paths for the policy"""
+    path_regex = r"^[/.a-zA-Z0-9-_\*{}+]+$"
+    """The regular expression used to validate resource paths for the policy.
+
+    Supports standard path characters and API Gateway path parameters:
+    - Standard: `/path/to/resource`
+    - Wildcard: `/path/*` or `/path/*/resource`
+    - Path parameter: `/path/{param}`
+    - Greedy path parameter: `/{proxy+}` or `/path/{proxy+}`
+    """
 
     def __init__(
         self,

--- a/tests/unit/data_classes/required_dependencies/test_api_gateway_authorizer.py
+++ b/tests/unit/data_classes/required_dependencies/test_api_gateway_authorizer.py
@@ -221,3 +221,60 @@ def test_parse_api_gateway_arn_with_resource():
     response = authorizer_policy.asdict()
 
     assert mock_event["methodArn"] == response["policyDocument"]["Statement"][0]["Resource"][0]
+
+
+def test_authorizer_response_allow_route_with_proxy_plus(builder: APIGatewayAuthorizerResponse):
+    """Test that {proxy+} greedy path parameter is supported.
+
+    See: https://github.com/aws-powertools/powertools-lambda-python/issues/7979
+    """
+    builder.allow_route(http_method="*", resource="/{proxy+}")
+    assert builder.asdict() == {
+        "principalId": "foo",
+        "policyDocument": {
+            "Version": "2012-10-17",
+            "Statement": [
+                {
+                    "Action": "execute-api:Invoke",
+                    "Effect": "Allow",
+                    "Resource": ["arn:aws:execute-api:us-west-1:123456789:fantom/dev/*/{proxy+}"],
+                },
+            ],
+        },
+    }
+
+
+def test_authorizer_response_allow_route_with_path_parameter(builder: APIGatewayAuthorizerResponse):
+    """Test that standard path parameters like {id} are supported."""
+    builder.allow_route(http_method="GET", resource="/users/{userId}")
+    assert builder.asdict() == {
+        "principalId": "foo",
+        "policyDocument": {
+            "Version": "2012-10-17",
+            "Statement": [
+                {
+                    "Action": "execute-api:Invoke",
+                    "Effect": "Allow",
+                    "Resource": ["arn:aws:execute-api:us-west-1:123456789:fantom/dev/GET/users/{userId}"],
+                },
+            ],
+        },
+    }
+
+
+def test_authorizer_response_allow_route_with_nested_proxy(builder: APIGatewayAuthorizerResponse):
+    """Test that {proxy+} can be used with a path prefix."""
+    builder.allow_route(http_method="*", resource="/api/v1/{proxy+}")
+    assert builder.asdict() == {
+        "principalId": "foo",
+        "policyDocument": {
+            "Version": "2012-10-17",
+            "Statement": [
+                {
+                    "Action": "execute-api:Invoke",
+                    "Effect": "Allow",
+                    "Resource": ["arn:aws:execute-api:us-west-1:123456789:fantom/dev/*/api/v1/{proxy+}"],
+                },
+            ],
+        },
+    }


### PR DESCRIPTION
## Summary

Update the `path_regex` pattern in `APIGatewayAuthorizerResponse` to support API Gateway path parameters including:
- Standard path parameters: `{param}`
- Greedy path parameters: `{proxy+}`

Previously, the regex `r"^[/.a-zA-Z0-9-_\*]+$"` did not allow `{`, `}`, or `+` characters, causing `allow_route` and `deny_route` to reject valid API Gateway resource paths like `/{proxy+}`.

## Root Cause

The regex pattern at line 440 in `api_gateway_authorizer_event.py` was too restrictive and didn't account for path parameter syntax that API Gateway supports.

## Changes

- Updated `path_regex` to `r"^[/.a-zA-Z0-9-_\*{}+]+$"` to allow path parameters
- Added docstring explaining supported path formats
- Added 3 test cases for path parameter scenarios

## Test Plan

- [x] All 16 tests pass (`pytest tests/unit/data_classes/required_dependencies/test_api_gateway_authorizer.py`)
- [x] Verified exact issue case works: `builder.allow_route(http_method='GET', resource='/{proxy+}')`
- [x] Linting passes (`ruff check`)
- [x] Formatting passes (`ruff format --check`)

Fixes #7979

---

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*