### PR TITLE
fix(event_handler): support finding type annotated resolver when merging schemas

### DIFF
--- a/aws_lambda_powertools/event_handler/openapi/merge.py
+++ b/aws_lambda_powertools/event_handler/openapi/merge.py
@@ -67,11 +67,15 @@ def _file_has_resolver(file_path: Path, resolver_name: str) -> bool:
         return False
 
     for node in ast.walk(tree):
+        targets = []
         if isinstance(node, ast.Assign):
-            for target in node.targets:
-                if isinstance(target, ast.Name) and target.id == resolver_name:
-                    if _is_resolver_call(node.value):
-                        return True
+            targets = node.targets
+        elif isinstance(node, ast.AnnAssign):
+            targets = [node.target]
+        for target in targets:
+            if isinstance(target, ast.Name) and target.id == resolver_name:
+                if _is_resolver_call(node.value):
+                    return True
     return False
 
 

--- a/aws_lambda_powertools/event_handler/openapi/merge.py
+++ b/aws_lambda_powertools/event_handler/openapi/merge.py
@@ -67,14 +67,17 @@ def _file_has_resolver(file_path: Path, resolver_name: str) -> bool:
         return False
 
     for node in ast.walk(tree):
-        targets = []
+        targets: list[ast.expr] = []
+        value: ast.expr | None = None
         if isinstance(node, ast.Assign):
             targets = node.targets
+            value = node.value
         elif isinstance(node, ast.AnnAssign):
             targets = [node.target]
+            value = node.value
         for target in targets:
             if isinstance(target, ast.Name) and target.id == resolver_name:
-                if _is_resolver_call(node.value):
+                if value is not None and _is_resolver_call(value):
                     return True
     return False
 

--- a/tests/functional/event_handler/_pydantic/merge_handlers/typed_handler.py
+++ b/tests/functional/event_handler/_pydantic/merge_handlers/typed_handler.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+from pydantic import BaseModel
+
+from aws_lambda_powertools.event_handler import APIGatewayRestResolver
+
+app: APIGatewayRestResolver = APIGatewayRestResolver(enable_validation=True)
+
+
+class Product(BaseModel):
+    id: int
+    name: str
+    price: float
+
+
+@app.get("/products")
+def get_products() -> list[Product]:
+    return [
+        Product(id=1, name="Widget", price=9.99),
+    ]
+
+
+def handler(event, context):
+    return app.resolve(event, context)

--- a/tests/functional/event_handler/_pydantic/test_openapi_merge.py
+++ b/tests/functional/event_handler/_pydantic/test_openapi_merge.py
@@ -367,3 +367,19 @@ def test_openapi_merge_schema_is_cached():
 
     # AND paths should not be duplicated
     assert len([p for p in schema1["paths"] if p == "/users"]) == 1
+
+
+def test_openapi_merge_discover_type_annotated_resolver():
+    # GIVEN an OpenAPIMerge instance
+    merge = OpenAPIMerge(title="Typed API", version="1.0.0")
+
+    # WHEN discovering a handler with a type-annotated resolver (app: Resolver = Resolver())
+    merge.discover(
+        path=MERGE_HANDLERS_PATH,
+        pattern="**/typed_handler.py",
+        resolver_name="app",
+    )
+
+    # THEN it should find the resolver and include its routes in the schema
+    schema = merge.get_openapi_schema()
+    assert "/products" in schema["paths"]

--- a/tests/unit/event_handler/openapi/test_openapi_merge.py
+++ b/tests/unit/event_handler/openapi/test_openapi_merge.py
@@ -57,15 +57,6 @@ app = APIGatewayRestResolver()
     assert _file_has_resolver(handler_file, "app") is True
 
 
-def test_file_has_resolver_found_with_type_annotation(tmp_path: Path):
-    handler_file = tmp_path / "handler.py"
-    handler_file.write_text("""
-from aws_lambda_powertools.event_handler import APIGatewayRestResolver
-app: APIGatewayRestResolver = APIGatewayRestResolver()
-""")
-    assert _file_has_resolver(handler_file, "app") is True
-
-
 def test_is_excluded_with_directory_pattern():
     root = Path("/project")
     assert _is_excluded(Path("/project/tests/handler.py"), root, ["**/tests/**"]) is True

--- a/tests/unit/event_handler/openapi/test_openapi_merge.py
+++ b/tests/unit/event_handler/openapi/test_openapi_merge.py
@@ -57,6 +57,15 @@ app = APIGatewayRestResolver()
     assert _file_has_resolver(handler_file, "app") is True
 
 
+def test_file_has_resolver_found_with_type_annotation(tmp_path: Path):
+    handler_file = tmp_path / "handler.py"
+    handler_file.write_text("""
+from aws_lambda_powertools.event_handler import APIGatewayRestResolver
+app: APIGatewayRestResolver = APIGatewayRestResolver()
+""")
+    assert _file_has_resolver(handler_file, "app") is True
+
+
 def test_is_excluded_with_directory_pattern():
     root = Path("/project")
     assert _is_excluded(Path("/project/tests/handler.py"), root, ["**/tests/**"]) is True


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
**Issue number:** closes #8073

## Summary

### Changes

Support type annotated resolver finding for OpenAPI merge.

### User experience

Type annotated resolver was simply not found, now it is.

<!-------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/aws-powertools/powertools-lambda-python/blob/main/CONTRIBUTING.md#sending-a-pull-request
- Check that there isn't already a PR that addresses the same issue. If you find a duplicate, please leave a comment under the existing PR so we can discuss how to move forward
- Check that the change meets the project's tenets https://docs.powertools.aws.dev/lambda/python/latest/#tenets
- Add a PR title that follows the conventional commit semantics - https://github.com/aws-powertools/powertools-lambda-python/blob/develop/.github/semantic.yml
- If relevant, add tests that prove that the change is effective and works
------->

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
