### PR TITLE
fix(event_handler): read swagger files with UTF-8 encoding

### DIFF
--- a/aws_lambda_powertools/event_handler/api_gateway.py
+++ b/aws_lambda_powertools/event_handler/api_gateway.py
@@ -2224,8 +2224,12 @@ class ApiGatewayResolver(BaseRouter):
                 # We now inject CSS and JS into the SwaggerUI file
                 swagger_js = Path.open(
                     Path(__file__).parent / "openapi" / "swagger_ui" / "swagger-ui-bundle.min.js",
+                    encoding="utf-8",
                 ).read()
-                swagger_css = Path.open(Path(__file__).parent / "openapi" / "swagger_ui" / "swagger-ui.min.css").read()
+                swagger_css = Path.open(
+                    Path(__file__).parent / "openapi" / "swagger_ui" / "swagger-ui.min.css",
+                    encoding="utf-8",
+                ).read()
 
             openapi_servers = servers or [Server(url=(base_path or "/"))]
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
**Issue number:** closes #8129

## Summary

### Changes

* When reading the swagger_ui js and css files, they are opened with UTF-8 encoding.

### User experience

* The js and css files will be loaded as UTF-8 regardless of the default encoding set on the runtime environment. Other than fixing the bug, I would not expect this to have an impact on user experience.

<!-------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/aws-powertools/powertools-lambda-python/blob/main/CONTRIBUTING.md#sending-a-pull-request
- Check that there isn't already a PR that addresses the same issue. If you find a duplicate, please leave a comment under the existing PR so we can discuss how to move forward
- Check that the change meets the project's tenets https://docs.powertools.aws.dev/lambda/python/latest/#tenets
- Add a PR title that follows the conventional commit semantics - https://github.com/aws-powertools/powertools-lambda-python/blob/develop/.github/semantic.yml
- If relevant, add tests that prove that the change is effective and works
------->

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
