### PR TITLE
fix(ci): remove DUB region

### DIFF
--- a/.github/workflows/reusable_deploy_v3_layer_stack.yml
+++ b/.github/workflows/reusable_deploy_v3_layer_stack.yml
@@ -76,7 +76,7 @@ jobs:
                  "ap-south-1", "ap-south-2", "ap-southeast-1", "ap-southeast-2", "ap-southeast-3",
                  "ap-southeast-4", "ap-southeast-5", "ap-southeast-7", "ca-central-1", "ca-west-1", "eu-central-1", "eu-central-2",
                  "eu-north-1", "eu-south-1", "eu-south-2", "eu-west-1", "eu-west-2", "eu-west-3",
-                 "il-central-1", "me-central-1", "me-south-1", "mx-central-1", "sa-east-1", "us-east-1",
+                 "il-central-1", "me-south-1", "mx-central-1", "sa-east-1", "us-east-1",
                  "us-east-2", "us-west-1", "us-west-2"]
         python-version: ["3.10","3.11","3.12","3.13","3.14"]
         include:
@@ -127,8 +127,6 @@ jobs:
           - region: "eu-west-3"
             has_arm64_support: "true"
           - region: "il-central-1"
-            has_arm64_support: "true"
-          - region: "me-central-1"
             has_arm64_support: "true"
           - region: "me-south-1"
             has_arm64_support: "true"

--- a/.github/workflows/update_ssm.yml
+++ b/.github/workflows/update_ssm.yml
@@ -78,7 +78,7 @@ jobs:
                  "ap-south-1", "ap-south-2", "ap-southeast-1", "ap-southeast-2", "ap-southeast-3",
                  "ap-southeast-4", "ap-southeast-5", "ap-southeast-7", "ca-central-1", "ca-west-1", "eu-central-1", "eu-central-2",
                  "eu-north-1", "eu-south-1", "eu-south-2", "eu-west-1", "eu-west-2", "eu-west-3",
-                 "il-central-1", "me-central-1", "me-south-1", "mx-central-1", "sa-east-1", "us-east-1",
+                 "il-central-1", "me-south-1", "mx-central-1", "sa-east-1", "us-east-1",
                  "us-east-2", "us-west-1", "us-west-2"]
 
     permissions:


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
**Issue number:** closes #8022 

## Summary

### Changes

Remove DUB region from the deployment script. Region is down.

### User experience

> Please share what the user experience looks like before and after this change

<!-------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/aws-powertools/powertools-lambda-python/blob/main/CONTRIBUTING.md#sending-a-pull-request
- Check that there isn't already a PR that addresses the same issue. If you find a duplicate, please leave a comment under the existing PR so we can discuss how to move forward
- Check that the change meets the project's tenets https://docs.powertools.aws.dev/lambda/python/latest/#tenets
- Add a PR title that follows the conventional commit semantics - https://github.com/aws-powertools/powertools-lambda-python/blob/develop/.github/semantic.yml
- If relevant, add tests that prove that the change is effective and works
------->

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
