### PR TITLE
fix(parameters): accumulate results across chunks in get_parameters_by_name

### DIFF
--- a/aws_lambda_powertools/utilities/parameters/ssm.py
+++ b/aws_lambda_powertools/utilities/parameters/ssm.py
@@ -583,12 +583,12 @@ class SSMProvider(BaseProvider):
         diff = {key: value for key, value in batch.items() if key not in cache}
 
         for chunk in slice_dictionary(data=diff, chunk_size=self._MAX_GET_PARAMETERS_ITEM):
-            response, possible_errors = self._get_parameters_by_name(
+            chunk_response, possible_errors = self._get_parameters_by_name(
                 parameters=chunk,
                 raise_on_error=raise_on_error,
                 decrypt=decrypt,
             )
-            response.update(response)
+            response.update(chunk_response)
             errors.extend(possible_errors)
 
         return response, errors

--- a/tests/functional/parameters/_boto3/test_utilities_parameters.py
+++ b/tests/functional/parameters/_boto3/test_utilities_parameters.py
@@ -2347,6 +2347,38 @@ def test_get_parameters_by_name_with_max_batch(monkeypatch, config):
     parameters.get_parameters_by_name(parameters=params)
 
 
+def test_get_parameters_by_name_accumulates_results_across_chunks(monkeypatch, config):
+    # GIVEN a batch of 12 parameters (more than 10, which is the max batch size)
+    # This test verifies the fix for GitHub issue #7832:
+    # When fetching more than 10 parameters, results from all chunks should be accumulated
+    params = {f"/dev/param{i}": {} for i in range(12)}
+
+    class TestProvider(SSMProvider):
+        def __init__(self, boto_config: Config = config, **kwargs):
+            super().__init__(boto_config=boto_config, **kwargs)
+
+        def _get_parameters_by_name(
+            self,
+            parameters: dict[str, dict],
+            raise_on_error: bool = True,
+            decrypt: bool = False,
+        ) -> tuple[dict[str, Any], list[str]]:
+            # Return a value for each parameter in this chunk
+            return {name: f"value_{name}" for name in parameters.keys()}, []
+
+    monkeypatch.setitem(parameters.base.DEFAULT_PROVIDERS, "ssm", TestProvider())
+
+    # WHEN get_parameters_by_name is called with more than 10 parameters
+    result = parameters.get_parameters_by_name(parameters=params)
+
+    # THEN all 12 parameters should be returned (not just the last chunk of 2)
+    assert len(result) == 12
+    for i in range(12):
+        param_name = f"/dev/param{i}"
+        assert param_name in result
+        assert result[param_name] == f"value_{param_name}"
+
+
 def test_get_parameters_by_name_cache(monkeypatch, mock_name, mock_value, config):
     # GIVEN we have a parameter to fetch but is already in cache
     params = {mock_name: {}}


### PR DESCRIPTION
## Issue # (if applicable)

Closes #7832

## Summary

Fixes a variable shadowing bug in `_get_parameters_by_name_in_chunks` that caused `get_parameters_by_name` to return only the last chunk of parameters when fetching more than 10 parameters.

### Root Cause

In the `_get_parameters_by_name_in_chunks` method, the loop variable `response` was being overwritten on each iteration instead of being accumulated:

```python
# Before (buggy):
for chunk in slice_dictionary(data=diff, chunk_size=self._MAX_GET_PARAMETERS_ITEM):
    response, possible_errors = self._get_parameters_by_name(...)  # response overwritten!
    response.update(response)  # No-op: updating dict with itself
    errors.extend(possible_errors)
```

```python
# After (fixed):
for chunk in slice_dictionary(data=diff, chunk_size=self._MAX_GET_PARAMETERS_ITEM):
    chunk_response, possible_errors = self._get_parameters_by_name(...)
    response.update(chunk_response)  # Accumulate results
    errors.extend(possible_errors)
```

### Impact

When fetching more than 10 parameters with `get_parameters_by_name`, only the last chunk (up to 10 parameters) was returned. For example, fetching 12 parameters would only return the last 2 parameters instead of all 12.

## Changes

1. **`aws_lambda_powertools/utilities/parameters/ssm.py`**: Fixed variable shadowing by renaming the loop variable from `response` to `chunk_response`

2. **`tests/functional/parameters/_boto3/test_utilities_parameters.py`**: Added `test_get_parameters_by_name_accumulates_results_across_chunks` to verify results are accumulated across chunks

## Test Plan

- [x] New test `test_get_parameters_by_name_accumulates_results_across_chunks` verifies all 12 parameters are returned when fetching more than 10
- [x] All existing `get_parameters_by_name` tests pass (16 tests)
- [x] Ruff linting passes on both modified files

### Test Commands

```bash
# Run the new test
python -m pytest tests/functional/parameters/_boto3/test_utilities_parameters.py::test_get_parameters_by_name_accumulates_results_across_chunks -v

# Run all related tests
python -m pytest tests/functional/parameters/_boto3/test_utilities_parameters.py -k "get_parameters_by_name" -v
```

## Acknowledgment

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license.