### PR TITLE
fix(ci): add ty check to parser folder

### DIFF
--- a/aws_lambda_powertools/utilities/parser/functions.py
+++ b/aws_lambda_powertools/utilities/parser/functions.py
@@ -98,7 +98,7 @@ def _validate_source_ip(value):
     try:
         # The value is always an instance of str before Pydantic validation occurs.
         # So the first thing to do is try to convert it.
-        IPvAnyNetwork(value)
+        IPvAnyNetwork(value)  # ty: ignore[call-non-callable]
     except ValueError:
         try:
             # Handle IPv6 with port: [IPv6]:port
@@ -110,7 +110,7 @@ def _validate_source_ip(value):
                 # If it"s not in IP:port format, validate as-is
                 ip_part = value
 
-            IPvAnyNetwork(ip_part)
+            IPvAnyNetwork(ip_part)  # ty: ignore[call-non-callable]
         except (ValueError, IndexError) as e:
             raise ValueError(f"Invalid IP address in sourceIp: {ip_part}") from e
 

--- a/aws_lambda_powertools/utilities/parser/parser.py
+++ b/aws_lambda_powertools/utilities/parser/parser.py
@@ -115,7 +115,7 @@ def event_parser(
     else:
         parsed_event = parse(event=event, model=model)
 
-    logger.debug(f"Calling handler {handler.__name__}")
+    logger.debug(f"Calling handler {handler.__name__}")  # ty: ignore[unresolved-attribute]
     return handler(parsed_event, context, **kwargs)
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -237,7 +237,6 @@ exclude = [
     "aws_lambda_powertools/metrics/**",
     "aws_lambda_powertools/middleware_factory/**",
     "aws_lambda_powertools/utilities/streaming/**",
-    "aws_lambda_powertools/utilities/parser/**",
     "aws_lambda_powertools/utilities/data_masking/**",
     "aws_lambda_powertools/tracing/**",
     "aws_lambda_powertools/utilities/data_classes/**",


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
**Issue number:** closes #7931
## Summary

### Changes

Resolve all ty diagnostics in utilities/parser/ and remove from ty exclusion list in pyproject.toml.

### User experience

> Please share what the user experience looks like before and after this change

<!-------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/aws-powertools/powertools-lambda-python/blob/main/CONTRIBUTING.md#sending-a-pull-request
- Check that there isn't already a PR that addresses the same issue. If you find a duplicate, please leave a comment under the existing PR so we can discuss how to move forward
- Check that the change meets the project's tenets https://docs.powertools.aws.dev/lambda/python/latest/#tenets
- Add a PR title that follows the conventional commit semantics - https://github.com/aws-powertools/powertools-lambda-python/blob/develop/.github/semantic.yml
- If relevant, add tests that prove that the change is effective and works
------->

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
