### PR TITLE
fix(parameters): fix variable shadowing in SSM parameter chunking

### DIFF
--- a/aws_lambda_powertools/utilities/parameters/ssm.py
+++ b/aws_lambda_powertools/utilities/parameters/ssm.py
@@ -583,12 +583,12 @@ class SSMProvider(BaseProvider):
         diff = {key: value for key, value in batch.items() if key not in cache}
 
         for chunk in slice_dictionary(data=diff, chunk_size=self._MAX_GET_PARAMETERS_ITEM):
-            response, possible_errors = self._get_parameters_by_name(
+            chunk_response, possible_errors = self._get_parameters_by_name(
                 parameters=chunk,
                 raise_on_error=raise_on_error,
                 decrypt=decrypt,
             )
-            response.update(response)
+            response.update(chunk_response)
             errors.extend(possible_errors)
 
         return response, errors

--- a/tests/functional/parameters/_boto3/test_utilities_parameters.py
+++ b/tests/functional/parameters/_boto3/test_utilities_parameters.py
@@ -2347,6 +2347,26 @@ def test_get_parameters_by_name_with_max_batch(monkeypatch, config):
     parameters.get_parameters_by_name(parameters=params)
 
 
+def test_get_parameters_by_name_chunks(monkeypatch, config):
+    # GIVEN a batch of 12 parameters (more than max batch size of 10)
+    params = {f"param{i}": {} for i in range(12)}
+
+    class TestProvider(SSMProvider):
+        def __init__(self, boto_config: Config = config, **kwargs):
+            super().__init__(boto_config=boto_config, **kwargs)
+
+        def _get_parameters_by_name(self, parameters, raise_on_error=True, decrypt=False):
+            return {name: f"val_{name}" for name in parameters}, []
+
+    monkeypatch.setitem(parameters.base.DEFAULT_PROVIDERS, "ssm", TestProvider())
+
+    # WHEN get_parameters_by_name is called
+    result = parameters.get_parameters_by_name(parameters=params)
+
+    # THEN all parameters should be returned across chunks
+    assert len(result) == 12
+
+
 def test_get_parameters_by_name_cache(monkeypatch, mock_name, mock_value, config):
     # GIVEN we have a parameter to fetch but is already in cache
     params = {mock_name: {}}


### PR DESCRIPTION
**Issue number:** closes #7832

## Summary

### Changes

Fixed variable shadowing bug in `_get_parameters_by_name_in_chunks` where the `response` variable was being overwritten on each loop iteration instead of accumulating results from all chunks.

- Changed `response, possible_errors = self._get_parameters_by_name(...)` to `chunk_response, possible_errors = self._get_parameters_by_name(...)`
- Changed `response.update(response)` to `response.update(chunk_response)`
- Added test to verify all parameters are returned when fetching more than 10 parameters

### User experience

**Before:** When calling `get_parameters_by_name` with more than 10 parameters, only the last chunk (up to 10 parameters) was returned.

**After:** All requested parameters are correctly returned regardless of batch size.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.