### PR TITLE
fix(idempotency): fix serialization of Pydantic idempotency keys for special data types

### DIFF
--- a/aws_lambda_powertools/utilities/idempotency/base.py
+++ b/aws_lambda_powertools/utilities/idempotency/base.py
@@ -60,7 +60,7 @@ def _prepare_data(data: Any) -> Any:
 
     # Convert from Pydantic model
     if callable(getattr(data, "model_dump", None)):
-        return data.model_dump()
+        return data.model_dump(mode="json")
 
     # Convert from event source data class
     if callable(getattr(data, "dict", None)):

--- a/tests/functional/idempotency/_pydantic/test_idempotency_with_pydantic.py
+++ b/tests/functional/idempotency/_pydantic/test_idempotency_with_pydantic.py
@@ -1,4 +1,5 @@
 from typing import Optional
+from uuid import UUID
 
 import pytest
 from pydantic import BaseModel
@@ -191,6 +192,19 @@ def test_idempotent_function_pydantic():
     data = Foo(name="Bar")
     as_dict = _prepare_data(data)
     assert as_dict == data.dict()
+    assert as_dict == expected_result
+
+
+def test_idempotent_function_pydantic_uuid():
+    # Scenario _prepare_data should convert a pydantic model with UUIDs to a dict
+    # with serialization of UUIDs to strings
+    class Foo(BaseModel):
+        uuid: UUID
+
+    uuid = UUID("01234567-0123-0123-0123-0123456789ab")
+    expected_result = {"uuid": str(uuid)}
+    data = Foo(uuid=uuid)
+    as_dict = _prepare_data(data)
     assert as_dict == expected_result
 
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
**Issue number:** closes #8065 

## Summary

### Changes

- Updated the Pydantic serialization mode of idempotency keys to use `mode="json"` instead of relying on the default `mode="python"`

### User experience

**Before:** Special data types such as UUID and dates cannot be used in idempotency keys because they cannot be serialized by Pydantic's default `.model_dump()`.

**After:** Setting `mode="json"` allows Pydantic to convert supported data types (such as UUIDs) to valid JSON values, allowing them to be used as part of idempotency keys. If an unsupported type is used and can't be serialized to JSON, a [PydanticSerializationError](https://docs.pydantic.dev/latest/api/pydantic_core/#pydantic_core.PydanticSerializationError) exception is raised.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
